### PR TITLE
Fix hlint warnings found by hlint 1.9.11

### DIFF
--- a/src/Ganeti/HTools/Program/Hroller.hs
+++ b/src/Ganeti/HTools/Program/Hroller.hs
@@ -409,7 +409,7 @@ main opts args = do
                            sortBy (flip compare `on` length . fst) $
                            nodesRebootGroups
       confToMoveNames =
-        map (Instance.name *** (Node.name *** flip (>>=) (return . Node.name)))
+        map (Instance.name *** (Node.name *** (=<<) (return . Node.name)))
         . getMoves (nlf, ilf)
       namesAndMoves = map (map Node.name *** confToMoveNames) outputRebootGroups
 

--- a/src/Ganeti/Hypervisor/Xen/Types.hs
+++ b/src/Ganeti/Hypervisor/Xen/Types.hs
@@ -66,7 +66,7 @@ class FromLispConfig a where
 -- | Instance of FromLispConfig for Int.
 instance FromLispConfig Int where
   fromLispConfig (LCDouble d) = Ok $ floor d
-  fromLispConfig (LCList (LCString _:LCDouble d:[])) = Ok $ floor d
+  fromLispConfig (LCList [LCString _, LCDouble d]) = Ok $ floor d
   fromLispConfig c =
     Bad $ "Unable to extract a Int from this configuration: "
       ++ show c
@@ -74,7 +74,7 @@ instance FromLispConfig Int where
 -- | Instance of FromLispConfig for Double.
 instance FromLispConfig Double where
   fromLispConfig (LCDouble d) = Ok d
-  fromLispConfig (LCList (LCString _:LCDouble d:[])) = Ok d
+  fromLispConfig (LCList [LCString _, LCDouble d]) = Ok d
   fromLispConfig c =
     Bad $ "Unable to extract a Double from this configuration: "
       ++ show c
@@ -82,7 +82,7 @@ instance FromLispConfig Double where
 -- | Instance of FromLispConfig for String
 instance FromLispConfig String where
   fromLispConfig (LCString s) = Ok s
-  fromLispConfig (LCList (LCString _:LCString s:[])) = Ok s
+  fromLispConfig (LCList [LCString _, LCString s]) = Ok s
   fromLispConfig c =
     Bad $ "Unable to extract a String from this configuration: "
       ++ show c

--- a/src/Ganeti/Utils.hs
+++ b/src/Ganeti/Utils.hs
@@ -226,8 +226,8 @@ if' _    _ y = y
 
 -- | Parse results from readsPrec.
 parseChoices :: Monad m => String -> String -> [(a, String)] -> m a
-parseChoices _ _ ((v, ""):[]) = return v
-parseChoices name s ((_, e):[]) =
+parseChoices _ _ [(v, "")] = return v
+parseChoices name s [(_, e)] =
     fail $ name ++ ": leftover characters when parsing '"
            ++ s ++ "': '" ++ e ++ "'"
 parseChoices name s _ = fail $ name ++ ": cannot parse string '" ++ s ++ "'"

--- a/test/hs/Test/Ganeti/Hypervisor/Xen/XmParser.hs
+++ b/test/hs/Test/Ganeti/Hypervisor/Xen/XmParser.hs
@@ -86,7 +86,7 @@ instance Arbitrary LispConfig where
 -- | Determines conservatively whether a string could be a number.
 canBeNumber :: String -> Bool
 canBeNumber [] = False
-canBeNumber (c:[]) = canBeNumberChar c
+canBeNumber [c] = canBeNumberChar c
 canBeNumber (c:xs) = canBeNumberChar c && canBeNumber xs
 
 -- | Determines whether a char can be part of the string representation of a


### PR DESCRIPTION
Our current hlint version cannot find them yet.

Signed-off-by: Niklas Hambuechen niklash@google.com
Reviewed-by: Klaus Aehlig aehlig@google.com

Cherry-picked-from: d05f1c86fcca10d2a52cfdcf538e8bfaf517f655
