### PR TITLE
Cabal: Relax dependency versions

### DIFF
--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -58,7 +58,7 @@ library
     , hslogger                      >= 1.1.4      && < 1.3
     , json                          >= 0.5        && < 0.9
     , lens                          >= 3.10.2     && < 4.4
-    , lifted-base                   >= 0.2.1.1    && < 0.3
+    , lifted-base                   >= 0.2.0.3    && < 0.3
     , monad-control                 >= 0.3.1.3    && < 0.4
     , MonadCatchIO-transformers     >= 0.3.0.0    && < 0.4
     , network                       >= 2.3.0.13   && < 2.7


### PR DESCRIPTION
We support older versions of our dependencies, including lifted-base, QuickCheck and snap-server for Fedora 18 and Debian Jessie.
