### PR TITLE
Add Ed25519 SSH Key Type support (disabled for hostkey currently)

### DIFF
--- a/lib/ssh.py
+++ b/lib/ssh.py
@@ -87,6 +87,8 @@ def GetUserFiles(user, mkdir=False, dircheck=True, kind=constants.SSHK_DSA,
     suffix = "rsa"
   elif kind == constants.SSHK_ECDSA:
     suffix = "ecdsa"
+  elif kind == constants.SSHK_Ed25519:
+    suffix = "ed25519"
   else:
     raise errors.ProgrammerError("Unknown SSH key kind '%s'" % kind)
 
@@ -1254,6 +1256,7 @@ SSH_KEY_VALID_BITS = {
   constants.SSHK_DSA: KeyBitInfo(1024, lambda b: b == 1024),
   constants.SSHK_RSA: KeyBitInfo(2048, lambda b: b >= 768),
   constants.SSHK_ECDSA: KeyBitInfo(384, lambda b: b in [256, 384, 521]),
+  constants.SSHK_Ed25519: KeyBitInfo(256, lambda b: b == 256),
 }
 
 

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -4721,8 +4721,11 @@ sshkEcdsa = Types.sshKeyTypeToRaw ECDSA
 sshkRsa :: String
 sshkRsa = Types.sshKeyTypeToRaw RSA
 
+sshkEd25519 :: String
+sshkEd25519 = Types.sshKeyTypeToRaw Ed25519
+
 sshkAll :: FrozenSet String
-sshkAll = ConstantUtils.mkSet [sshkRsa, sshkDsa, sshkEcdsa]
+sshkAll = ConstantUtils.mkSet [sshkRsa, sshkDsa, sshkEcdsa, sshkEd25519]
 
 -- * SSH authorized key types
 
@@ -4820,6 +4823,13 @@ sshHostEcdsaPriv = sshConfigDir ++ "/ssh_host_ecdsa_key"
 sshHostEcdsaPub :: String
 sshHostEcdsaPub = sshHostEcdsaPriv ++ ".pub"
 
+-- Ed25519 Host Keys are not yet supported by Debian
+-- sshHostEd25519Priv :: String
+-- sshHostEd25519Priv = sshConfigDir ++ "/ssh_host_ed25519_key"
+
+-- sshHostEd25519Pub :: String
+-- sshHostEd25519Pub = sshHostEd25519Priv ++ ".pub"
+
 sshHostRsaPriv :: String
 sshHostRsaPriv = sshConfigDir ++ "/ssh_host_rsa_key"
 
@@ -4830,7 +4840,8 @@ sshDaemonKeyfiles :: Map String (String, String)
 sshDaemonKeyfiles =
   Map.fromList [ (sshkRsa, (sshHostRsaPriv, sshHostRsaPub))
                , (sshkDsa, (sshHostDsaPriv, sshHostDsaPub))
-               , (sshkEcdsa, (sshHostEcdsaPriv, sshHostEcdsaPub))
+               , (sshkEcdsa, (sshHostEcdsaPriv, sshHostEcdsaPub)) 
+               -- sshHostEd25519Priv,..
                ]
 
 -- * Node daemon setup

--- a/src/Ganeti/Types.hs
+++ b/src/Ganeti/Types.hs
@@ -962,6 +962,7 @@ $(THH.declareLADT ''String "SshKeyType"
   [ ("RSA", "rsa")
   , ("DSA", "dsa")
   , ("ECDSA", "ecdsa")
+  , ("Ed25519", "ed25519")
   ])
 $(THH.makeJSONInstance ''SshKeyType)
 

--- a/test/hs/Test/Ganeti/Objects.hs
+++ b/test/hs/Test/Ganeti/Objects.hs
@@ -412,6 +412,7 @@ instance Arbitrary SshKeyType where
     [ pure RSA
     , pure DSA
     , pure ECDSA
+    , pure Ed25519
     ]
 
 instance Arbitrary RepairStatus where

--- a/test/py/ganeti.ssh_unittest.py
+++ b/test/py/ganeti.ssh_unittest.py
@@ -150,6 +150,9 @@ class TestGetUserFiles(unittest.TestCase):
         constants.SSHK_ECDSA:
           (os.path.join(self.tmpdir, ".ssh", "id_ecdsa"),
            os.path.join(self.tmpdir, ".ssh", "id_ecdsa.pub")),
+        constants.SSHK_Ed25519:
+          (os.path.join(self.tmpdir, ".ssh", "id_ed25519"),
+           os.path.join(self.tmpdir, ".ssh", "id_ed25519.pub")),
       }))
     self.assertEqual(os.listdir(self.tmpdir), [])
 
