### PR TITLE
TestCommon: Fix QuickCheck unused import warning

### DIFF
--- a/test/hs/Test/Ganeti/TestCommon.hs
+++ b/test/hs/Test/Ganeti/TestCommon.hs
@@ -109,7 +109,9 @@ import System.IO.Error (isDoesNotExistError)
 import System.Process (readProcessWithExitCode)
 import qualified Test.HUnit as HUnit
 import Test.QuickCheck
+#if !MIN_VERSION_QuickCheck(2,7,0)
 import qualified Test.QuickCheck as QC
+#endif
 import Test.QuickCheck.Monadic
 import qualified Text.JSON as J
 import Numeric

--- a/test/hs/Test/Ganeti/Utils/Statistics.hs
+++ b/test/hs/Test/Ganeti/Utils/Statistics.hs
@@ -36,7 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module Test.Ganeti.Utils.Statistics (testUtils_Statistics) where
 
-import Test.QuickCheck
+import Test.QuickCheck (Property, forAll, choose, vectorOf)
 
 import Test.Ganeti.TestCommon
 import Test.Ganeti.TestHelper


### PR DESCRIPTION
This only appears on systems with QuickCheck >= 2.7 because
the QC qualified name is only used in the conditional section.

Fixed by making the import conditional as well.

Signed-off-by: Niklas Hambuechen niklash@google.com
