### PR TITLE
HTools: Pass --ignore-soft-errors all the way through

### DIFF
--- a/src/Ganeti/HTools/Backend/IAlloc.hs
+++ b/src/Ganeti/HTools/Backend/IAlloc.hs
@@ -414,19 +414,19 @@ processRequest opts request =
   let Request rqtype (ClusterData gl nl il _ _) = request
   in case rqtype of
        Allocate xi (Cluster.AllocDetails reqn Nothing) ->
-         Cluster.tryMGAlloc gl nl il xi reqn >>= formatAllocate il
+         Cluster.tryMGAlloc opts gl nl il xi reqn >>= formatAllocate il
        Allocate xi (Cluster.AllocDetails reqn (Just gn)) ->
-         Cluster.tryGroupAlloc gl nl il gn xi reqn >>= formatAllocate il
+         Cluster.tryGroupAlloc opts gl nl il gn xi reqn >>= formatAllocate il
        Relocate idx reqn exnodes ->
          processRelocate opts gl nl il idx reqn exnodes >>= formatRelocate
        ChangeGroup gdxs idxs ->
-         Cluster.tryChangeGroup gl nl il idxs gdxs >>=
+         Cluster.tryChangeGroup opts gl nl il idxs gdxs >>=
                 formatNodeEvac gl nl il
        NodeEvacuate xi mode ->
          Cluster.tryNodeEvac opts gl nl il mode xi >>=
                 formatNodeEvac gl nl il
        MultiAllocate xies ->
-         Cluster.allocList gl nl il xies [] >>= formatMultiAlloc
+         Cluster.allocList opts gl nl il xies [] >>= formatMultiAlloc
 
 -- | Reads the request from the data file(s).
 readRequest :: FilePath -> IO Request

--- a/test/hs/Test/Ganeti/HTools/Backend/Text.hs
+++ b/test/hs/Test/Ganeti/HTools/Backend/Text.hs
@@ -52,6 +52,7 @@ import Test.Ganeti.HTools.Instance (genInstanceSmallerThanNode,
 import Test.Ganeti.HTools.Node (genNode, genOnlineNode, genUniqueNodeList)
 
 import Ganeti.BasicTypes
+import qualified Ganeti.HTools.AlgorithmParams as Alg
 import qualified Ganeti.HTools.Backend.Text as Text
 import qualified Ganeti.HTools.Cluster as Cluster
 import qualified Ganeti.HTools.Container as Container
@@ -211,8 +212,10 @@ prop_CreateSerialise =
   forAll (genInstanceSmallerThanNode node) $ \inst ->
   let nl = makeSmallCluster node count
       reqnodes = Instance.requiredNodes $ Instance.diskTemplate inst
+      opts = Alg.defaultOptions
   in case Cluster.genAllocNodes defGroupList nl reqnodes True >>= \allocn ->
-     Cluster.iterateAlloc nl Container.empty (Just maxiter) inst allocn [] []
+     Cluster.iterateAlloc opts nl Container.empty (Just maxiter) inst allocn
+                          [] []
      of
        Bad msg -> failTest $ "Failed to allocate: " ++ msg
        Ok (_, _, _, [], _) -> printTestCase


### PR DESCRIPTION
Fixes hail silently ignoring the --ignore-soft-errors flag.

See issue 1006.

For hspace and tests, the default is to use defaultOptions
(do not force, like it was before).

The core change is in `allocateOnSingle`/`allocateOnPair`,
which now call `addPriEx force` instead of `addPri` (that one
defaults to `force = False`).