### PR TITLE
Htools should use state-of-record instance size

### DIFF
--- a/src/Ganeti/HTools/Backend/Luxi.hs
+++ b/src/Ganeti/HTools/Backend/Luxi.hs
@@ -136,7 +136,7 @@ queryInstancesMsg :: L.LuxiOp
 queryInstancesMsg =
   L.Query (Qlang.ItemTypeOpCode Qlang.QRInstance)
      ["name", "disk_usage", "be/memory", "be/vcpus",
-      "status", "pnode", "snodes", "tags", "oper_ram",
+      "status", "pnode", "snodes", "tags",
       "be/auto_balance", "disk_template",
       "be/spindle_use", "disk.sizes", "disk.spindles",
       "forthcoming"] Qlang.EmptyFilter
@@ -179,15 +179,13 @@ parseInstance :: NameAssoc
               -> [(JSValue, JSValue)]
               -> Result (String, Instance.Instance)
 parseInstance ktn [ name, disk, mem, vcpus
-                  , status, pnode, snodes, tags, oram
+                  , status, pnode, snodes, tags
                   , auto_balance, disk_template, su
                   , dsizes, dspindles, forthcoming ] = do
   xname <- annotateResult "Parsing new instance" (fromJValWithStatus name)
   let convert a = genericConvert "Instance" xname a
   xdisk <- convert "disk_usage" disk
-  xmem <- case oram of -- FIXME: remove the "guessing"
-            (_, JSRational _ _) -> convert "oper_ram" oram
-            _ -> convert "be/memory" mem
+  xmem <- convert "be/memory" mem
   xvcpus <- convert "be/vcpus" vcpus
   xpnode <- convert "pnode" pnode >>= lookupNode ktn xname
   xsnodes <- convert "snodes" snodes::Result [String]


### PR DESCRIPTION
The actual memory usage is irrelevant, because even if the instance uses less
memory, it can decide anytime to touch the yet unused portion, so we can't take
that away from the instance without risking OOM conditions (on KVM). If it uses
more, it will be accounted as missing memory.

In case of oversubscription (unsupported yet) we have the following mechanisms:

KVM: Memory manager has to evict some pages to swap. That means:
 swap + physical_memory > sum(all instances state-of-record size) + node_memory

Xen: Balooning has to ask the instance's permission to take some pages by
allocating a buffer in the instance's balooning kernel driver. Thus the instance
isn't in fact resized, just some pages are borrowed and reused in the free pool.

Signed-off-by: Viktor Bachraty <vbachraty@google.com>
Reviewed-by: Rafael Marinheiro <marinheiro@google.com>