### PR TITLE
Add optStaticKvmNodeMemory to HTools and IAllocator

### DIFF
--- a/src/Ganeti/HTools/CLI.hs
+++ b/src/Ganeti/HTools/CLI.hs
@@ -112,6 +112,7 @@ module Ganeti.HTools.CLI
   , oShowVer
   , oShowComp
   , oSkipNonRedundant
+  , oStaticKvmNodeMemory
   , oStdSpec
   , oTargetResources
   , oTieredSpec
@@ -203,6 +204,7 @@ data Options = Options
   , optShowNodes   :: Maybe [String] -- ^ Whether to show node status
   , optShowVer     :: Bool           -- ^ Just show the program version
   , optSkipNonRedundant :: Bool      -- ^ Skip nodes with non-redundant instance
+  , optStaticKvmNodeMemory :: Int    -- ^ Use static value for node memory on KVM
   , optStdSpec     :: Maybe RSpec    -- ^ Requested standard specs
   , optTargetResources :: Double     -- ^ Target resources for squeezing
   , optTestCount   :: Maybe Int      -- ^ Optional test count override
@@ -259,6 +261,7 @@ defaultOptions  = Options
   , optNodeSim     = []
   , optNodeTags    = Nothing
   , optSkipNonRedundant = False
+  , optStaticKvmNodeMemory = 4096
   , optOffline     = []
   , optRestrictToNodes = Nothing
   , optOfflineMaintenance = False
@@ -659,7 +662,7 @@ oNodeTags =
    (ReqArg (\ f opts -> Ok opts { optNodeTags = Just $ sepSplit ',' f })
     "TAG,...") "Restrict to nodes with the given tags",
    OptComplString)
-     
+
 oOfflineMaintenance :: OptType
 oOfflineMaintenance =
   (Option "" ["offline-maintenance"]
@@ -761,6 +764,14 @@ oSkipNonRedundant =
    (NoArg (\ opts -> Ok opts { optSkipNonRedundant = True }))
     "Skip nodes that host a non-redundant instance",
     OptComplNone)
+
+oStaticKvmNodeMemory :: OptType
+oStaticKvmNodeMemory =
+  (Option "" ["static-kvm-node-memory"]
+   (reqWithConversion (tryRead "static node memory")
+    (\i opts -> Ok opts { optStaticKvmNodeMemory = i }) "N")
+   "use static node memory [in MB] on KVM instead of value reported by hypervisor.",
+   OptComplInteger)
 
 oStdSpec :: OptType
 oStdSpec =

--- a/src/Ganeti/HTools/CLI.hs
+++ b/src/Ganeti/HTools/CLI.hs
@@ -770,7 +770,8 @@ oStaticKvmNodeMemory =
   (Option "" ["static-kvm-node-memory"]
    (reqWithConversion (tryRead "static node memory")
     (\i opts -> Ok opts { optStaticKvmNodeMemory = i }) "N")
-   "use static node memory [in MB] on KVM instead of value reported by hypervisor.",
+   "use static node memory [in MB] on KVM instead of value reported by hypervisor.\
+   \ Use 0 to take value reported from hypervisor.",
    OptComplInteger)
 
 oStdSpec :: OptType

--- a/src/Ganeti/HTools/Loader.hs
+++ b/src/Ganeti/HTools/Loader.hs
@@ -378,9 +378,9 @@ setStaticKvmNodeMem :: Node.List -- ^ Nodes to update
                        -> Int -- ^ Static node size
                        -> Node.List -- ^ Updated nodes
 setStaticKvmNodeMem nl static_node_mem =
-  let updateNM n = if Node.hypervisor n == Just Kvm
-                   then n { Node.nMem = static_node_mem }
-                   else n
+  let updateNM n
+          | Node.hypervisor n == Just Kvm = n { Node.nMem = static_node_mem }
+          | otherwise = n
   in Container.map updateNM nl
 
 -- | Update node memory stat based on instance list.

