### PR TITLE
When hinting to do gnt-instance info, show the instance.

### DIFF
--- a/lib/cmdlib/instance_storage.py
+++ b/lib/cmdlib/instance_storage.py
@@ -2981,8 +2981,8 @@ class TLReplaceDisks(Tasklet):
       if msg:
         raise errors.OpExecError(
           "Can't attach drbd disks on node %s: %s (please do a gnt-instance "
-          "info to see the status of disks)" %
-          (self.cfg.GetNodeName(to_node), msg))
+          "info %s to see the status of disks)" %
+          (self.cfg.GetNodeName(to_node), msg, self.instance.name))
 
     cstep = itertools.count(5)
 


### PR DESCRIPTION
Present in 2.10 and master.

Did not test if it worked, but looking at ganeti.objects.Instance seems plausible to work.