### PR TITLE
Cabal: Relax deps to lens-3.10

### DIFF
--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -57,7 +57,7 @@ library
     , hinotify                      >= 0.3.2      && < 0.4
     , hslogger                      >= 1.1.4      && < 1.3
     , json                          >= 0.5        && < 0.9
-    , lens                          >= 3.10.2     && < 4.4
+    , lens                          >= 3.10       && < 4.4
     , lifted-base                   >= 0.2.0.3    && < 0.3
     , monad-control                 >= 0.3.1.3    && < 0.4
     , MonadCatchIO-transformers     >= 0.3.0.0    && < 0.4


### PR DESCRIPTION
Ubuntu Trusty has 3.10 and we support it.

Tested on our buildbot.

Signed-off-by: Niklas Hambuechen niklash@google.com
