### PR TITLE
Force "sudo: false" on Travis-CI config file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: haskell
 
+sudo: false
+
 addons:
   apt:
     packages: &core_packages


### PR DESCRIPTION
We should use the container build to properly isolate our dependencies. In order
to do this we have to run the build using "sudo: false". The current
configuration file works fine for recent forks because the default for them is 
"sudo: false", while the default for older repos is "sudo: required" (see [1]).

[1]: https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments 

Signed-off-by: Rafael Marinheiro <<marinheiro@google.com>>