--- a/src/Ganeti/HTools/Loader.hs
+++ b/src/Ganeti/HTools/Loader.hs
@@ -381,7 +381,9 @@ setStaticKvmNodeMem nl static_node_mem =
   let updateNM n
           | Node.hypervisor n == Just Kvm = n { Node.nMem = static_node_mem }
           | otherwise = n
-  in Container.map updateNM nl
+  in if static_node_mem > 0
+     then Container.map updateNM nl
+     else nl
 
 -- | Update node memory stat based on instance list.
 updateMemStat :: Node.Node -> Instance.List -> Node.Node
@@ -400,9 +402,7 @@ updateMissing :: Node.List -- ^ All nodes in the cluster
 updateMissing nl il static_node_mem =
     -- This overrides node mem on KVM as loaded from backend. Ganeti 2.17
     -- handles this using obtainNodeMemory.
-    let nl2 = if static_node_mem > 0
-              then setStaticKvmNodeMem nl static_node_mem
-              else nl
+    let nl2 = setStaticKvmNodeMem nl static_node_mem
         updateSingle msgs node =
             let nname = Node.name node
                 newn = updateMemStat node il

--- a/src/Ganeti/HTools/Loader.hs
+++ b/src/Ganeti/HTools/Loader.hs
@@ -38,7 +38,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 module Ganeti.HTools.Loader
   ( mergeData
   , clearDynU
-  , checkData
+  , updateMissing
+  , updateMemStat
   , assignIndices
   , setMaster
   , lookupNode
@@ -77,7 +78,7 @@ import qualified Ganeti.HTools.Tags as Tags
 import qualified Ganeti.HTools.Tags.Constants as TagsC
 import Ganeti.HTools.Types
 import Ganeti.Utils
-import Ganeti.Types (EvacMode)
+import Ganeti.Types (EvacMode, Hypervisor(..))
 
 -- * Types
 
@@ -372,29 +373,49 @@ clearDynU cdata@(ClusterData _ _ il _ _) =
   let il2 = Container.map (\ inst -> inst {Instance.util = zeroUtil }) il
   in Ok cdata { cdInstances = il2 }
 
--- | Checks the cluster data for consistency.
-checkData :: Node.List -> Instance.List
-          -> ([String], Node.List)
-checkData nl il =
-    Container.mapAccum
-        (\ msgs node ->
-             let nname = Node.name node
-                 delta_mem = truncate (Node.tMem node)
-                             - Node.nMem node
-                             - Node.fMem node
-                             - nodeImem node il
-                 delta_dsk = truncate (Node.tDsk node)
-                             - Node.fDsk node
-                             - nodeIdsk node il
-                 newn = node `Node.setXmem` delta_mem
-                 umsg1 =
-                   if delta_mem > 512 || delta_dsk > 1024
-                      then printf "node %s is missing %d MB ram \
-                                  \and %d GB disk"
-                                  nname delta_mem (delta_dsk `div` 1024):msgs
-                      else msgs
-             in (umsg1, newn)
-        ) [] nl
+-- | Update cluster data to use static node memory on KVM.
+setStaticKvmNodeMem :: Node.List -- ^ Nodes to update
+                       -> Int -- ^ Static node size
+                       -> Node.List -- ^ Updated nodes
+setStaticKvmNodeMem nl static_node_mem =
+  let updateNM n = if Node.hypervisor n == Just Kvm
+                   then n { Node.nMem = static_node_mem }
+                   else n
+  in Container.map updateNM nl
+
+-- | Update node memory stat based on instance list.
+updateMemStat :: Node.Node -> Instance.List -> Node.Node
+updateMemStat node il =
+    let missing = truncate (Node.tMem node)
+                  - Node.nMem node
+                  - Node.fMem node
+                  - nodeImem node il
+    in node { Node.xMem = missing }
+
+-- | Check the cluster for memory/disk allocation consistency and update stats.
+updateMissing :: Node.List -- ^ All nodes in the cluster
+              -> Instance.List  -- ^ All instances in the cluster
+              -> Int -- ^ Static node memory for KVM
+              -> ([String], Node.List) -- ^ Pair of errors, update node list
+updateMissing nl il static_node_mem =
+    -- This overrides node mem on KVM as loaded from backend. Ganeti 2.17
+    -- handles this using obtainNodeMemory.
+    let nl2 = if static_node_mem > 0
+              then setStaticKvmNodeMem nl static_node_mem
+              else nl
+        updateSingle msgs node =
+            let nname = Node.name node
+                newn = updateMemStat node il
+                delta_mem = Node.xMem newn
+                delta_dsk = truncate (Node.tDsk node)
+                            - Node.fDsk node
+                            - nodeIdsk node il
+                umsg1 = if delta_mem > 512 || delta_dsk > 1024
+                        then printf "node %s is missing %d MB ram and %d GB disk"
+                             nname delta_mem (delta_dsk `div` 1024):msgs
+                        else msgs
+            in (umsg1, newn)
+    in Container.mapAccum updateSingle [] nl2
 
 -- | Compute the amount of memory used by primary instances on a node.
 nodeImem :: Node.Node -> Instance.List -> Int

--- a/src/Ganeti/HTools/Node.hs
+++ b/src/Ganeti/HTools/Node.hs
@@ -59,6 +59,7 @@ module Ganeti.HTools.Node
   , setMigrationTags
   , setRecvMigrationTags
   , setLocationTags
+  , setHypervisor
   -- * Tag maps
   , addTags
   , delTags
@@ -113,7 +114,7 @@ import Text.Printf (printf)
 
 import qualified Ganeti.Constants as C
 import qualified Ganeti.OpCodes as OpCodes
-import Ganeti.Types (OobCommand(..), TagKind(..), mkNonEmpty)
+import Ganeti.Types (Hypervisor(..), OobCommand(..), TagKind(..), mkNonEmpty)
 import Ganeti.HTools.Container (Container)
 import qualified Ganeti.HTools.Container as Container
 import Ganeti.HTools.Instance (Instance)
@@ -213,6 +214,7 @@ data Node = Node
   , instanceMap :: Map.Map (String, String) Int -- ^ Number of instances with
                                                 -- each exclusion/location tags
                                                 -- pair
+  , hypervisor :: Maybe Hypervisor -- ^ Active hypervisor on the node
   } deriving (Show, Eq)
 {- A note on how we handle spindles
 
@@ -378,6 +380,7 @@ create name_init mem_t_init mem_n_init mem_f_init
        , locationTags = Set.empty
        , locationScore = 0
        , instanceMap = Map.empty
+       , hypervisor = Nothing
        }
 
 -- | Conversion formula from mDsk\/tDsk to loDsk.
