### PR TITLE
Full QuickCheck 2.7 compatibility

### DIFF
--- a/doc/dev-codestyle.rst
+++ b/doc/dev-codestyle.rst
@@ -587,14 +587,14 @@ test on that, by default 500 of those big instances are generated for each
 property. In many cases, it would be sufficient to only generate those 500
 instances once and test all properties on those. To do this, create a property
 that uses ``conjoin`` to combine several properties into one. Use
-``printTestCase`` to add expressive error messages. For example::
+``counterexample`` to add expressive error messages. For example::
 
   prop_myMegaProp :: myBigType -> Property
   prop_myMegaProp b =
     conjoin
-      [ printTestCase
+      [ counterexample
           ("Something failed horribly here: " ++ show b) (subProperty1 b)
-      , printTestCase
+      , counterexample
           ("Something else failed horribly here: " ++ show b)
           (subProperty2 b)
       , -- more properties here ...

--- a/test/hs/Test/Ganeti/BasicTypes.hs
+++ b/test/hs/Test/Ganeti/BasicTypes.hs
@@ -146,9 +146,9 @@ prop_monad_laws :: Int -> Result Int
                 -> Property
 prop_monad_laws a m (Fun _ k) (Fun _ h) =
   conjoin
-  [ printTestCase "return a >>= k == k a" ((return a >>= k) ==? k a)
-  , printTestCase "m >>= return == m" ((m >>= return) ==? m)
-  , printTestCase "m >>= (\\x -> k x >>= h) == (m >>= k) >>= h)"
+  [ counterexample "return a >>= k == k a" ((return a >>= k) ==? k a)
+  , counterexample "m >>= return == m" ((m >>= return) ==? m)
+  , counterexample "m >>= (\\x -> k x >>= h) == (m >>= k) >>= h)"
     ((m >>= (\x -> k x >>= h)) ==? ((m >>= k) >>= h))
   ]
 
@@ -159,11 +159,11 @@ prop_monad_laws a m (Fun _ k) (Fun _ h) =
 -- > v >> mzero = mzero
 prop_monadplus_mzero :: Result Int -> Fun Int (Result Int) -> Property
 prop_monadplus_mzero v (Fun _ f) =
-  printTestCase "mzero >>= f = mzero" ((mzero >>= f) ==? mzero) .&&.
+  counterexample "mzero >>= f = mzero" ((mzero >>= f) ==? mzero) .&&.
   -- FIXME: since we have "many" mzeros, we can't test for equality,
   -- just that we got back a 'Bad' value; I'm not sure if this means
   -- our MonadPlus instance is not sound or not...
-  printTestCase "v >> mzero = mzero" (isBad (v >> mzero))
+  counterexample "v >> mzero = mzero" (isBad (v >> mzero))
 
 testSuite "BasicTypes"
   [ 'prop_functor_id

--- a/test/hs/Test/Ganeti/Confd/Utils.hs
+++ b/test/hs/Test/Ganeti/Confd/Utils.hs
@@ -70,10 +70,10 @@ prop_req_sign key (NonNegative timestamp) (Positive bad_delta)
       bad_timestamp = timestamp + if pm then bad_delta' else (-bad_delta')
       ts_ok = Confd.Utils.parseRequest key signed good_timestamp
       ts_bad = Confd.Utils.parseRequest key signed bad_timestamp
-  in printTestCase "Failed to parse good message"
+  in counterexample "Failed to parse good message"
        (ts_ok ==? BasicTypes.Ok (encoded, crq)) .&&.
-     printTestCase ("Managed to deserialise message with bad\
-                    \ timestamp, got " ++ show ts_bad)
+     counterexample ("Managed to deserialise message with bad\
+                     \ timestamp, got " ++ show ts_bad)
        (ts_bad ==? BasicTypes.Bad "Too old/too new timestamp or clock skew")
 
 -- | Tests that a ConfdReply can be properly encoded, signed and parsed using
@@ -105,7 +105,7 @@ prop_bad_key salt crq =
   forAll (vector 20 `suchThat` (/= key_sign)) $ \key_verify ->
   let signed = Confd.Utils.signMessage key_sign salt (J.encode crq)
       encoded = J.encode signed
-  in printTestCase ("Accepted message signed with different key" ++ encoded) $
+  in counterexample ("Accepted message signed with different key" ++ encoded) $
      (Confd.Utils.parseSignedMessage key_verify encoded
       :: BasicTypes.Result (String, String, Confd.ConfdRequest)) ==?
        BasicTypes.Bad "HMAC verification failed"

--- a/test/hs/Test/Ganeti/HTools/Backend/Text.hs
+++ b/test/hs/Test/Ganeti/HTools/Backend/Text.hs
@@ -92,8 +92,8 @@ prop_Load_Instance name mem dsk vcpus status
                sbal, pnode, pnode, tags]
   in case inst of
        Bad msg -> failTest $ "Failed to load instance: " ++ msg
-       Ok (_, i) -> printTestCase "Mismatch in some field while\
-                                  \ loading the instance" $
+       Ok (_, i) -> counterexample "Mismatch in some field while\
+                                   \ loading the instance" $
                Instance.name i == name &&
                Instance.vcpus i == vcpus &&
                Instance.mem i == mem &&
@@ -110,7 +110,7 @@ prop_Load_InstanceFail ktn fields =
   length fields < 10 || length fields > 12 ==>
     case Text.loadInst nl fields of
       Ok _ -> failTest "Managed to load instance from invalid data"
-      Bad msg -> printTestCase ("Unrecognised error message: " ++ msg) $
+      Bad msg -> counterexample ("Unrecognised error message: " ++ msg) $
                  "Invalid/incomplete instance data: '" `isPrefixOf` msg
     where nl = Map.fromList ktn
 
@@ -215,7 +215,7 @@ prop_CreateSerialise =
      Cluster.iterateAlloc nl Container.empty (Just maxiter) inst allocn [] []
      of
        Bad msg -> failTest $ "Failed to allocate: " ++ msg
-       Ok (_, _, _, [], _) -> printTestCase
+       Ok (_, _, _, [], _) -> counterexample
                               "Failed to allocate: no allocations" False
        Ok (_, nl', il', _, _) ->
          let cdata = Loader.ClusterData defGroupList nl' il' ctags

--- a/test/hs/Test/Ganeti/HTools/Cluster.hs
+++ b/test/hs/Test/Ganeti/HTools/Cluster.hs
@@ -161,9 +161,9 @@ prop_Alloc_sane inst =
            Just (xnl, xi, _, cv) ->
              let il' = Container.add (Instance.idx xi) xi il
                  tbl = Cluster.Table xnl il' cv []
-             in printTestCase "Cluster can be balanced after allocation"
+             in counterexample "Cluster can be balanced after allocation"
                   (not (canBalance tbl True True False)) .&&.
-                printTestCase "Solution score differs from actual node list"
+                counterexample "Solution score differs from actual node list"
                   (abs (Cluster.compCV xnl - cv) < 1e-12)
 
 -- | Checks that on a 2-5 node cluster, we can allocate a random
@@ -190,7 +190,7 @@ prop_CanTieredAlloc =
              all_nodes fn = sum $ map fn (Container.elems nl)
              all_res fn = sum $ map fn [ai_alloc, ai_pool, ai_unav]
          in conjoin
-            [ printTestCase "No instances allocated" $ not (null ixes)
+            [ counterexample "No instances allocated" $ not (null ixes)
             , IntMap.size il' ==? length ixes
             , length ixes     ==? length cstats
             , all_res Types.allocInfoVCpus ==? all_nodes Node.hiCpu
@@ -256,7 +256,7 @@ check_EvacMode grp inst result =
                v -> failmsg  ("invalid solution: " ++ show v) False
            ]
   where failmsg :: String -> Bool -> Property
-        failmsg msg = printTestCase ("Failed to evacuate: " ++ msg)
+        failmsg msg = counterexample ("Failed to evacuate: " ++ msg)
         idx = Instance.idx inst
 
 -- | Checks that on a 4-8 node cluster, once we allocate an instance,
@@ -320,7 +320,7 @@ prop_AllocBalance =
          let ynl = Container.add (Node.idx hnode) hnode xnl
              cv = Cluster.compCV ynl
              tbl = Cluster.Table ynl il' cv []
-         in printTestCase "Failed to rebalance" $
+         in counterexample "Failed to rebalance" $
             canBalance tbl True True False
 
 -- | Checks consistency.
@@ -384,9 +384,9 @@ prop_AllocPolicy =
   let rqn = Instance.requiredNodes $ Instance.diskTemplate inst
       node' = Node.setPolicy ipol node
       nl = makeSmallCluster node' count
-  in printTestCase "Allocation check:"
+  in counterexample "Allocation check:"
        (isNothing (canAllocOn (makeSmallCluster node count) rqn inst)) .&&.
-     printTestCase "Policy failure check:" (isJust $ canAllocOn nl rqn inst)
+     counterexample "Policy failure check:" (isJust $ canAllocOn nl rqn inst)
 
 testSuite "HTools/Cluster"
             [ 'prop_Score_Zero

--- a/test/hs/Test/Ganeti/HTools/Container.hs
+++ b/test/hs/Test/Ganeti/HTools/Container.hs
@@ -88,7 +88,7 @@ prop_findByName =
   in conjoin
        [ Container.findByName nl' (Node.name target) ==? Just target
        , Container.findByName nl' (Node.alias target) ==? Just target
-       , printTestCase "Found non-existing name"
+       , counterexample "Found non-existing name"
          (isNothing (Container.findByName nl' othername))
        ]
 

--- a/test/hs/Test/Ganeti/HTools/Node.hs
+++ b/test/hs/Test/Ganeti/HTools/Node.hs
@@ -324,7 +324,7 @@ prop_rMem inst =
   in case (node_add_ab, node_add_nb, node_del_ab, node_del_nb) of
        (Ok a_ab, Ok a_nb,
         Ok d_ab, Ok d_nb) ->
-         printTestCase "Consistency checks failed" $
+         counterexample "Consistency checks failed" $
            Node.rMem a_ab >  orig_rmem &&
            Node.rMem a_ab - orig_rmem == Instance.mem inst_ab &&
            Node.rMem a_nb == orig_rmem &&

--- a/test/hs/Test/Ganeti/HTools/Types.hs
+++ b/test/hs/Test/Ganeti/HTools/Types.hs
@@ -164,7 +164,7 @@ prop_IPolicy_serialisation = testSerialisation
 prop_opToResult :: Types.OpResult Int -> Property
 prop_opToResult op =
   case op of
-    Bad _ -> printTestCase ("expected bad but got " ++ show r) $ isBad r
+    Bad _ -> counterexample ("expected bad but got " ++ show r) $ isBad r
     Ok v  -> case r of
                Bad msg -> failTest ("expected Ok but got Bad " ++ msg)
                Ok v' -> v ==? v'

--- a/test/hs/Test/Ganeti/Hypervisor/Xen/XmParser.hs
+++ b/test/hs/Test/Ganeti/Hypervisor/Xen/XmParser.hs
@@ -139,7 +139,7 @@ isAlmostEqual (LCList c1) (LCList c2) =
   (length c1 ==? length c2) .&&.
   conjoin (zipWith isAlmostEqual c1 c2)
 isAlmostEqual (LCString s1) (LCString s2) = s1 ==? s2
-isAlmostEqual (LCDouble d1) (LCDouble d2) = printTestCase msg $ rel <= 1e-12
+isAlmostEqual (LCDouble d1) (LCDouble d2) = counterexample msg $ rel <= 1e-12
     where rel = relativeError d1 d2
           msg = "Relative error " ++ show rel ++ " not smaller than 1e-12\n" ++
                 "expected: " ++ show d2 ++ "\n but got: " ++ show d1
@@ -166,7 +166,7 @@ prop_config :: LispConfig -> Property
 prop_config conf =
   case A.parseOnly lispConfigParser . pack . serializeConf $ conf of
         Left msg -> failTest $ "Parsing failed: " ++ msg
-        Right obtained -> printTestCase "Failing almost equal check" $
+        Right obtained -> counterexample "Failing almost equal check" $
                           isAlmostEqual obtained conf
 
 -- | Test whether a randomly generated UptimeInfo text line can be parsed.

--- a/test/hs/Test/Ganeti/JQScheduler.hs
+++ b/test/hs/Test/Ganeti/JQScheduler.hs
@@ -238,11 +238,11 @@ prop_reasonRateLimit =
            "queued jobs cannot be started because of rate limiting"
 
        $ conjoin
-           [ printTestCase "scheduled jobs must be subsequence" $
+           [ counterexample "scheduled jobs must be subsequence" $
                toRun `isSubsequenceOf` enqueued
 
            -- This is the key property:
-           , printTestCase "no job may exceed its bucket limits, except from\
+           , counterexample "no job may exceed its bucket limits, except from\
                             \ jobs that were already running with exceeded\
                             \ limits; those must not increase" $
                conjoin
@@ -558,10 +558,10 @@ prop_jobFiltering =
       -- bugs 25 and 27).
       in (enqueued /= []) ==> actionCovers $ conjoin
 
-           [ printTestCase "scheduled jobs must be subsequence" $
+           [ counterexample "scheduled jobs must be subsequence" $
                toRun `isSubsequenceOf` enqueued
 
-           , printTestCase "a reason for each job (not) being scheduled" .
+           , counterexample "a reason for each job (not) being scheduled" .
 
                -- All enqueued jobs must have a reason why they were (not)
                -- scheduled, determined by the filter that applies.

--- a/test/hs/Test/Ganeti/JQueue.hs
+++ b/test/hs/Test/Ganeti/JQueue.hs
@@ -103,15 +103,15 @@ prop_JobStatus =
       -- computes status for a job with an added opcode after
       st_post_op pop = calcJobStatus (job1 { qjOps = qjOps job1 ++ [pop] })
   in conjoin
-     [ printTestCase "pre-success doesn't change status"
+     [ counterexample "pre-success doesn't change status"
        (st_pre_op op_succ ==? st1)
-     , printTestCase "post-success doesn't change status"
+     , counterexample "post-success doesn't change status"
        (st_post_op op_succ ==? st1)
-     , printTestCase "pre-error is error"
+     , counterexample "pre-error is error"
        (st_pre_op op_err ==? JOB_STATUS_ERROR)
-     , printTestCase "pre-canceling is canceling"
+     , counterexample "pre-canceling is canceling"
        (st_pre_op op_cnl ==? JOB_STATUS_CANCELING)
-     , printTestCase "pre-canceled is canceled"
+     , counterexample "pre-canceled is canceled"
        (st_pre_op op_cnd ==? JOB_STATUS_CANCELED)
      ]
 
@@ -171,10 +171,10 @@ prop_ListJobIDs = monadicIO $ do
     full_dir <- extractJobIDs $ getJobIDs [tempdir]
     invalid_dir <- getJobIDs [tempdir </> "no-such-dir"]
     return (empty_dir, sortJobIDs full_dir, invalid_dir)
-  stop $ conjoin [ printTestCase "empty directory" $ e ==? []
-                 , printTestCase "directory with valid names" $
+  stop $ conjoin [ counterexample "empty directory" $ e ==? []
+                 , counterexample "directory with valid names" $
                    f ==? sortJobIDs jobs
-                 , printTestCase "invalid directory" $ isBad g
+                 , counterexample "invalid directory" $ isBad g
                  ]
 
 -- | Tests loading jobs from disk.
@@ -211,7 +211,7 @@ prop_LoadJobs = monadicIO $ do
                  , current ==? Ganeti.BasicTypes.Ok (job, False)
                  , archived ==? Ganeti.BasicTypes.Ok (job, True)
                  , missing_current ==? noSuchJob
-                 , printTestCase "broken job" (isBad broken)
+                 , counterexample "broken job" (isBad broken)
                  ]
 
 -- | Tests computing job directories. Creates random directories,
@@ -254,15 +254,15 @@ prop_InputOpCode meta i =
 -- | Tests 'extractOpSummary'.
 prop_extractOpSummary :: MetaOpCode -> Int -> Property
 prop_extractOpSummary meta i =
-  conjoin [ printTestCase "valid opcode" $
+  conjoin [ counterexample "valid opcode" $
             extractOpSummary (ValidOpCode meta)      ==? summary
-          , printTestCase "invalid opcode, correct object" $
+          , counterexample "invalid opcode, correct object" $
             extractOpSummary (InvalidOpCode jsobj)   ==? summary
-          , printTestCase "invalid opcode, empty object" $
+          , counterexample "invalid opcode, empty object" $
             extractOpSummary (InvalidOpCode emptyo)  ==? invalid
-          , printTestCase "invalid opcode, object with invalid OP_ID" $
+          , counterexample "invalid opcode, object with invalid OP_ID" $
             extractOpSummary (InvalidOpCode invobj)  ==? invalid
-          , printTestCase "invalid opcode, not jsobject" $
+          , counterexample "invalid opcode, not jsobject" $
             extractOpSummary (InvalidOpCode jsinval) ==? invalid
           ]
     where summary = opSummary (metaOpCode meta)

--- a/test/hs/Test/Ganeti/Locking/Locks.hs
+++ b/test/hs/Test/Ganeti/Locking/Locks.hs
@@ -78,7 +78,7 @@ prop_ImpliedOrder :: Property
 prop_ImpliedOrder =
   forAll ((arbitrary :: Gen GanetiLocks)
           `suchThat` (not . null . lockImplications)) $ \b ->
-  printTestCase "Implied locks must be earlier in the lock order"
+  counterexample "Implied locks must be earlier in the lock order"
   . flip all (lockImplications b) $ \a ->
   a < b
 
@@ -89,7 +89,7 @@ prop_ImpliedIntervall =
           `suchThat` (not . null . lockImplications)) $ \b ->
   forAll (elements $ lockImplications b) $ \a ->
   forAll (arbitrary `suchThat` liftA2 (&&) (a <) (<= b)) $ \x ->
-  printTestCase ("Locks between a group and a member of the group"
+  counterexample ("Locks between a group and a member of the group"
                  ++ " must also belong to the group")
   $ a `elem` lockImplications x
 

--- a/test/hs/Test/Ganeti/Network.hs
+++ b/test/hs/Test/Ganeti/Network.hs
@@ -24,21 +24,21 @@ import Test.Ganeti.TestHelper
 prop_addressPoolProperties :: Network -> Property
 prop_addressPoolProperties a =
   conjoin
-    [ printTestCase
+    [ counterexample
         ("Not all reservations are included in 'allReservations' of " ++
          "address pool:" ++ show a) (allReservationsSubsumesInternal a)
-    , printTestCase
+    , counterexample
         ("Not all external reservations are covered by 'allReservations' " ++
          "of address pool: " ++ show a)
         (allReservationsSubsumesExternal a)
-    , printTestCase
+    , counterexample
         ("The counts of free and reserved addresses do not add up for " ++
          "address pool: " ++ show a)
         (checkCounts a)
-    , printTestCase
+    , counterexample
         ("'isFull' wrongly classified the status of the address pool: " ++
          show a) (checkIsFull a)
-    , printTestCase
+    , counterexample
         ("Network map is inconsistent with reservations of address pool: " ++
          show a) (checkGetMap a)
     ]

--- a/test/hs/Test/Ganeti/Objects.hs
+++ b/test/hs/Test/Ganeti/Objects.hs
@@ -465,11 +465,11 @@ prop_fillDict defaults custom =
       d_keys = map fst defaults
       c_map = Map.fromList custom
       c_keys = map fst custom
-  in conjoin [ printTestCase "Empty custom filling"
+  in conjoin [ counterexample "Empty custom filling"
                (fillDict d_map Map.empty [] == d_map)
-             , printTestCase "Empty defaults filling"
+             , counterexample "Empty defaults filling"
                (fillDict Map.empty c_map [] == c_map)
-             , printTestCase "Delete all keys"
+             , counterexample "Delete all keys"
                (fillDict d_map c_map (d_keys++c_keys) == Map.empty)
              ]
 

--- a/test/hs/Test/Ganeti/OpCodes.hs
+++ b/test/hs/Test/Ganeti/OpCodes.hs
@@ -702,7 +702,7 @@ prop_setOpComment op comment =
 prop_mkDiskIndex_fail :: QuickCheck.Positive Int -> Property
 prop_mkDiskIndex_fail (Positive i) =
   case mkDiskIndex (negate i) of
-    Bad msg -> printTestCase "error message " $
+    Bad msg -> counterexample "error message " $
                "Invalid value" `isPrefixOf` msg
     Ok v -> failTest $ "Succeeded to build disk index '" ++ show v ++
                        "' from negative value " ++ show (negate i)

--- a/test/hs/Test/Ganeti/Query/Filter.hs
+++ b/test/hs/Test/Ganeti/Query/Filter.hs
@@ -63,7 +63,7 @@ checkQueryResults :: ConfigData -> Query -> String
                   -> [[ResultEntry]] -> Property
 checkQueryResults cfg qr descr expected = monadicIO $ do
   result <- run (query cfg False qr) >>= resultProp
-  stop $ printTestCase ("Inconsistent results in " ++ descr)
+  stop $ counterexample ("Inconsistent results in " ++ descr)
          (qresData result ==? expected)
 
 -- | Makes a node name query, given a filter.
@@ -192,13 +192,13 @@ prop_makeSimpleFilter =
   forAll (resize 10 $ listOf1 genName) $ \names ->
   forAll (resize 10 $ listOf1 arbitrary) $ \ids ->
   forAll genName $ \namefield ->
-  conjoin [ printTestCase "test expected names" $
+  conjoin [ counterexample "test expected names" $
               makeSimpleFilter namefield (map Left names) ==?
               OrFilter (map (EQFilter namefield . QuotedString) names)
-          , printTestCase "test expected IDs" $
+          , counterexample "test expected IDs" $
               makeSimpleFilter namefield (map Right ids) ==?
               OrFilter (map (EQFilter namefield . NumericValue) ids)
-          , printTestCase "test empty names" $
+          , counterexample "test empty names" $
               makeSimpleFilter namefield [] ==? EmptyFilter
           ]
 

--- a/test/hs/Test/Ganeti/Query/Language.hs
+++ b/test/hs/Test/Ganeti/Query/Language.hs
@@ -142,7 +142,7 @@ prop_filter_serialisation = forAll genFilter testSerialisation
 -- | Tests that filter regexes are serialised correctly.
 prop_filterregex_instances :: FilterRegex -> Property
 prop_filterregex_instances rex =
-  printTestCase "failed JSON encoding" (testSerialisation rex)
+  counterexample "failed JSON encoding" (testSerialisation rex)
 
 -- | Tests 'ResultStatus' serialisation.
 prop_resultstatus_serialisation :: ResultStatus -> Property

--- a/test/hs/Test/Ganeti/Query/Query.hs
+++ b/test/hs/Test/Ganeti/Query/Query.hs
@@ -88,13 +88,13 @@ prop_queryNode_noUnknown =
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields (ItemTypeOpCode QRNode) [field])
   stop $ conjoin
-         [ printTestCase ("Got unknown fields via query (" ++
-                          show fdefs ++ ")") (hasUnknownFields fdefs)
-         , printTestCase ("Got unknown result status via query (" ++
-                          show fdata ++ ")")
+         [ counterexample ("Got unknown fields via query (" ++
+                           show fdefs ++ ")") (hasUnknownFields fdefs)
+         , counterexample ("Got unknown result status via query (" ++
+                           show fdata ++ ")")
            (all (all ((/= RSUnknown) . rentryStatus)) fdata)
-         , printTestCase ("Got unknown fields via query fields (" ++
-                          show fdefs'++ ")") (hasUnknownFields fdefs')
+         , counterexample ("Got unknown fields via query fields (" ++
+                           show fdefs'++ ")") (hasUnknownFields fdefs')
          ]
 
 -- | Tests that an unknown field is returned as such.
@@ -109,16 +109,16 @@ prop_queryNode_Unknown =
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields (ItemTypeOpCode QRNode) [field])
   stop $ conjoin
-         [ printTestCase ("Got known fields via query (" ++ show fdefs ++ ")")
+         [ counterexample ("Got known fields via query (" ++ show fdefs ++ ")")
            (not $ hasUnknownFields fdefs)
-         , printTestCase ("Got /= ResultUnknown result status via query (" ++
-                          show fdata ++ ")")
+         , counterexample ("Got /= ResultUnknown result status via query (" ++
+                           show fdata ++ ")")
            (all (all ((== RSUnknown) . rentryStatus)) fdata)
-         , printTestCase ("Got a Just in a result value (" ++
-                          show fdata ++ ")")
+         , counterexample ("Got a Just in a result value (" ++
+                           show fdata ++ ")")
            (all (all (isNothing . rentryValue)) fdata)
-         , printTestCase ("Got known fields via query fields (" ++ show fdefs'
-                          ++ ")") (not $ hasUnknownFields fdefs')
+         , counterexample ("Got known fields via query fields (" ++ show fdefs'
+                           ++ ")") (not $ hasUnknownFields fdefs')
          ]
 
 -- | Checks that a result type is conforming to a field definition.
@@ -155,13 +155,13 @@ prop_queryNode_types =
     run (query cfg False (Query (ItemTypeOpCode QRNode)
                           [field] EmptyFilter)) >>= resultProp
   stop $ conjoin
-         [ printTestCase ("Inconsistent result entries (" ++ show fdata ++ ")")
+         [ counterexample ("Inconsistent result entries (" ++ show fdata ++ ")")
            (conjoin $ map (conjoin . zipWith checkResultType fdefs) fdata)
-         , printTestCase "Wrong field definitions length"
+         , counterexample "Wrong field definitions length"
            (length fdefs ==? 1)
-         , printTestCase "Wrong field result rows length"
+         , counterexample "Wrong field result rows length"
            (all ((== 1) . length) fdata)
-         , printTestCase "Wrong number of result rows"
+         , counterexample "Wrong number of result rows"
            (length fdata ==? numnodes)
          ]
 
@@ -201,7 +201,7 @@ prop_queryNode_filter =
       run (query cluster False (Query (ItemTypeOpCode QRNode)
                                 ["name"] flt)) >>= resultProp
     stop $ conjoin
-      [ printTestCase "Invalid node names" $
+      [ counterexample "Invalid node names" $
         map (map rentryValue) fdata ==? map (\f -> [Just (showJSON f)]) fqdns
       ]
 
@@ -218,13 +218,13 @@ prop_queryGroup_noUnknown =
     QueryFieldsResult fdefs' <-
       resultProp $ queryFields (QueryFields (ItemTypeOpCode QRGroup) [field])
     stop $ conjoin
-     [ printTestCase ("Got unknown fields via query (" ++ show fdefs ++ ")")
+     [ counterexample ("Got unknown fields via query (" ++ show fdefs ++ ")")
           (hasUnknownFields fdefs)
-     , printTestCase ("Got unknown result status via query (" ++
-                      show fdata ++ ")")
+     , counterexample ("Got unknown result status via query (" ++
+                       show fdata ++ ")")
        (all (all ((/= RSUnknown) . rentryStatus)) fdata)
-     , printTestCase ("Got unknown fields via query fields (" ++ show fdefs'
-                      ++ ")") (hasUnknownFields fdefs')
+     , counterexample ("Got unknown fields via query fields (" ++ show fdefs'
+                       ++ ")") (hasUnknownFields fdefs')
      ]
 
 prop_queryGroup_Unknown :: Property
@@ -238,16 +238,16 @@ prop_queryGroup_Unknown =
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields (ItemTypeOpCode QRGroup) [field])
   stop $ conjoin
-         [ printTestCase ("Got known fields via query (" ++ show fdefs ++ ")")
+         [ counterexample ("Got known fields via query (" ++ show fdefs ++ ")")
            (not $ hasUnknownFields fdefs)
-         , printTestCase ("Got /= ResultUnknown result status via query (" ++
-                          show fdata ++ ")")
+         , counterexample ("Got /= ResultUnknown result status via query (" ++
+                           show fdata ++ ")")
            (all (all ((== RSUnknown) . rentryStatus)) fdata)
-         , printTestCase ("Got a Just in a result value (" ++
-                          show fdata ++ ")")
+         , counterexample ("Got a Just in a result value (" ++
+                           show fdata ++ ")")
            (all (all (isNothing . rentryValue)) fdata)
-         , printTestCase ("Got known fields via query fields (" ++ show fdefs'
-                          ++ ")") (not $ hasUnknownFields fdefs')
+         , counterexample ("Got known fields via query fields (" ++ show fdefs'
+                           ++ ")") (not $ hasUnknownFields fdefs')
          ]
 
 prop_queryGroup_types :: Property
@@ -259,10 +259,10 @@ prop_queryGroup_types =
     run (query cfg False (Query (ItemTypeOpCode QRGroup)
                           [field] EmptyFilter)) >>= resultProp
   stop $ conjoin
-         [ printTestCase ("Inconsistent result entries (" ++ show fdata ++ ")")
+         [ counterexample ("Inconsistent result entries (" ++ show fdata ++ ")")
            (conjoin $ map (conjoin . zipWith checkResultType fdefs) fdata)
-         , printTestCase "Wrong field definitions length" (length fdefs ==? 1)
-         , printTestCase "Wrong field result rows length"
+         , counterexample "Wrong field definitions length" (length fdefs ==? 1)
+         , counterexample "Wrong field result rows length"
            (all ((== 1) . length) fdata)
          ]
 
@@ -289,7 +289,7 @@ prop_queryGroup_nodeCount =
       run (query cluster False (Query (ItemTypeOpCode QRGroup)
                                 ["node_cnt"] EmptyFilter)) >>= resultProp
     stop $ conjoin
-      [ printTestCase "Invalid node count" $
+      [ counterexample "Invalid node count" $
         map (map rentryValue) fdata ==? [[Just (showJSON nodes)]]
       ]
 
@@ -312,13 +312,13 @@ prop_queryJob_noUnknown =
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields qtype [field])
   stop $ conjoin
-         [ printTestCase ("Got unknown fields via query (" ++
-                          show fdefs ++ ")") (hasUnknownFields fdefs)
-         , printTestCase ("Got unknown result status via query (" ++
-                          show fdata ++ ")")
+         [ counterexample ("Got unknown fields via query (" ++
+                           show fdefs ++ ")") (hasUnknownFields fdefs)
+         , counterexample ("Got unknown result status via query (" ++
+                           show fdata ++ ")")
            (all (all ((/= RSUnknown) . rentryStatus)) fdata)
-         , printTestCase ("Got unknown fields via query fields (" ++
-                          show fdefs'++ ")") (hasUnknownFields fdefs')
+         , counterexample ("Got unknown fields via query fields (" ++
+                           show fdefs'++ ")") (hasUnknownFields fdefs')
          ]
 
 -- | Tests that an unknown field is returned as such.
@@ -335,16 +335,16 @@ prop_queryJob_Unknown =
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields qtype [field])
   stop $ conjoin
-         [ printTestCase ("Got known fields via query (" ++ show fdefs ++ ")")
+         [ counterexample ("Got known fields via query (" ++ show fdefs ++ ")")
            (not $ hasUnknownFields fdefs)
-         , printTestCase ("Got /= ResultUnknown result status via query (" ++
-                          show fdata ++ ")")
+         , counterexample ("Got /= ResultUnknown result status via query (" ++
+                           show fdata ++ ")")
            (all (all ((== RSUnknown) . rentryStatus)) fdata)
-         , printTestCase ("Got a Just in a result value (" ++
-                          show fdata ++ ")")
+         , counterexample ("Got a Just in a result value (" ++
+                           show fdata ++ ")")
            (all (all (isNothing . rentryValue)) fdata)
-         , printTestCase ("Got known fields via query fields (" ++ show fdefs'
-                          ++ ")") (not $ hasUnknownFields fdefs')
+         , counterexample ("Got known fields via query fields (" ++ show fdefs'
+                           ++ ")") (not $ hasUnknownFields fdefs')
          ]
 
 -- ** Misc other tests
@@ -357,12 +357,12 @@ prop_getRequestedNames =
       q_node1 = QuotedString node1
       eq_name = EQFilter "name"
       eq_node1 = eq_name q_node1
-  in conjoin [ printTestCase "empty filter" $ chk EmptyFilter ==? []
-             , printTestCase "and filter" $ chk (AndFilter [eq_node1]) ==? []
-             , printTestCase "simple equality" $ chk eq_node1 ==? [node1]
-             , printTestCase "non-name field" $
+  in conjoin [ counterexample "empty filter" $ chk EmptyFilter ==? []
+             , counterexample "and filter" $ chk (AndFilter [eq_node1]) ==? []
+             , counterexample "simple equality" $ chk eq_node1 ==? [node1]
+             , counterexample "non-name field" $
                chk (EQFilter "foo" q_node1) ==? []
-             , printTestCase "non-simple filter" $
+             , counterexample "non-simple filter" $
                chk (OrFilter [ eq_node1 , LTFilter "foo" q_node1]) ==? []
              ]
 

--- a/test/hs/Test/Ganeti/SlotMap.hs
+++ b/test/hs/Test/Ganeti/SlotMap.hs
@@ -182,9 +182,9 @@ prop_occupySlots =
   forAll arbitrary $ \(sm :: SlotMap Int, cm :: CountMap Int) ->
     let smOcc = sm `occupySlots` cm
     in conjoin
-         [ printTestCase "input keys are preserved" $
+         [ counterexample "input keys are preserved" $
              all (`member` smOcc) (keyUnion sm cm)
-         , printTestCase "all keys must come from the input keys" $
+         , counterexample "all keys must come from the input keys" $
              all (`Set.member` keyUnion sm cm) (keys smOcc)
          ]
 
@@ -251,12 +251,12 @@ prop_hasSlotsFor =
           oldOverfullBucks = overfullKeys sm1
           newOverfullBucks = overfullKeys smOcc
       in conjoin
-           [ printTestCase "if there's enough extra space, then the new\
+           [ counterexample "if there's enough extra space, then the new\
                             \ overfull keys must be as before" $
              fits ==> (newOverfullBucks ==? oldOverfullBucks)
            -- Note that the other way around does not hold:
            --   (newOverfullBucks == oldOverfullBucks) ==> fits
-           , printTestCase "joining SlotMaps must not change the number of\
+           , counterexample "joining SlotMaps must not change the number of\
                             \ overfull keys (but may change their slot\
                             \ counts"
                . property $ size newOverfullBucks >= size oldOverfullBucks

--- a/test/hs/Test/Ganeti/Ssconf.hs
+++ b/test/hs/Test/Ganeti/Ssconf.hs
@@ -60,7 +60,7 @@ instance Arbitrary Ssconf.SSConf where
 
 prop_filename :: Ssconf.SSKey -> Property
 prop_filename key =
-  printTestCase "Key doesn't start with correct prefix" $
+  counterexample "Key doesn't start with correct prefix" $
     Ssconf.sSFilePrefix `isPrefixOf` Ssconf.keyToFilename "" key
 
 caseParseNodesVmCapable :: HUnit.Assertion

--- a/test/hs/Test/Ganeti/TestCommon.hs
+++ b/test/hs/Test/Ganeti/TestCommon.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 {-| Common helper functions and instances for all Ganeti tests.
@@ -88,6 +89,7 @@ module Test.Ganeti.TestCommon
   , relativeError
   , getTempFileName
   , listOfUniqueBy
+  , counterexample
   ) where
 
 import Control.Applicative
@@ -107,6 +109,7 @@ import System.IO.Error (isDoesNotExistError)
 import System.Process (readProcessWithExitCode)
 import qualified Test.HUnit as HUnit
 import Test.QuickCheck
+import qualified Test.QuickCheck as QC
 import Test.QuickCheck.Monadic
 import qualified Text.JSON as J
 import Numeric
@@ -163,7 +166,7 @@ maxOpCodes = 16
 -- | Checks for equality with proper annotation. The first argument is
 -- the computed value, the second one the expected value.
 (==?) :: (Show a, Eq a) => a -> a -> Property
-(==?) x y = printTestCase
+(==?) x y = counterexample
             ("Expected equality, but got mismatch\nexpected: " ++
              show y ++ "\n but got: " ++ show x) (x == y)
 infix 3 ==?
@@ -172,14 +175,14 @@ infix 3 ==?
 -- is the computed value, the second one the expected (not equal)
 -- value.
 (/=?) :: (Show a, Eq a) => a -> a -> Property
-(/=?) x y = printTestCase
+(/=?) x y = counterexample
             ("Expected inequality, but got equality: '" ++
              show x ++ "'.") (x /= y)
 infix 3 /=?
 
 -- | Show a message and fail the test.
 failTest :: String -> Property
-failTest msg = printTestCase msg False
+failTest msg = counterexample msg False
 
 -- | A 'True' property.
 passTest :: Property
@@ -579,3 +582,9 @@ listOfUniqueBy gen keyFun forbidden = do
       else do
         x <- gen `suchThat` ((`Set.notMember` usedKeys) . keyFun)
         return $ Just (x, (i + 1, Set.insert (keyFun x) usedKeys))
+
+
+#if !MIN_VERSION_QuickCheck(2,7,0)
+counterexample :: Testable prop => String -> prop -> Property
+counterexample = QC.printTestCase
+#endif

--- a/test/hs/Test/Ganeti/Utils/MultiMap.hs
+++ b/test/hs/Test/Ganeti/Utils/MultiMap.hs
@@ -74,8 +74,8 @@ prop_MultiMap_equality
   :: MultiMap Three Three -> MultiMap Three Three -> Property
 prop_MultiMap_equality m1 m2 =
   let testKey k = MM.lookup k m1 == MM.lookup k m2
-   in printTestCase ("Extensional equality of '" ++ show m1
-                     ++ "' and '" ++ show m2 ++ " doesn't match '=='.")
+   in counterexample ("Extensional equality of '" ++ show m1
+                      ++ "' and '" ++ show m2 ++ " doesn't match '=='.")
       $ all testKey [minBound..maxBound] ==? (m1 == m2)
 
 prop_MultiMap_serialisation :: MultiMap Int Int -> Property

--- a/test/hs/Test/Ganeti/Utils/Statistics.hs
+++ b/test/hs/Test/Ganeti/Utils/Statistics.hs
@@ -38,6 +38,7 @@ module Test.Ganeti.Utils.Statistics (testUtils_Statistics) where
 
 import Test.QuickCheck
 
+import Test.Ganeti.TestCommon
 import Test.Ganeti.TestHelper
 
 import Ganeti.Utils (stdDev)
@@ -56,9 +57,9 @@ prop_stddev_update =
       with_update = getStatisticValue
                     $ updateStatistics (getStdDevStatistics original) (a,b)
       direct = stdDev modified
-  in printTestCase ("Value computed by update " ++ show with_update
-                    ++ " differs too much from correct value " ++ show direct)
-                   (abs (with_update - direct) < 1e-12)
+  in counterexample ("Value computed by update " ++ show with_update
+                     ++ " differs too much from correct value " ++ show direct)
+                    (abs (with_update - direct) < 1e-12)
 
 testSuite "Utils/Statistics"
   [ 'prop_stddev_update


### PR DESCRIPTION
This renames the deprecated `printTestCase` to its replacement
`counterexample`, add provides a CPP-guarded fallback for QuickCheck < 2.7.

Signed-off-by: Niklas Hambuechen niklash@google.com