@@ -513,6 +516,11 @@ class TestDetermineKeyBits(testutils.GanetiTestCase):
                       None, None)
     for b in [256, 384, 521]:
       self.assertEquals(b, ssh.DetermineKeyBits("ecdsa", b, None, None))
+  
+  def testEd25519SpecificValues(self):
+    self.assertRaises(errors.OpPrereqError, ssh.DetermineKeyBits, "ed25519", 256,
+                      None, None)
+    self.assertEquals(b, ssh.DetermineKeyBits("ed25519", b, None, None))
 
   def testRsaSpecificValues(self):
     self.assertRaises(errors.OpPrereqError, ssh.DetermineKeyBits, "dsa", 766,
@@ -603,7 +611,7 @@ class TestManageLocalSshPubKeys(testutils.GanetiTestCase):
 
   @testutils.patch_object(ssh, "GetAllUserFiles")
   def testReadPublicKeyFilesWithSuffix(self, mock_getalluserfiles):
-    key_types = [constants.SSHK_DSA, constants.SSHK_ECDSA]
+    key_types = [constants.SSHK_DSA, constants.SSHK_ECDSA, constants.SSHK_Ed25519]
 
     mock_getalluserfiles.return_value = (None, self._key_file_dict)
 

--- a/test/py/ganeti.tools.prepare_node_join_unittest.py
+++ b/test/py/ganeti.tools.prepare_node_join_unittest.py
@@ -102,6 +102,10 @@ class TestUpdateSshDaemon(unittest.TestCase):
       constants.SSHK_ECDSA:
         (utils.PathJoin(self.tmpdir, "ecdsa.private"),
          utils.PathJoin(self.tmpdir, "ecdsa.public")),
+      # No Ed25519 Host-key support yet in Debian
+      #constants.SSHK_Ed25519:
+      #  (utils.PathJoin(self.tmpdir, "ed25519.private"),
+      #   utils.PathJoin(self.tmpdir, "ed25519.public")),
       }
 
   def tearDown(self):
@@ -139,12 +143,21 @@ class TestUpdateSshDaemon(unittest.TestCase):
         ],
       })
 
+
   def testDryRunEcdsa(self):
     self._TestDryRun({
       constants.SSHS_SSH_HOST_KEY: [
         (constants.SSHK_ECDSA, "ecdsapriv", "ecdsapub"),
         ],
       })
+
+  # No SSH Host Key support in Debian yet
+  #def testDryRunEd25519(self):
+  #  self._TestDryRun({
+  #    constants.SSHS_SSH_HOST_KEY: [
+  #      (constants.SSHK_Ed25519, "ed2559priv", "ed25519pub"),
+  #      ],
+  #    })
 
   def _RunCmd(self, fail, cmd, interactive=NotImplemented):
     self.assertTrue(interactive)


### PR DESCRIPTION
OpenSSH has, for a while now, supported SSH keys with Ed25519. Host keys
are currently unsupported in Debian Jessie, but that might change in the
future. Thus these functions have been commented-out.

Signed-off-by: Aaron Zauner <azet@azet.org>