@@ -431,6 +434,10 @@ setLocationTags t val = t { locationTags = val }
 -- | Sets the unnaccounted memory.
 setXmem :: Node -> Int -> Node
 setXmem t val = t { xMem = val }
+
+-- | Sets the hypervisor attribute.
+setHypervisor :: Node -> Hypervisor -> Node
+setHypervisor t val = t { hypervisor = Just val }
 
 -- | Sets the max disk usage ratio.
 setMdsk :: Node -> Double -> Node

--- a/src/Ganeti/HTools/Program/Hbal.hs
+++ b/src/Ganeti/HTools/Program/Hbal.hs
@@ -95,6 +95,7 @@ options = do
     , oVerbose
     , oQuiet
     , oOfflineNode
+    , oStaticKvmNodeMemory
     , oMinScore
     , oMaxCpu
     , oMinDisk

--- a/src/Ganeti/HTools/Program/Hinfo.hs
+++ b/src/Ganeti/HTools/Program/Hinfo.hs
@@ -75,6 +75,7 @@ options = do
     , oIgnoreDyn
     , oMonD
     , oMonDDataFile
+    , oStaticKvmNodeMemory
     ]
 
 -- | The list of arguments supported by the program.

--- a/src/Ganeti/HTools/Program/Hroller.hs
+++ b/src/Ganeti/HTools/Program/Hroller.hs
@@ -85,6 +85,7 @@ options = do
     , oIgnoreNonRedundant
     , oForce
     , oOneStepOnly
+    , oStaticKvmNodeMemory
     ]
 
 -- | The list of arguments supported by the program.

--- a/src/Ganeti/HTools/Program/Hspace.hs
+++ b/src/Ganeti/HTools/Program/Hspace.hs
@@ -93,6 +93,7 @@ options = do
     , oStdSpec
     , oTieredSpec
     , oSaveCluster
+    , oStaticKvmNodeMemory
     ]
 
 -- | The list of arguments supported by the program.

--- a/src/Ganeti/HTools/Program/Hsqueeze.hs
+++ b/src/Ganeti/HTools/Program/Hsqueeze.hs
@@ -84,6 +84,7 @@ options = do
     , oPrintCommands
     , oVerbose
     , oNoHeaders
+    , oStaticKvmNodeMemory
     ]
 
 -- | The list of arguments supported by the program.

--- a/test/hs/Test/Ganeti/HTools/Backend/Text.hs
+++ b/test/hs/Test/Ganeti/HTools/Backend/Text.hs
@@ -283,7 +283,7 @@ prop_CreateSerialise =
             of
               Bad msg -> failTest $ "Failed to load/merge: " ++ msg
               Ok (Loader.ClusterData gl2 nl2 il2 ctags2 cpol2) ->
-                let (_, nl3) = Loader.checkData nl2 il2
+                let (_, nl3) = Loader.updateMissing nl2 il2 0
                 in conjoin [ ctags2 ==? ctags
                            , cpol2 ==? Types.defIPolicy
                            , il2 ==? il

--- a/test/hs/Test/Ganeti/HTools/Node.hs
+++ b/test/hs/Test/Ganeti/HTools/Node.hs
@@ -134,6 +134,7 @@ genEmptyOnlineNode =
                        , Node.rMemForth = 0
                        , Node.pRem = 0
                        , Node.pRemForth = 0
+                       , Node.xMem = 0
                        }
       return node') `suchThat` (\ n -> not (Node.failN1 n) &&
                                        Node.availDisk n > 0 &&


### PR DESCRIPTION
This is an attempt to fix balancing on 2.16 using KVM hypervisor. The problem
with KVM is, that it reports 'active' memory from /proc/memstat for node
memory a.k.a. nMem a.k.a. memory_dom0.

This is plain wrong, as 'active' memory in Linux includes memory from all
running processes, including instances (qemu processes). We can't calculate
the node memory on the hypervisor side, simply subtracting RES used by qemu
processes would give us only approximate value and still it would be the actively
used memory rather than a upper hard limit as in dom0 size in Xen. As KVM
does not provide proper isolation for node memory, the only thing we can do is
to instruct htools to reserve a static value for node memory.

This is solved in 2.17 in patch f971341471 implementing the obtainNodeMemory
function that takes the live dom0 size in Xen, but uses 'hv_state' for exporting
the node size configurable parameter for KVM. I've opted for _not_ backporting
the cluster parameter from 2.17 for these reasons:

* this way the change is isolated to hbal, no need to change cluster config
* the obtainNodeMemory is for Luxi/Rapi only, this flag works with any backend
* the goal is to fix balancing as it is, without adding support for memory
overcommitment, doing so would require backporting a bunch of other dependencies:
d2bfc50608, f971341471 and possibly more.

The flag is ignored on Xen, and on KVM is set by default to 4G, so the change
should be backward compatible (no need to specify this flag unless you need
a different value).

Signed-off-by: Viktor Bachraty <vbachraty@google.com>
Reviewed-by: Rafael Marinheiro <marinheiro@google.com>