### PR TITLE
Merge branch 'upmerge-2.16' into stable-2.16

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1759,7 +1759,7 @@ Version 2.10.6
 
 *(Released Mon, 30 Jun 2014)*
 
-- Make Ganeti tolerant towards differnt openssl library
+- Make Ganeti tolerant towards different openssl library
   version on different nodes (issue 853).
 - Allow hspace to make useful predictions in multi-group
   clusters with one group overfull (isse 861).
@@ -1900,7 +1900,7 @@ New features
   specified if the destination cluster has a default iallocator.
 - Users can now change the soundhw and cpuid settings for XEN hypervisors.
 - Hail and hbal now have the (optional) capability of accessing average CPU
-  load information through the monitoring deamon, and to use it to dynamically
+  load information through the monitoring daemon, and to use it to dynamically
   adapt the allocation of instances.
 - Hotplug support. Introduce new option '--hotplug' to ``gnt-instance modify``
   so that disk and NIC modifications take effect without the need of actual
@@ -2262,7 +2262,7 @@ Incompatible/important changes
   '--file-storage-dir' and '--shared-file-storage-dir'.
 - Cluster verification now includes stricter checks regarding the
   default file and shared file storage directories. It now checks that
-  the directories are explicitely allowed in the 'file-storage-paths' file and
+  the directories are explicitly allowed in the 'file-storage-paths' file and
   that the directories exist on all nodes.
 - The list of allowed disk templates in the instance policy and the list
   of cluster-wide enabled disk templates is now checked for consistency
@@ -4435,7 +4435,7 @@ fixes/small improvements/cleanups.
 Significant features
 ~~~~~~~~~~~~~~~~~~~~
 
-The node deamon now tries to mlock itself into memory, unless the
+The node daemon now tries to mlock itself into memory, unless the
 ``--no-mlock`` flag is passed. It also doesn't fail if it can't write
 its logs, and falls back to console logging. This allows emergency
 features such as ``gnt-node powercycle`` to work even in the event of a

--- a/configure.ac
+++ b/configure.ac
@@ -640,7 +640,7 @@ AM_CONDITIONAL([GHC_LE_76], [$GHC --numeric-version | grep -q '^7\.[[0-6]]\.'])
 
 AC_MSG_CHECKING([checking for extra GHC flags])
 GHC_BYVERSION_FLAGS=
-# check for GHC supported flags that vary accross versions
+# check for GHC supported flags that vary across versions
 for flag in -fwarn-incomplete-uni-patterns; do
   if $GHC -e '0' $flag >/dev/null 2>/dev/null; then
    GHC_BYVERSION_FLAGS="$GHC_BYVERSION_FLAGS $flag"

--- a/doc/cluster-keys-replacement.rst
+++ b/doc/cluster-keys-replacement.rst
@@ -27,7 +27,7 @@ Replacing SSL keys
 The cluster-wide SSL key is stored in ``/var/lib/ganeti/server.pem``.
 Besides that, since Ganeti 2.11, each node has an individual node
 SSL key, which is stored in ``/var/lib/ganeti/client.pem``. This
-client certificate is signed by the cluster-wide SSL certficate.
+client certificate is signed by the cluster-wide SSL certificate.
 
 To renew the individual node certificates, run this command::
 

--- a/doc/design-2.10.rst
+++ b/doc/design-2.10.rst
@@ -15,4 +15,3 @@ The following designs have been partially implemented in Ganeti 2.10.
 
 - :doc:`design-ceph-ganeti-support`
 - :doc:`design-internal-shutdown`
-- :doc:`design-query-splitting`

--- a/doc/design-2.11.rst
+++ b/doc/design-2.11.rst
@@ -6,6 +6,8 @@ The following design documents have been implemented in Ganeti 2.11.
 
 - :doc:`design-internal-shutdown`
 - :doc:`design-kvmd`
+- :doc:`design-glusterfs-ganeti-support`
+- :doc:`design-multi-version-tests`
 
 The following designs have been partially implemented in Ganeti 2.11.
 

--- a/doc/design-2.12.rst
+++ b/doc/design-2.12.rst
@@ -7,9 +7,11 @@ The following design documents have been implemented in Ganeti 2.12.
 - :doc:`design-daemons`
 - :doc:`design-systemd`
 - :doc:`design-cpu-speed`
+- :doc:`design-move-instance-improvements`
 
 The following designs have been partially implemented in Ganeti 2.12.
 
 - :doc:`design-node-security`
 - :doc:`design-hsqueeze`
 - :doc:`design-os`
+- :doc:`design-reservations`

--- a/doc/design-2.14.rst
+++ b/doc/design-2.14.rst
@@ -2,6 +2,10 @@
 Ganeti 2.14 design
 ==================
 
+The following designs have been implemented in Ganeti 2.14.
+
+- :doc:`design-file-based-disks-ownership`
+
 The following designs have been partially implemented in Ganeti 2.14.
 
 - :doc:`design-location`

--- a/doc/design-2.6.rst
+++ b/doc/design-2.6.rst
@@ -6,6 +6,7 @@ The following design documents have been implemented in Ganeti 2.6:
 
 - :doc:`design-cpu-pinning`
 - :doc:`design-ovf-support`
+- :doc:`design-resource-model`
 
 .. vim: set textwidth=72 :
 .. Local Variables:

--- a/doc/design-2.7.rst
+++ b/doc/design-2.7.rst
@@ -16,6 +16,7 @@ The following design documents have been implemented in Ganeti 2.7:
 
 The following designs have been partially implemented in Ganeti 2.7:
 
+- :doc:`design-network`
 - :doc:`design-query-splitting`: only queries not needing RPC are
   supported, through confd
 - :doc:`design-partitioned`: only exclusive use of disks is implemented

--- a/doc/design-allocation-efficiency.rst
+++ b/doc/design-allocation-efficiency.rst
@@ -2,6 +2,10 @@
 Improving allocation efficiency by considering the total reserved memory
 =========================================================================
 
+:Created: 2015-Mar-19
+:Status: Implemented
+:Ganeti-Version: 2.15.0
+
 This document describes a change to the cluster metric to enhance
 the allocation efficiency of Ganeti's ``htools``.
 
@@ -42,7 +46,7 @@ weight of 0.25, so that counting current violations still dominate.
 
 Another consequence of this metric change is that the value 0 is no longer
 obtainable: as soon as we have DRBD instance, we have to reserve memory.
-However, in most cases only differences of scores influence decissions made.
+However, in most cases only differences of scores influence decisions made.
 In the few cases, were absolute values of the cluster score are specified,
 they are interpreted as relative to the theoretical minimum of the reserved
 memory score.

--- a/doc/design-autorepair.rst
+++ b/doc/design-autorepair.rst
@@ -2,6 +2,10 @@
 Instance auto-repair
 ====================
 
+:Created: 2012-Sep-03
+:Status: Implemented
+:Ganeti-Version: 2.8.0
+
 .. contents:: :depth: 4
 
 This is a design document detailing the implementation of self-repair and
@@ -107,7 +111,7 @@ present at this time. While this is known we won't solve these race
 conditions in the first version.
 
 It might also be useful to easily have an operation that tags all
-instances matching a  filter on some charateristic. But again, this
+instances matching a filter on some characteristic. But again, this
 wouldn't be specific to this tag.
 
 If there are multiple
@@ -273,8 +277,8 @@ needs to look at it. To be decided).
 
 A graph with the possible transitions follows; note that in the graph,
 following the implementation, the two ``Needs repair`` states have been
-coalesced into one; and the ``Suspended`` state disapears, for it
-becames an attribute of the instance object (its auto-repair policy).
+coalesced into one; and the ``Suspended`` state disappears, for it
+becomes an attribute of the instance object (its auto-repair policy).
 
 .. digraph:: "auto-repair-states"
 
@@ -343,7 +347,7 @@ Possible repairs are:
 
 Note that more than one of these operations may need to happen before a
 full repair is completed (eg. if a drbd primary goes offline first a
-failover will happen, then a replce-disks).
+failover will happen, then a replace-disks).
 
 The self-repair tool will first take care of all needs-repair instance
 that can be brought into ``pending`` state, and transition them as

--- a/doc/design-bulk-create.rst
+++ b/doc/design-bulk-create.rst
@@ -2,6 +2,10 @@
 Ganeti Bulk Create
 ==================
 
+:Created: 2012-Sep-03
+:Status: Implemented
+:Ganeti-Version: 2.7.0
+
 .. contents:: :depth: 4
 .. highlight:: python
 
@@ -58,7 +62,7 @@ of ``request`` dicts as described in :doc:`Operation specific input
 placements in the order of the ``request`` field.
 
 In addition, the old ``allocate`` request type will be deprecated and at
-latest in Ganeti 2.8 incooperated into this new request. Current code
+latest in Ganeti 2.8 incorporated into this new request. Current code
 will need slight adaption to work with the new request. This needs
 careful testing.
 

--- a/doc/design-ceph-ganeti-support.rst
+++ b/doc/design-ceph-ganeti-support.rst
@@ -2,6 +2,10 @@
 RADOS/Ceph support in Ganeti
 ============================
 
+:Created: 2013-Jul-26
+:Status: Partially Implemented
+:Ganeti-Version: 2.10.0
+
 .. contents:: :depth: 4
 
 Objective

--- a/doc/design-chained-jobs.rst
+++ b/doc/design-chained-jobs.rst
@@ -2,6 +2,10 @@
 Chained jobs
 ============
 
+:Created: 2011-Jul-14
+:Status: Implemented
+:Ganeti-Version: 2.5.0
+
 .. contents:: :depth: 4
 
 This is a design document about the innards of Ganeti's job processing.
@@ -33,7 +37,7 @@ Proposed changes
 ================
 
 With the implementation of :ref:`job priorities
-<jqueue-job-priority-design>` the processing code was re-architectured
+<jqueue-job-priority-design>` the processing code was re-architected
 and became a lot more versatile. It now returns jobs to the queue in
 case the locks for an opcode can't be acquired, allowing other
 jobs/opcodes to be run in the meantime.
@@ -160,7 +164,7 @@ following possibilities:
 Based on these arguments, the proposal is to do the following:
 
 - Rename ``JOB_STATUS_WAITLOCK`` constant to ``JOB_STATUS_WAITING`` to
-  reflect its actual meanting: the job is waiting for something
+  reflect its actual meaning: the job is waiting for something
 - While waiting for dependencies and locks, jobs are in the "waiting"
   status
 - Export dependency information in lock monitor; example output::

--- a/doc/design-cmdlib-unittests.rst
+++ b/doc/design-cmdlib-unittests.rst
@@ -2,6 +2,10 @@
 Unit tests for cmdlib / LogicalUnit's
 =====================================
 
+:Created: 2013-Jul-22
+:Status: Implemented
+:Ganeti-Version: 2.10.0
+
 .. contents:: :depth: 4
 
 This is a design document describing unit tests for the cmdlib module.

--- a/doc/design-configlock.rst
+++ b/doc/design-configlock.rst
@@ -2,6 +2,10 @@
 Removal of the Config Lock Overhead
 ===================================
 
+:Created: 2013-Jul-22
+:Status: Partially Implemented
+:Ganeti-Version: 2.14.0, 2.15.0
+
 .. contents:: :depth: 4
 
 This is a design document detailing how the adverse effect of
@@ -11,7 +15,7 @@ Current state and shortcomings
 ==============================
 
 As a result of the :doc:`design-daemons`, the configuration is held
-in a proccess different from the processes carrying out the Ganeti
+in a process different from the processes carrying out the Ganeti
 jobs. Therefore, job processes have to contact WConfD in order to
 change the configuration. Of course, these modifications of the
 configuration need to be synchronised.
@@ -23,7 +27,7 @@ update the configuration is to
 
 - acquire the ``ConfigLock`` from WConfD,
 
-- read the configration,
+- read the configuration,
 
 - write the modified configuration, and
 
@@ -53,7 +57,7 @@ Proposed changes for an incremental improvement
 
 Ideally, jobs would just send patches for the configuration to WConfD
 that are applied by means of atomically updating the respective ``IORef``.
-This, however, would require chaning all of Ganeti's logical units in
+This, however, would require changing all of Ganeti's logical units in
 one big change. Therefore, we propose to keep the ``ConfigLock`` and,
 step by step, reduce its impact till it eventually will be just used
 internally in the WConfD process.
@@ -66,7 +70,7 @@ a shared config lock, and therefore necessarily read-only, will instead
 use WConfD's ``readConfig`` used to obtain a snapshot of the configuration.
 This will be done without modifying the locks. It is sound, as reads to
 a Haskell ``IORef`` always yield a consistent value. From that snapshot
-the required view is computed locally. This saves two lock-configurtion
+the required view is computed locally. This saves two lock-configuration
 write cycles per read and, additionally, does not block any concurrent
 modifications.
 
@@ -98,7 +102,7 @@ For a lot of operations, the regular locks already ensure that only
 one job can modify a certain part of the configuration. For example,
 only jobs with an exclusive lock on an instance will modify that
 instance. Therefore, it can update that entity atomically,
-without relying on the configuration lock to achive consistency.
+without relying on the configuration lock to achieve consistency.
 ``WConfD`` will provide such operations. To
 avoid interference with non-atomic operations that still take the
 config lock and write the configuration as a whole, this operation
@@ -111,7 +115,7 @@ triggering a writeout of the lock status.
 Note that the thread handling the request has to take the lock in its
 own name and not in that of the requesting job. A writeout of the lock
 status can still happen, triggered by other requests. Now, if
-``WConfD`` gets restarted after the lock acquisition, if that happend
+``WConfD`` gets restarted after the lock acquisition, if that happened
 in the name of the job, it would own a lock without knowing about it,
 and hence that lock would never get released.
 

--- a/doc/design-cpu-pinning.rst
+++ b/doc/design-cpu-pinning.rst
@@ -1,5 +1,10 @@
+==================
 Ganeti CPU Pinning
 ==================
+
+:Created: 2011-May-28
+:Status: Implemented
+:Ganeti-Version: 2.6.0
 
 Objective
 ---------

--- a/doc/design-cpu-speed.rst
+++ b/doc/design-cpu-speed.rst
@@ -2,6 +2,10 @@
 Taking relative CPU speed into account
 ======================================
 
+:Created: 2014-Apr-17
+:Status: Implemented
+:Ganeti-Version: 2.12.0
+
 .. contents:: :depth: 4
 
 This document describes the suggested addition of a new
@@ -20,7 +24,7 @@ instances, even for a cluster not running at full capacity.
 
 For for one resources, however, hardware differences are not taken into
 account: CPU speed. For CPU, the load is measured by the ratio of used virtual
-to physical CPUs on the node. Balancing this measure implictly assumes
+to physical CPUs on the node. Balancing this measure implicitly assumes
 equal speed of all CPUs.
 
 

--- a/doc/design-daemons.rst
+++ b/doc/design-daemons.rst
@@ -2,6 +2,10 @@
 Ganeti daemons refactoring
 ==========================
 
+:Created: 2013-Sep-27
+:Status: Implemented
+:Ganeti-Version: 2.12.0
+
 .. contents:: :depth: 2
 
 This is a design document detailing the plan for refactoring the internal
@@ -138,7 +142,7 @@ proposed, and presented hereafter.
   submitting jobs. Therefore, this daemon will also be the one responsible with
   managing the job queue. When a job needs to be executed, the LuxiD will spawn
   a separate process tasked with the execution of that specific job, thus making
-  it easier to terminate the job itself, if needeed.  When a job requires locks,
+  it easier to terminate the job itself, if needed.  When a job requires locks,
   LuxiD will request them from WConfD.
   In order to keep availability of the cluster in case of failure of the master
   node, LuxiD will replicate the job queue to the other master candidates, by
@@ -258,7 +262,7 @@ leaving the codebase in a consistent and usable state.
    independent process. LuxiD will spawn a new (Python) process for every single
    job. The RPCs will remain unchanged, and the LU code will stay as is as much
    as possible.
-   MasterD will cease to exist as a deamon on its own at this point, but not
+   MasterD will cease to exist as a daemon on its own at this point, but not
    before.
 
 #. Improve job scheduling algorithm.
@@ -480,7 +484,7 @@ protocol will allow the following operations on the set:
   provided for convenience, it's redundant wrt. *list* and *update*. Immediate,
   never fails.
 
-Addidional restrictions due to lock implications:
+Additional restrictions due to lock implications:
   Ganeti supports locks that act as if a lock on a whole group (like all nodes)
   were held. To avoid dead locks caused by the additional blockage of those
   group locks, we impose certain restrictions. Whenever `A` is a group lock and

--- a/doc/design-dedicated-allocation.rst
+++ b/doc/design-dedicated-allocation.rst
@@ -2,6 +2,10 @@
 Allocation for Partitioned Ganeti
 =================================
 
+:Created: 2015-Jan-22
+:Status: Implemented
+:Ganeti-Version: 2.15.0
+
 .. contents:: :depth: 4
 
 
@@ -61,7 +65,7 @@ instance sizes.
 
 If allocating in a node group with ``exclusive_storage`` set
 to true, hail will try to minimise the pair of the lost-allocations
-vector and the remaining disk space on the node afer, ordered
+vector and the remaining disk space on the node after, ordered
 lexicographically.
 
 Example

--- a/doc/design-device-uuid-name.rst
+++ b/doc/design-device-uuid-name.rst
@@ -2,6 +2,10 @@
 Design for adding UUID and name to devices
 ==========================================
 
+:Created: 2013-Apr-17
+:Status: Implemented
+:Ganeti-Version: 2.9.0
+
 .. contents:: :depth: 4
 
 This is a design document about adding UUID and name to instance devices

--- a/doc/design-disk-conversion.rst
+++ b/doc/design-disk-conversion.rst
@@ -2,6 +2,10 @@
 Conversion between disk templates
 =================================
 
+:Created: 2014-May-23
+:Status: Implemented
+:Ganeti-Version: 2.13.0
+
 .. contents:: :depth: 4
 
 This design document describes the support for generic disk template

--- a/doc/design-disks.rst
+++ b/doc/design-disks.rst
@@ -2,6 +2,10 @@
 Disks
 =====
 
+:Created: 2014-Apr-09
+:Status: Implemented
+:Ganeti-Version: 2.14.0
+
 .. contents:: :depth: 4
 
 This is a design document detailing the implementation of disks as a new

--- a/doc/design-draft.rst
+++ b/doc/design-draft.rst
@@ -10,19 +10,11 @@ Design document drafts
    design-x509-ca.rst
    design-http-server.rst
    design-impexp2.rst
-   design-resource-model.rst
-   design-storagetypes.rst
-   design-glusterfs-ganeti-support.rst
    design-hugepages-support.rst
-   design-ceph-ganeti-support.rst
-   design-os.rst
-   design-move-instance-improvements.rst
-   design-node-security.rst
    design-ifdown.rst
    design-reservations.rst
    design-sync-rate-throttling.rst
    design-network2.rst
-   design-configlock.rst
    design-multi-storage-htools.rst
    design-repaird.rst
    design-scsi-kvm.rst

--- a/doc/design-file-based-disks-ownership.rst
+++ b/doc/design-file-based-disks-ownership.rst
@@ -2,6 +2,10 @@
 Ganeti file-based disks ownership
 =================================
 
+:Created: 2015-Jan-20
+:Status: Implemented
+:Ganeti-Version: 2.14.0
+
 .. contents:: :depth: 2
 
 This design document explains the issue that emerges from the usage of the

--- a/doc/design-file-based-storage.rst
+++ b/doc/design-file-based-storage.rst
@@ -2,6 +2,10 @@
 File-based Storage
 ==================
 
+:Created: 2014-Jan-27
+:Status: Implemented
+:Ganeti-Version: 2.0.0
+
 This page describes the proposed file-based storage for the 2.0 version
 of Ganeti. The project consists in extending Ganeti in order to support
 a filesystem image as Virtual Block Device (VBD) in Dom0 as the primary
@@ -131,7 +135,7 @@ Disadvantages:
 
 * stable, but not as much tested as loopback driver
 
-3) ubklback driver
+3) ublkback driver
 ^^^^^^^^^^^^^^^^^^
 
 The Xen Roadmap states "Work is well under way to implement a
@@ -365,6 +369,6 @@ the file-based disk-template.
 Other hypervisors
 +++++++++++++++++
 
-Other hypervisors have mostly differnet ways to make storage available
+Other hypervisors have mostly different ways to make storage available
 to their virtual instances/machines. This is beyond the scope of this
 document.

--- a/doc/design-glusterfs-ganeti-support.rst
+++ b/doc/design-glusterfs-ganeti-support.rst
@@ -2,6 +2,10 @@
 GlusterFS Ganeti support
 ========================
 
+:Created: 2013-Jun-24
+:Status: Implemented
+:Ganeti-Version: 2.11.0
+
 This document describes the plan for adding GlusterFS support inside Ganeti.
 
 .. contents:: :depth: 4

--- a/doc/design-hotplug.rst
+++ b/doc/design-hotplug.rst
@@ -2,6 +2,10 @@
 Hotplug
 =======
 
+:Created: 2013-Jul-24
+:Status: Implemented
+:Ganeti-Version: 2.10.0
+
 .. contents:: :depth: 4
 
 This is a design document detailing the implementation of device

--- a/doc/design-hroller.rst
+++ b/doc/design-hroller.rst
@@ -2,6 +2,10 @@
 HRoller tool
 ============
 
+:Created: 2013-Feb-15
+:Status: Implemented
+:Ganeti-Version: 2.8.0, 2.9.0
+
 .. contents:: :depth: 4
 
 This is a design document detailing the cluster maintenance scheduler,

--- a/doc/design-hsqueeze.rst
+++ b/doc/design-hsqueeze.rst
@@ -2,6 +2,10 @@
 HSqueeze tool
 =============
 
+:Created: 2013-Oct-14
+:Status: Implemented
+:Ganeti-Version: 2.11.0, 2.12.0, 2.13.0
+
 .. contents:: :depth: 4
 
 This is a design document detailing the node-freeing scheduler, HSqueeze.

--- a/doc/design-htools-2.3.rst
+++ b/doc/design-htools-2.3.rst
@@ -2,6 +2,10 @@
  Synchronising htools to Ganeti 2.3
 ====================================
 
+:Created: 2011-Mar-18
+:Status: Implemented
+:Ganeti-Version: 2.5.0
+
 Ganeti 2.3 introduces a number of new features that change the cluster
 internals significantly enough that the htools suite needs to be
 updated accordingly in order to function correctly.

--- a/doc/design-http-server.rst
+++ b/doc/design-http-server.rst
@@ -2,6 +2,9 @@
 Design for replacing Ganeti's HTTP server
 =========================================
 
+:Created: 2011-Mar-23
+:Status: Draft
+
 .. contents:: :depth: 4
 
 .. _http-srv-shortcomings:

--- a/doc/design-hugepages-support.rst
+++ b/doc/design-hugepages-support.rst
@@ -1,6 +1,12 @@
 ===============================
 Huge Pages Support for Ganeti
 ===============================
+
+:Created: 2013-Jul-17
+:Status: Draft
+
+.. contents:: :depth: 4
+
 This is a design document about implementing support for huge pages in
 Ganeti. (Please note that Ganeti works with Transparent Huge Pages i.e.
 THP and any reference in this document to Huge Pages refers to explicit
@@ -37,7 +43,7 @@ cluster level via the hypervisor parameter ``mem_path`` as::
 This hypervisor parameter is inherited by all the instances as
 default although it can be overriden at the instance level.
 
-The following changes will be made to the inheritence behaviour.
+The following changes will be made to the inheritance behaviour.
 
 -  The hypervisor parameter   ``mem_path`` and all other hypervisor
    parameters will be made available at the node group level (in
@@ -47,7 +53,7 @@ The following changes will be made to the inheritence behaviour.
 	$ gnt-group add/modify\
 	> -H hv:parameter=value
 
-   This changes the hypervisor inheritence level as::
+   This changes the hypervisor inheritance level as::
 
      cluster -> group -> OS -> instance
 

--- a/doc/design-ifdown.rst
+++ b/doc/design-ifdown.rst
@@ -2,6 +2,9 @@
 Design for adding ifdown script to KVM
 ======================================
 
+:Created: 2014-Jun-23
+:Status: Draft
+
 .. contents:: :depth: 4
 
 This is a design document about adding support for an ifdown script responsible

--- a/doc/design-impexp2.rst
+++ b/doc/design-impexp2.rst
@@ -2,6 +2,11 @@
 Design for import/export version 2
 ==================================
 
+:Created: 2011-Mar-23
+:Status: Draft
+:Depends-On: - :doc:`design-x509-ca`
+             - :doc:`design-http-server`
+
 .. contents:: :depth: 4
 
 Current state and shortcomings
@@ -89,7 +94,7 @@ import/export, allowing the certificate to be used as a Certificate
 Authority (CA). This worked by means of starting a new ``socat``
 instance per instance import/export.
 
-Under the version 2 model, a continously running HTTP server will be
+Under the version 2 model, a continuously running HTTP server will be
 used. This disallows the use of self-signed certificates for
 authentication as the CA needs to be the same for all issued
 certificates.
@@ -264,7 +269,7 @@ issues) it should be retried using an exponential backoff delay. The
 opcode submitter can specify for how long the transfer should be
 retried.
 
-At the end of a transfer, succssful or not, the source cluster must be
+At the end of a transfer, successful or not, the source cluster must be
 notified. A the same time the RSA key needs to be destroyed.
 
 Support for HTTP proxies can be implemented by setting

--- a/doc/design-internal-shutdown.rst
+++ b/doc/design-internal-shutdown.rst
@@ -2,6 +2,10 @@
 Detection of user-initiated shutdown from inside an instance
 ============================================================
 
+:Created: 2011-Mar-23
+:Status: Partially Implemented
+:Ganeti-Version: 2.10.0, 2.11.0
+
 .. contents:: :depth: 2
 
 This is a design document detailing the implementation of a way for Ganeti to

--- a/doc/design-kvmd.rst
+++ b/doc/design-kvmd.rst
@@ -2,6 +2,10 @@
 KVM daemon
 ==========
 
+:Created: 2014-Jan-09
+:Status: Implemented
+:Ganeti-Version: 2.11.0
+
 .. toctree::
    :maxdepth: 2
 

--- a/doc/design-linuxha.rst
+++ b/doc/design-linuxha.rst
@@ -2,6 +2,10 @@
 Linux HA integration
 ====================
 
+:Created: 2013-Oct-24
+:Status: Implemented
+:Ganeti-Version: 2.7.0
+
 .. contents:: :depth: 4
 
 This is a design document detailing the integration of Ganeti and Linux HA.
@@ -101,7 +105,7 @@ as a cloned resource that is active on all nodes.
 
 In partial mode it will always return success (and thus trigger a
 failure only upon an HA level or network failure). Full mode, which
-initially will not be implemented, couls also check for the node daemon
+initially will not be implemented, could also check for the node daemon
 being unresponsive or other local conditions (TBD).
 
 When a failure happens the HA notification system will trigger on all

--- a/doc/design-location.rst
+++ b/doc/design-location.rst
@@ -2,6 +2,10 @@
 Improving location awareness of Ganeti
 ======================================
 
+:Created: 2014-Jul-22
+:Status: Partially Implemented
+:Ganeti-Version: 2.13.0, 2.14.0
+
 This document describes an enhancement of Ganeti's instance
 placement by taking into account that some nodes are vulnerable
 to common failures.
@@ -65,7 +69,7 @@ static information into account, essentially amounts to counting disks. In
 this way, Ganeti will be willing to sacrifice equal numbers of disks on every
 node in order to fulfill location requirements.
 
-Appart from changing the balancedness metric, common-failure tags will
+Apart from changing the balancedness metric, common-failure tags will
 not have any other effect. In particular, as opposed to exclusion tags,
 no hard guarantees are made: ``hail`` will try allocate an instance in
 a common-failure avoiding way if possible, but still allocate the instance

--- a/doc/design-lu-generated-jobs.rst
+++ b/doc/design-lu-generated-jobs.rst
@@ -2,6 +2,10 @@
 Submitting jobs from logical units
 ==================================
 
+:Created: 2011-Mar-23
+:Status: Implemented
+:Ganeti-Version: 2.5.0
+
 .. contents:: :depth: 4
 
 This is a design document about the innards of Ganeti's job processing.

--- a/doc/design-monitoring-agent.rst
+++ b/doc/design-monitoring-agent.rst
@@ -2,6 +2,10 @@
 Ganeti monitoring agent
 =======================
 
+:Created: 2012-Oct-18
+:Status: Implemented
+:Ganeti-Version: 2.7.0, 2.8.0, 2.9.0
+
 .. contents:: :depth: 4
 
 This is a design document detailing the implementation of a Ganeti
@@ -85,7 +89,7 @@ the data collectors:
 ``category``
   A collector can belong to a given category of collectors (e.g.: storage
   collectors, daemon collector). This means that it will have to provide a
-  minumum set of prescribed fields, as documented for each category.
+  minimum set of prescribed fields, as documented for each category.
   This field will contain the name of the category the collector belongs to,
   if any, or just the ``null`` value.
 
@@ -175,7 +179,7 @@ in its ``data`` section, at least the following field:
     It assumes a numeric value, encoded in such a way to allow using a bitset
     to easily distinguish which states are currently present in the whole
     cluster. If the bitwise OR of all the ``status`` fields is 0, the cluster
-    is completely healty.
+    is completely healthy.
     The status codes are as follows:
 
     ``0``
@@ -206,7 +210,7 @@ in its ``data`` section, at least the following field:
 
     If the status code is ``2``, the message should specify what has gone
     wrong.
-    If the status code is ``4``, the message shoud explain why it was not
+    If the status code is ``4``, the message should explain why it was not
     possible to determine a proper status.
 
 The ``data`` section will also contain all the fields describing the gathered
@@ -450,7 +454,7 @@ each representing one logical volume and providing the following fields:
   Type of LV segment.
 
 ``seg_start``
-  Offset within the LVto the start of the segment in bytes.
+  Offset within the LV to the start of the segment in bytes.
 
 ``seg_start_pe``
   Offset within the LV to the start of the segment in physical extents.
@@ -603,7 +607,7 @@ collector will provide the following fields:
       The speed of the synchronization.
 
     ``want``
-      The desiderd speed of the synchronization.
+      The desired speed of the synchronization.
 
     ``speedUnit``
       The measurement unit of the ``speed`` and ``want`` values. Expressed
@@ -655,7 +659,7 @@ that is not generic enough be abstracted.
 
 The ``kind`` field will be ``0`` (`Performance reporting collectors`_).
 
-Each of the hypervisor data collectory will be of ``category``: ``hypervisor``.
+Each of the hypervisor data collectors will be of ``category``: ``hypervisor``.
 
 Node OS resources report
 ++++++++++++++++++++++++
@@ -869,7 +873,7 @@ from the nodes from a monitoring system and for Ganeti itself.
 One extra feature we may need is a way to query for only sub-parts of
 the report (eg. instances status only). This can be done by passing
 arguments to the HTTP GET, which will be defined when we get to this
-funtionality.
+functionality.
 
 Finally the :doc:`autorepair system design <design-autorepair>`. system
 (see its design) can be expanded to use the monitoring agent system as a

--- a/doc/design-move-instance-improvements.rst
+++ b/doc/design-move-instance-improvements.rst
@@ -2,6 +2,10 @@
 Instance move improvements
 ========================================
 
+:Created: 2014-Apr-11
+:Status: Partially Implemented
+:Ganeti-Version: 2.12.0
+
 .. contents:: :depth: 3
 
 Ganeti provides tools for moving instances within and between clusters. Through

--- a/doc/design-multi-reloc.rst
+++ b/doc/design-multi-reloc.rst
@@ -1,6 +1,10 @@
-====================================
-Moving instances accross node groups
-====================================
+===================================
+Moving instances across node groups
+===================================
+
+:Created: 2011-Mar-28
+:Status: Implemented
+:Ganeti-Version: 2.5.0
 
 This design document explains the changes needed in Ganeti to perform
 instance moves across node groups. Reader familiarity with the following

--- a/doc/design-multi-storage-htools.rst
+++ b/doc/design-multi-storage-htools.rst
@@ -2,6 +2,9 @@
 HTools support for multiple storage units per node
 ==================================================
 
+:Created: 2015-Jan-21
+:Status: Draft
+
 .. contents:: :depth: 4
 
 This design document describes changes to hbal and related components (first

--- a/doc/design-multi-version-tests.rst
+++ b/doc/design-multi-version-tests.rst
@@ -2,6 +2,10 @@
 Multi-version tests
 ===================
 
+:Created: 2013-Oct-30
+:Status: Implemented
+:Ganeti-Version: 2.11.0
+
 .. contents:: :depth: 4
 
 This is a design document describing how tests which use multiple

--- a/doc/design-network.rst
+++ b/doc/design-network.rst
@@ -2,6 +2,10 @@
 Network management
 ==================
 
+:Created: 2011-Jun-17
+:Status: Partially Implemented
+:Ganeti-Version: 2.7.0
+
 .. contents:: :depth: 4
 
 This is a design document detailing the implementation of network resource
@@ -34,7 +38,7 @@ b) The NIC network information is incomplete, lacking netmask and
    enable Ganeti nodes to become more self-contained and be able to
    infer system configuration (e.g. /etc/network/interfaces content)
    from Ganeti configuration. This should make configuration of
-   newly-added nodes a lot easier and less dependant on external
+   newly-added nodes a lot easier and less dependent on external
    tools/procedures.
 
 c) Instance placement must explicitly take network availability in
@@ -112,7 +116,7 @@ reservation, using a TemporaryReservationManager.
 
 It should be noted that IP pool management is performed only for IPv4
 networks, as they are expected to be densely populated. IPv6 networks
-can use different approaches, e.g. sequential address asignment or
+can use different approaches, e.g. sequential address assignment or
 EUI-64 addresses.
 
 New NIC parameter: network
@@ -255,7 +259,7 @@ Network addition/deletion
  gnt-network add --network=192.168.100.0/28 --gateway=192.168.100.1 \
                  --network6=2001:db8:2ffc::/64 --gateway6=2001:db8:2ffc::1 \
                  --add-reserved-ips=192.168.100.10,192.168.100.11 net100
-  (Checks for already exising name and valid IP values)
+  (Checks for already existing name and valid IP values)
  gnt-network remove network_name
   (Checks if not connected to any nodegroup)
 

--- a/doc/design-network2.rst
+++ b/doc/design-network2.rst
@@ -2,6 +2,9 @@
 Network Management (revised)
 ============================
 
+:Created: 2014-Sep-26
+:Status: Draft
+
 .. contents:: :depth: 4
 
 This is a design document detailing how to extend the existing network

--- a/doc/design-node-add.rst
+++ b/doc/design-node-add.rst
@@ -1,5 +1,10 @@
+=====================================
 Design for adding a node to a cluster
 =====================================
+
+:Created: 2012-Oct-16
+:Status: Implemented
+:Ganeti-Version: 2.7.0
 
 .. contents:: :depth: 3
 

--- a/doc/design-node-security.rst
+++ b/doc/design-node-security.rst
@@ -2,6 +2,10 @@
 Improvements of Node Security
 =============================
 
+:Created: 2013-Dec-05
+:Status: Partially Implemented
+:Ganeti-Version: 2.11.0, 2.12.0, 2.13.0
+
 This document describes an enhancement of Ganeti's security by restricting
 the distribution of security-sensitive data to the master and master
 candidates only.
@@ -17,7 +21,7 @@ Objective
 Up till 2.10, Ganeti distributes security-relevant keys to all nodes,
 including nodes that are neither master nor master-candidates. Those
 keys are the private and public SSH keys for node communication and the
-SSL certficate and private key for RPC communication. Objective of this
+SSL certificate and private key for RPC communication. Objective of this
 design is to limit the set of nodes that can establish ssh and RPC
 connections to the master and master candidates.
 
@@ -125,7 +129,7 @@ the current powers a user of the RAPI interface would have. The
 That means, an attacker that has access to the RAPI interface, can make
 all non-master-capable nodes master-capable, and then increase the master
 candidate pool size till all machines are master candidates (or at least
-a particular machine that he is aming for). This means that with RAPI
+a particular machine that he is aiming for). This means that with RAPI
 access and a compromised normal node, one can make this node a master
 candidate and then still have the power to compromise the whole cluster.
 
@@ -137,7 +141,7 @@ To mitigate this issue, we propose the following changes:
   set to ``False`` by default and can itself only be changed on the
   commandline. In this design doc, we refer to the flag as the
   "rapi flag" from here on.
-- Only if the ``master_capabability_rapi_modifiable`` switch is set to
+- Only if the ``master_capability_rapi_modifiable`` switch is set to
   ``True``, it is possible to modify the master-capability flag of
   nodes.
 
@@ -168,7 +172,7 @@ However, we think these are rather confusing semantics of the involved
 flags and thus we go with proposed design.
 
 Note that this change will break RAPI compatibility, at least if the
-rapi flag is not explicitely set to ``True``. We made this choice to
+rapi flag is not explicitly set to ``True``. We made this choice to
 have the more secure option as default, because otherwise it is
 unlikely to be widely used.
 
@@ -272,7 +276,7 @@ it was issued, Ganeti does not do anything.
 
 Note that when you demote a node from master candidate to normal node, another
 master-capable and normal node will be promoted to master candidate. For this
-newly promoted node, the same changes apply as if it was explicitely promoted.
+newly promoted node, the same changes apply as if it was explicitly promoted.
 
 The same behavior should be ensured for the corresponding rapi command.
 
@@ -283,7 +287,7 @@ Offlining and onlining a node
 When offlining a node, it immediately loses its role as master or master
 candidate as well. When it is onlined again, it will become master
 candidate again if it was so before. The handling of the keys should be done
-in the same way as when the node is explicitely promoted or demoted to or from
+in the same way as when the node is explicitly promoted or demoted to or from
 master candidate. See the previous section for details.
 
 This affects the command:
@@ -346,7 +350,7 @@ will be backed up and not simply overridden.
 Downgrades
 ~~~~~~~~~~
 
-These downgrading steps will be implemtented from 2.13 to 2.12:
+These downgrading steps will be implemented from 2.13 to 2.12:
 
 - The master node's private/public key pair will be distributed to all
   nodes (via SSH) and the individual SSH keys will be backed up.
@@ -389,7 +393,7 @@ in the design.
   and client certificate, we generate a common server certificate (and
   the corresponding private key) for all nodes and a different client
   certificate (and the corresponding private key) for each node. The
-  server certificate will be self-signed. The client certficate will
+  server certificate will be self-signed. The client certificate will
   be signed by the server certificate. The client certificates will
   use the node UUID as serial number to ensure uniqueness within the
   cluster. They will use the host's hostname as the certificate
@@ -466,7 +470,7 @@ Alternative proposals:
   as trusted CAs. As this would have resulted in having to restart
   noded on all nodes every time a node is added, removed, demoted
   or promoted, this was not feasible and we switched to client
-  certficates which are signed by the server certificate.
+  certificates which are signed by the server certificate.
 - Instead of generating a client certificate per node, one could think
   of just generating two different client certificates, one for normal
   nodes and one for master candidates. Noded could then just check if
@@ -495,7 +499,7 @@ created. With our design, two certificates (and corresponding keys)
 need to be created, a server certificate to be distributed to all nodes
 and a client certificate only to be used by this particular node. In the
 following, we use the term node daemon certificate for the server
-certficate only.
+certificate only.
 
 In the cluster configuration, the candidate map is created. It is
 populated with the respective entry for the master node. It is also
@@ -508,7 +512,7 @@ written to ssconf.
 When a node is added, the server certificate is copied to the node (as
 before). Additionally, a new client certificate (and the corresponding
 private key) is created on the new node to be used only by the new node
-as client certifcate.
+as client certificate.
 
 If the new node is a master candidate, the candidate map is extended by
 the new node's data. As before, the updated configuration is distributed
@@ -532,7 +536,7 @@ distributed to all nodes. If there was already an entry for the node,
 we override it.
 
 On demotion of a master candidate, the node's entry in the candidate map
-gets removed and the updated configuration gets redistibuted.
+gets removed and the updated configuration gets redistributed.
 
 The same procedure applied to onlining and offlining master candidates.
 

--- a/doc/design-oob.rst
+++ b/doc/design-oob.rst
@@ -1,5 +1,10 @@
+====================================
 Ganeti Node OOB Management Framework
 ====================================
+
+:Created: 2010-Nov-04
+:Status: Implemented
+:Ganeti-Version: 2.4.0
 
 Objective
 ---------

--- a/doc/design-openvswitch.rst
+++ b/doc/design-openvswitch.rst
@@ -2,6 +2,10 @@
 Support for Open vSwitch
 ========================
 
+:Created: 2013-Jun-28
+:Status: Implemented
+:Ganeti-Version: 2.10.0
+
 .. contents:: :depth: 3
 
 This is a design document detailing the implementation of support for

--- a/doc/design-opportunistic-locking.rst
+++ b/doc/design-opportunistic-locking.rst
@@ -1,5 +1,10 @@
+====================================================================
 Design for parallelized instance creations and opportunistic locking
 ====================================================================
+
+:Created: 2012-Dec-03
+:Status: Implemented
+:Ganeti-Version: 2.7.0
 
 .. contents:: :depth: 3
 

--- a/doc/design-optables.rst
+++ b/doc/design-optables.rst
@@ -2,6 +2,10 @@
 Filtering of jobs for the Ganeti job queue
 ==========================================
 
+:Created: 2013-Jul-24
+:Status: Implemented
+:Ganeti-Version: 2.13.0
+
 .. contents:: :depth: 4
 
 This is a design document detailing the semantics of the fine-grained control
@@ -39,7 +43,7 @@ Proposed changes
 ================
 
 We propose to add filters on the job queue. These will be part of the
-configuration and as such are persisted with it. Conceptionally, the
+configuration and as such are persisted with it. Conceptually, the
 filters are always processed when a job enters the queue and while it
 is still in the queue. Of course, in the implementation, reevaluation
 is only carried out, if something could make the result change, e.g.,

--- a/doc/design-os.rst
+++ b/doc/design-os.rst
@@ -2,6 +2,10 @@
 Ganeti OS installation redesign
 ===============================
 
+:Created: 2013-Dec-12
+:Status: Partially Implemented
+:Ganeti-Version: 2.12.0, 2.13.0
+
 .. contents:: :depth: 3
 
 This is a design document detailing a new OS installation procedure, which is

--- a/doc/design-ovf-support.rst
+++ b/doc/design-ovf-support.rst
@@ -2,6 +2,10 @@
 Ganeti Instance Import/Export using Open Virtualization Format
 ==============================================================
 
+:Created: 2011-Jul-22
+:Status: Implemented
+:Ganeti-Version: 2.6.0
+
 Background
 ==========
 
@@ -84,7 +88,7 @@ currently use OVF.
   OpenStack: mostly ``.vmdk``
 
 In our implementation of the OVF we allow a choice between raw, cow and
-vmdk disk formats for both import and export. Other formats covertable
+vmdk disk formats for both import and export. Other formats convertable
 using ``qemu-img`` are allowed in import mode, but not tested.
 The justification is the following:
 

--- a/doc/design-partitioned.rst
+++ b/doc/design-partitioned.rst
@@ -2,6 +2,10 @@
 Partitioned Ganeti
 ==================
 
+:Created: 2012-Oct-05
+:Status: Implemented
+:Ganeti-Version: 2.7.0, 2.8.0, 2.9.0
+
 .. contents:: :depth: 4
 
 Current state and shortcomings

--- a/doc/design-performance-tests.rst
+++ b/doc/design-performance-tests.rst
@@ -2,6 +2,10 @@
 Performance tests for QA
 ========================
 
+:Created: 2014-Apr-28
+:Status: Implemented
+:Ganeti-Version: 2.10.0
+
 .. contents:: :depth: 4
 
 This design document describes performance tests to be added to QA in

--- a/doc/design-query-splitting.rst
+++ b/doc/design-query-splitting.rst
@@ -2,6 +2,9 @@
 Splitting the query and job execution paths
 ===========================================
 
+:Created: 2012-May-07
+:Status: Implemented
+:Ganeti-Version: 2.7.0, 2.8.0, 2.9.0
 
 Introduction
 ============

--- a/doc/design-query2.rst
+++ b/doc/design-query2.rst
@@ -2,6 +2,10 @@
 Query version 2 design
 ======================
 
+:Created: 2010-Nov-12
+:Status: Implemented
+:Ganeti-Version: 2.4.0
+
 .. contents:: :depth: 4
 .. highlight:: python
 

--- a/doc/design-reason-trail.rst
+++ b/doc/design-reason-trail.rst
@@ -2,6 +2,10 @@
 Ganeti reason trail
 ===================
 
+:Created: 2013-Mar-15
+:Status: Implemented
+:Ganeti-Version: 2.9.0
+
 .. contents:: :depth: 2
 
 This is a design document detailing the implementation of a way for Ganeti to

--- a/doc/design-reservations.rst
+++ b/doc/design-reservations.rst
@@ -2,6 +2,10 @@
 Instance Reservations
 =====================
 
+:Created: 2014-Jul-22
+:Status: Partially Implemented
+:Ganeti-Version: 2.12.0, 2.14.0
+
 .. contents:: :depth: 4
 
 This is a design document detailing the addition of a concept
@@ -83,8 +87,8 @@ Representation in the Configuration
 -----------------------------------
 
 As for most part of the system, forthcoming instances and their disks are to
-be treated as if they were real. Therefore, the wire representation will
-be by adding an additional, optional, ``fortcoming`` flag to the ``instances``
+be treated as if they were real. Therefore, the wire representation will be
+by adding an additional, optional, ``forthcoming`` flag to the ``instances``
 and ``disks`` objects. Additionally, the internal consistency condition will
 be relaxed to have all non-uuid fields optional if an instance or disk is
 forthcoming.
@@ -112,7 +116,7 @@ and the remaining fields depend on the value of that field). Of course, in
 the Haskell part of our code base, this will be represented in the standard way
 having two constructors for the type; additionally there will be accessors
 for all the fields of the JSON representation (yielding ``Maybe`` values,
-as they can be optional if we're in the ``Forthcoming`` constuctor).
+as they can be optional if we're in the ``Forthcoming`` constructor).
 
 
 Adaptions of htools

--- a/doc/design-resource-model.rst
+++ b/doc/design-resource-model.rst
@@ -2,6 +2,9 @@
  Resource model changes
 ========================
 
+:Created: 2011-Oct-12
+:Status: Implemented
+:Ganeti-Version: 2.6.0
 
 Introduction
 ============
@@ -650,7 +653,7 @@ in these structures:
 +---------------+----------------------------------+--------------+
 |disk_size      |Allowed disk size                 |int           |
 +---------------+----------------------------------+--------------+
-|nic_count      |Alowed NIC count                  |int           |
+|nic_count      |Allowed NIC count                 |int           |
 +---------------+----------------------------------+--------------+
 
 Inheritance
@@ -730,7 +733,7 @@ brackets.
 +========+==============+=========================+=====================+======+
 |plain   |stripes       |How many stripes to use  |Configured at        |int   |
 |        |              |for newly created (plain)|./configure time, not|      |
-|        |              |logical voumes           |overridable at       |      |
+|        |              |logical volumes          |overridable at       |      |
 |        |              |                         |runtime              |      |
 +--------+--------------+-------------------------+---------------------+------+
 |drbd    |data-stripes  |How many stripes to use  |Same as for          |int   |
@@ -850,7 +853,7 @@ For the new memory model, we'll add the following parameters, in a
 dictionary indexed by the hypervisor name (node attribute
 ``hv_state``). The rationale is that, even though multi-hypervisor
 clusters are rare, they make sense sometimes, and thus we need to
-support multipe node states (one per hypervisor).
+support multiple node states (one per hypervisor).
 
 Since usually only one of the multiple hypervisors is the 'main' one
 (and the others used sparringly), capacity computation will still only
@@ -914,7 +917,7 @@ are at node group level); the proposal is to do this via a cluster-level
 
 Beside the per-hypervisor attributes, we also have disk attributes,
 which are queried directly on the node (without hypervisor
-involvment). The are stored in a separate attribute (``disk_state``),
+involvement). The are stored in a separate attribute (``disk_state``),
 which is indexed per storage type and name; currently this will be just
 ``DT_PLAIN`` and the volume name as key.
 

--- a/doc/design-restricted-commands.rst
+++ b/doc/design-restricted-commands.rst
@@ -1,5 +1,10 @@
+=====================================
 Design for executing commands via RPC
 =====================================
+
+:Created: 2012-Oct-16
+:Status: Implemented
+:Ganeti-Version: 2.7.0
 
 .. contents:: :depth: 3
 

--- a/doc/design-shared-storage-redundancy.rst
+++ b/doc/design-shared-storage-redundancy.rst
@@ -2,10 +2,14 @@
 N+1 redundancy for shared storage
 =================================
 
+:Created: 2015-Apr-13
+:Status: Partially Implemented
+:Ganeti-Version: 2.15
+
 .. contents:: :depth: 4
 
 This document describes how N+1 redundancy is achieved
-for instanes using shared storage.
+for instances using shared storage.
 
 
 Current state and shortcomings
@@ -44,7 +48,7 @@ for DRBD is to be taken into account for all choices affecting instance
 location, including instance allocation and balancing.
 
 For shared-storage instances, they can move everywhere within the
-node group. So, in practise, this is mainly a question of capacity
+node group. So, in practice, this is mainly a question of capacity
 planing, especially is most instances have the same size. Nevertheless,
 offcuts if instances don't fill a node entirely may not be ignored.
 
@@ -53,7 +57,7 @@ Modifications to existing tools
 -------------------------------
 
 - ``hail`` will compute and rank possible allocations as usual. However,
-  before returing a choice it will filter out allocations that are
+  before returning a choice it will filter out allocations that are
   not N+1 redundant.
 
 - Normal ``gnt-cluster verify`` will not be changed; in particular,
@@ -97,4 +101,3 @@ acceptable; Ganeti generally follows the guideline that current problems are
 more important than future ones. Also, even with that change allocation is
 more careful than the current approach of completely ignoring N+1 redundancy
 for shared storage.
-

--- a/doc/design-shared-storage.rst
+++ b/doc/design-shared-storage.rst
@@ -2,6 +2,10 @@
 Ganeti shared storage support
 =============================
 
+:Created: 2011-Mar-01
+:Status: Implemented
+:Ganeti-Version: 2.7.0
+
 This document describes the changes in Ganeti 2.3+ compared to Ganeti
 2.3 storage model. It also documents the ExtStorage Interface.
 
@@ -284,15 +288,15 @@ command line::
                                             param1=value1,param2=value2
 
 The above parameters will be exported to the ExtStorage provider's
-scripts as the enviromental variables:
+scripts as the environment variables:
 
 - `EXTP_PARAM1 = str(value1)`
 - `EXTP_PARAM2 = str(value2)`
 
 We will also introduce a new Ganeti client called `gnt-storage` which
 will be used to diagnose ExtStorage providers and show information about
-them, similarly to the way  `gnt-os diagose` and `gnt-os info` handle OS
-definitions.
+them, similarly to the way  `gnt-os diagnose` and `gnt-os info` handle
+OS definitions.
 
 ExtStorage Interface support for userspace access
 =================================================

--- a/doc/design-ssh-ports.rst
+++ b/doc/design-ssh-ports.rst
@@ -2,6 +2,10 @@
 Design for supporting custom SSH ports for nodes
 ================================================
 
+:Created: 2013-Nov-08
+:Status: Implemented
+:Ganeti-Version: 2.11.0
+
 .. contents:: :depth: 4
 
 This design document describes the intention of supporting running SSH servers
@@ -11,7 +15,7 @@ on nodes with non-standard port numbers.
 Current state and shortcomings
 ==============================
 
-All SSH deamons are expected to be running on the default port 22. It has been
+All SSH daemons are expected to be running on the default port 22. It has been
 requested by Ganeti users (`Issue 235`_) to allow SSH daemons run on
 non-standard ports as well.
 

--- a/doc/design-storagetypes.rst
+++ b/doc/design-storagetypes.rst
@@ -2,6 +2,10 @@
 Management of storage types and disk templates, incl. storage space reporting
 =============================================================================
 
+:Created: 2013-Feb-15
+:Status: Implemented
+:Ganeti-Version: 2.8.0, 2.9.0, 2.10.0
+
 .. contents:: :depth: 4
 
 Background
@@ -42,7 +46,7 @@ the currently implemented disk templates: ``blockdev``, ``diskless``, ``drbd``,
 ``ext``, ``file``, ``plain``, ``rbd``, and ``sharedfile``. See
 ``DISK_TEMPLATES`` in ``constants.py``.
 
-Note that the abovementioned list of enabled disk types is just a "mechanism"
+Note that the above-mentioned list of enabled disk types is just a "mechanism"
 parameter that defines which disk templates the cluster can use. Further
 filtering about what's allowed can go in the ipolicy, which is not covered in
 this design doc. Note that it is possible to force an instance to use a disk

--- a/doc/design-sync-rate-throttling.rst
+++ b/doc/design-sync-rate-throttling.rst
@@ -1,5 +1,9 @@
+=========================
 DRBD Sync Rate Throttling
 =========================
+
+:Created: 2014-Sep-16
+:Status: Draft
 
 Objective
 ---------

--- a/doc/design-systemd.rst
+++ b/doc/design-systemd.rst
@@ -2,6 +2,10 @@
 Systemd integration
 ===================
 
+:Created: 2014-Mar-26
+:Status: Implemented
+:Ganeti-Version: 2.12.0
+
 .. contents:: :depth: 4
 
 This design document outlines the implementation of native systemd

--- a/doc/design-upgrade.rst
+++ b/doc/design-upgrade.rst
@@ -2,6 +2,10 @@
 Automatized Upgrade Procedure for Ganeti
 ========================================
 
+:Created: 2013-Aug-20
+:Status: Implemented
+:Ganeti-Version: 2.10.0
+
 .. contents:: :depth: 4
 
 This is a design document detailing the proposed changes to the
@@ -50,7 +54,7 @@ These paths will be changed in the following way.
   ``${PREFIX}/share/ganeti/${VERSION}`` so that they see their respective
   Ganeti library. ``${PREFIX}/share/ganeti/default`` is a symbolic link to
   ``${sysconfdir}/ganeti/share`` which, in turn, is a symbolic link to
-  ``${PREFIX}/share/ganeti/${VERSION}``. For all python executatables (like
+  ``${PREFIX}/share/ganeti/${VERSION}``. For all python executables (like
   ``gnt-cluster``, ``gnt-node``, etc) symbolic links going through
   ``${PREFIX}/share/ganeti/default`` are added under ``${PREFIX}/sbin``.
 
@@ -67,12 +71,12 @@ These paths will be changed in the following way.
 
 The set of links for ganeti binaries might change between the versions.
 However, as the file structure under ``${libdir}/ganeti/${VERSION}`` reflects
-that of ``/``, two links of differnt versions will never conflict. Similarly,
+that of ``/``, two links of different versions will never conflict. Similarly,
 the symbolic links for the python executables will never conflict, as they
 always point to a file with the same basename directly under
 ``${PREFIX}/share/ganeti/default``. Therefore, each version will make sure that
 enough symbolic links are present in ``${PREFIX}/bin``, ``${PREFIX}/sbin`` and
-so on, even though some might be dangling, if a differnt version of ganeti is
+so on, even though some might be dangling, if a different version of ganeti is
 currently active.
 
 The extra indirection through ``${sysconfdir}`` allows installations that choose
@@ -201,7 +205,7 @@ following actions.
 
 - A backup of all Ganeti-related status information is created for
   manual rollbacks. While the normal way of rolling back after an
-  upgrade should be calling ``gnt-clsuter upgrade`` from the newer version
+  upgrade should be calling ``gnt-cluster upgrade`` from the newer version
   with the older version as argument, a full backup provides an
   additional safety net, especially for jump-upgrades (skipping
   intermediate minor versions).
@@ -252,7 +256,7 @@ rolled back).
 To achieve this, ``gnt-cluster upgrade`` will support a ``--resume``
 option. It is recommended
 to have ``gnt-cluster upgrade --resume`` as an at-reboot task in the crontab.
-The ``gnt-cluster upgrade --resume`` comand first verifies that
+The ``gnt-cluster upgrade --resume`` command first verifies that
 it is running on the master node, using the same requirement as for
 starting the master daemon, i.e., confirmed by a majority of all
 nodes. If it is not the master node, it will remove any possibly

--- a/doc/design-virtual-clusters.rst
+++ b/doc/design-virtual-clusters.rst
@@ -2,6 +2,9 @@
 Design for virtual clusters support
 ===================================
 
+:Created: 2011-Oct-14
+:Status: Partial Implementation
+:Ganeti-Version: 2.7.0
 
 Introduction
 ============

--- a/doc/design-x509-ca.rst
+++ b/doc/design-x509-ca.rst
@@ -2,6 +2,9 @@
 Design for a X509 Certificate Authority
 =======================================
 
+:Created: 2011-Mar-23
+:Status: Draft
+
 .. contents:: :depth: 4
 
 Current state and shortcomings

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -99,8 +99,10 @@ Draft designs
    design-allocation-efficiency.rst
    design-autorepair.rst
    design-bulk-create.rst
+   design-ceph-ganeti-support.rst
    design-chained-jobs.rst
    design-cmdlib-unittests.rst
+   design-configlock.rst
    design-cpu-speed.rst
    design-cpu-pinning.rst
    design-dedicated-allocation.rst
@@ -110,6 +112,7 @@ Draft designs
    design-disks.rst
    design-file-based-storage.rst
    design-file-based-disks-ownership.rst
+   design-glusterfs-ganeti-support.rst
    design-hroller.rst
    design-hsqueeze.rst
    design-hotplug.rst
@@ -117,6 +120,7 @@ Draft designs
    design-kvmd.rst
    design-location.rst
    design-linuxha.rst
+   design-location.rst
    design-lu-generated-jobs.rst
    design-monitoring-agent.rst
    design-move-instance-improvements.rst
@@ -137,6 +141,8 @@ Draft designs
    design-query2.rst
    design-query-splitting.rst
    design-reason-trail.rst
+   design-reservations.rst
+   design-resource-model.rst
    design-restricted-commands.rst
    design-shared-storage.rst
    design-shared-storage-redundancy.rst

--- a/lib/backend.py
+++ b/lib/backend.py
@@ -5229,14 +5229,14 @@ def _GetImportExportIoCommand(instance, mode, ieio, ieargs):
       script = inst_os.import_script
 
     elif mode == constants.IEM_EXPORT:
-      disk_path_var = "DISK_%d_PATH" % disk_index
-      if disk_path_var in env:
-        env["EXPORT_DEVICE"] = env[disk_path_var]
-        env["EXPORT_DISK_PATH"] = env[disk_path_var]
+      real_disk = _OpenRealBD(disk)
+      if real_disk.dev_path:
+        env["EXPORT_DEVICE"] = real_disk.dev_path
+        env["EXPORT_DISK_PATH"] = real_disk.dev_path
 
-      disk_uri_var = "DISK_%d_URI" % disk_index
-      if disk_uri_var in env:
-        env["EXPORT_DISK_URI"] = env[disk_uri_var]
+      uri = _CalculateDeviceURI(instance, disk, real_disk)
+      if uri:
+        env["EXPORT_DISK_URI"] = uri
 
       env["EXPORT_INDEX"] = str(disk_index)
       script = inst_os.export_script

--- a/lib/cli_opts.py
+++ b/lib/cli_opts.py
@@ -855,7 +855,7 @@ IGNORE_CONSIST_OPT = cli_option("--ignore-consistency",
 IGNORE_HVVERSIONS_OPT = cli_option("--ignore-hvversions",
                                    dest="ignore_hvversions",
                                    action="store_true", default=False,
-                                   help="Ignore imcompatible hypervisor"
+                                   help="Ignore incompatible hypervisor"
                                    " versions between source and target")
 
 ALLOW_FAILOVER_OPT = cli_option("--allow-failover",

--- a/lib/client/gnt_backup.py
+++ b/lib/client/gnt_backup.py
@@ -171,16 +171,16 @@ commands = {
      SHUTDOWN_TIMEOUT_OPT, REMOVE_INSTANCE_OPT, IGNORE_REMOVE_FAILURES_OPT,
      DRY_RUN_OPT, PRIORITY_OPT, ZERO_FREE_SPACE_OPT, ZEROING_TIMEOUT_FIXED_OPT,
      ZEROING_TIMEOUT_PER_MIB_OPT, LONG_SLEEP_OPT] + SUBMIT_OPTS,
-    "-n <target_node> [opts...] <name>",
+    "-n <node-name> [opts...] <instance-name>",
     "Exports an instance to an image"),
   "import": (
     ImportInstance, ARGS_ONE_INSTANCE, COMMON_CREATE_OPTS + import_opts,
-    "[...] -t disk-type -n node[:secondary-node] <name>",
+    "[...] -t disk-type -n node[:secondary-node] <instance-name>",
     "Imports an instance from an exported image"),
   "remove": (
     RemoveExport, [ArgUnknown(min=1, max=1)],
     [DRY_RUN_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "<name>", "Remove exports of named instance from the filesystem."),
+    "<instance-name>", "Remove exports of named instance from the filesystem."),
   }
 
 

--- a/lib/client/gnt_cluster.py
+++ b/lib/client/gnt_cluster.py
@@ -1193,7 +1193,7 @@ def _RenewCrypto(new_cluster_cert, new_rapi_cert, # pylint: disable=R0911
   if new_rapi_cert or new_spice_cert or new_confd_hmac_key or new_cds:
     RunWhileClusterStopped(ToStdout, _RenewCryptoInner)
 
-  # If only node certficates are recreated, call _RenewClientCerts only.
+  # If only node certificates are recreated, call _RenewClientCerts only.
   if new_node_cert and not new_cluster_cert:
     RunWhileDaemonsStopped(ToStdout, [constants.NODED, constants.WCONFD],
                            _RenewClientCerts, verbose=verbose, debug=debug)
@@ -2472,14 +2472,14 @@ commands = {
      ENABLED_USER_SHUTDOWN_OPT, SSH_KEY_BITS_OPT, SSH_KEY_TYPE_OPT,
      ]
      + INSTANCE_POLICY_OPTS + SPLIT_ISPECS_OPTS,
-    "[opts...] <cluster_name>", "Initialises a new cluster configuration"),
+    "[<opts>...] <cluster-name>", "Initialises a new cluster configuration"),
   "destroy": (
     DestroyCluster, ARGS_NONE, [YES_DOIT_OPT],
     "", "Destroy cluster"),
   "rename": (
     RenameCluster, [ArgHost(min=1, max=1)],
     [FORCE_OPT, DRY_RUN_OPT],
-    "<new_name>",
+    "<new-name>",
     "Renames the cluster"),
   "redist-conf": (
     RedistributeConfig, ARGS_NONE, SUBMIT_OPTS +
@@ -2497,7 +2497,7 @@ commands = {
     "", "Does a check on the cluster disk status"),
   "repair-disk-sizes": (
     RepairDiskSizes, ARGS_MANY_INSTANCES, [DRY_RUN_OPT, PRIORITY_OPT],
-    "[instance...]", "Updates mismatches in recorded disk sizes"),
+    "[<instance-name>...]", "Updates mismatches in recorded disk sizes"),
   "master-failover": (
     MasterFailover, ARGS_NONE,
     [NOVOTING_OPT, FORCE_FAILOVER, IGNORE_OFFLINE_NODES_FAILOVER],
@@ -2514,11 +2514,12 @@ commands = {
   "copyfile": (
     ClusterCopyFile, [ArgFile(min=1, max=1)],
     [NODE_LIST_OPT, USE_REPL_NET_OPT, NODEGROUP_OPT],
-    "[-n node...] <filename>", "Copies a file to all (or only some) nodes"),
+    "[-n <node-name>...] <filename>",
+    "Copies a file to all (or only some) nodes"),
   "command": (
     RunClusterCommand, [ArgCommand(min=1)],
     [NODE_LIST_OPT, NODEGROUP_OPT, SHOW_MACHINE_OPT, FAILURE_ONLY_OPT],
-    "[-n node...] <command>", "Runs a command on all (or only some) nodes"),
+    "[-n <node-name>...] <command>", "Runs a command on all (or only some) nodes"),
   "info": (
     ShowClusterConfig, ARGS_NONE, [ROMAN_OPT],
     "[--roman]", "Show cluster configuration"),
@@ -2526,10 +2527,10 @@ commands = {
     ListTags, ARGS_NONE, [], "", "List the tags of the cluster"),
   "add-tags": (
     AddTags, [ArgUnknown()], [TAG_SRC_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "tag...", "Add tags to the cluster"),
+    "<tag>...", "Add tags to the cluster"),
   "remove-tags": (
     RemoveTags, [ArgUnknown()], [TAG_SRC_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "tag...", "Remove tags from the cluster"),
+    "<tag>...", "Remove tags from the cluster"),
   "search-tags": (
     SearchTags, [ArgUnknown(min=1, max=1)], [PRIORITY_OPT], "",
     "Searches the tags on all objects on"
@@ -2561,7 +2562,7 @@ commands = {
      [GLOBAL_FILEDIR_OPT, GLOBAL_SHARED_FILEDIR_OPT, ZEROING_IMAGE_OPT,
       COMPRESSION_TOOLS_OPT] +
      [ENABLED_DATA_COLLECTORS_OPT, DATA_COLLECTOR_INTERVAL_OPT],
-    "[opts...]",
+    "[<opts>...]",
     "Alters the parameters of the cluster"),
   "renew-crypto": (
     RenewCrypto, ARGS_NONE,
@@ -2571,13 +2572,13 @@ commands = {
      NEW_SPICE_CERT_OPT, SPICE_CERT_OPT, SPICE_CACERT_OPT,
      NEW_NODE_CERT_OPT, NEW_SSH_KEY_OPT, NOSSH_KEYCHECK_OPT,
      VERBOSE_OPT, SSH_KEY_BITS_OPT, SSH_KEY_TYPE_OPT],
-    "[opts...]",
+    "[<opts>...]",
     "Renews cluster certificates, keys and secrets"),
   "epo": (
     Epo, [ArgUnknown()],
     [FORCE_OPT, ON_OPT, GROUPS_OPT, ALL_OPT, OOB_TIMEOUT_OPT,
      SHUTDOWN_TIMEOUT_OPT, POWER_DELAY_OPT],
-    "[opts...] [args]",
+    "[<opts>...] [args]",
     "Performs an emergency power-off on given args"),
   "activate-master-ip": (
     ActivateMasterIp, ARGS_NONE, [], "", "Activates the master IP"),

--- a/lib/client/gnt_debug.py
+++ b/lib/client/gnt_debug.py
@@ -738,7 +738,7 @@ commands = {
                 action="store_true",
                 help="Don't take locks while performing the delay"),
      DRY_RUN_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "[opts...] <duration>", "Executes a TestDelay OpCode"),
+    "[<opts>...] <duration>", "Executes a TestDelay OpCode"),
   "submit-job": (
     GenericOpCodes, [ArgFile(min=1)],
     [VERBOSE_OPT,
@@ -752,7 +752,7 @@ commands = {
                 help="Submit each job separately"),
      DRY_RUN_OPT, PRIORITY_OPT,
      ],
-    "<op_list_file...>", "Submits jobs built from json files"
+    "<op-list-file>...", "Submits jobs built from json files"
     " containing a list of serialized opcodes"),
   "iallocator": (
     TestAllocator, [ArgUnknown(min=1)],
@@ -791,7 +791,7 @@ commands = {
                 default=2, type="int"),
      DRY_RUN_OPT, PRIORITY_OPT,
      ],
-    "{opts...} <instance>", "Executes a TestAllocator OpCode"),
+    "{<opts>...} <instance-name>", "Executes a TestAllocator OpCode"),
   "test-jobqueue": (
     TestJobqueue, ARGS_NONE, [PRIORITY_OPT],
     "", "Test a few aspects of the job queue"),

--- a/lib/client/gnt_filter.py
+++ b/lib/client/gnt_filter.py
@@ -203,29 +203,29 @@ commands = {
   "list": (
     ListFilters, ARGS_MANY_FILTERS,
     [NOHDR_OPT, SEP_OPT, FIELDS_OPT, VERBOSE_OPT],
-    "[<filter_uuid>...]",
+    "[<filter-uuid>...]",
     "Lists the job filter rules. The available fields can be shown"
     " using the \"list-fields\" command (see the man page for details)."
     " The default list is (in order): %s." % utils.CommaJoin(_LIST_DEF_FIELDS)),
   "list-fields": (
     ListFilterFields, [ArgUnknown()],
     [NOHDR_OPT, SEP_OPT],
-    "[fields...]",
+    "[<fields>...]",
     "Lists all available fields for filters"),
   "info": (
     ShowFilter, ARGS_MANY_FILTERS,
     [],
-    "[<filter_uuid>...]",
+    "[<filter-uuid>...]",
     "Shows information about the filter(s)"),
   "replace": (
     ReplaceFilter, ARGS_ONE_FILTER,
     [FILTER_PRIORITY_OPT, FILTER_PREDICATES_OPT, FILTER_ACTION_OPT],
-    "<filter_uuid>",
+    "<filter-uuid>",
     "Replaces a filter"),
   "delete": (
     DeleteFilter, ARGS_ONE_FILTER,
     [],
-    "<filter_uuid>",
+    "<filter-uuid>",
     "Removes a filter"),
 }
 

--- a/lib/client/gnt_group.py
+++ b/lib/client/gnt_group.py
@@ -338,15 +338,15 @@ commands = {
     [DRY_RUN_OPT, ALLOC_POLICY_OPT, NODE_PARAMS_OPT, DISK_PARAMS_OPT,
      HV_STATE_OPT, DISK_STATE_OPT, PRIORITY_OPT]
     + SUBMIT_OPTS + INSTANCE_POLICY_OPTS,
-    "<group_name>", "Add a new node group to the cluster"),
+    "<group-name>", "Add a new node group to the cluster"),
   "assign-nodes": (
     AssignNodes, ARGS_ONE_GROUP + ARGS_MANY_NODES,
     [DRY_RUN_OPT, FORCE_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "<group_name> <node>...", "Assign nodes to a group"),
+    "<group-name> <node-name>...", "Assign nodes to a group"),
   "list": (
     ListGroups, ARGS_MANY_GROUPS,
     [NOHDR_OPT, SEP_OPT, FIELDS_OPT, VERBOSE_OPT, FORCE_FILTER_OPT],
-    "[<group_name>...]",
+    "[<group-name>...]",
     "Lists the node groups in the cluster. The available fields can be shown"
     " using the \"list-fields\" command (see the man page for details)."
     " The default list is (in order): %s." % utils.CommaJoin(_LIST_DEF_FIELDS)),
@@ -359,39 +359,39 @@ commands = {
     [ALLOC_POLICY_OPT, NODE_PARAMS_OPT, HV_STATE_OPT, DISK_STATE_OPT,
      DISK_PARAMS_OPT, PRIORITY_OPT]
     + INSTANCE_POLICY_OPTS,
-    "<group_name>", "Alters the parameters of a node group"),
+    "<group>", "Alters the parameters of a node group"),
   "remove": (
     RemoveGroup, ARGS_ONE_GROUP, [DRY_RUN_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "[--dry-run] <group-name>",
+    "[--dry-run] <group>",
     "Remove an (empty) node group from the cluster"),
   "rename": (
     RenameGroup, [ArgGroup(min=2, max=2)],
     [DRY_RUN_OPT] + SUBMIT_OPTS + [PRIORITY_OPT],
-    "[--dry-run] <group-name> <new-name>", "Rename a node group"),
+    "[--dry-run] <old-name> <new-name>", "Rename a node group"),
   "evacuate": (
     EvacuateGroup, [ArgGroup(min=1, max=1)],
     [TO_GROUP_OPT, IALLOCATOR_OPT, EARLY_RELEASE_OPT, SEQUENTIAL_OPT,
      FORCE_FAILOVER_OPT]
     + SUBMIT_OPTS,
-    "[-I <iallocator>] [--to <group>]",
+    "[-I <iallocator>] [--to <group>] <source-group>",
     "Evacuate all instances within a group"),
   "list-tags": (
     ListTags, ARGS_ONE_GROUP, [],
-    "<group_name>", "List the tags of the given group"),
+    "<group>", "List the tags of the given group"),
   "add-tags": (
     AddTags, [ArgGroup(min=1, max=1), ArgUnknown()],
     [TAG_SRC_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "<group_name> tag...", "Add tags to the given group"),
+    "<group> <tag>...", "Add tags to the given group"),
   "remove-tags": (
     RemoveTags, [ArgGroup(min=1, max=1), ArgUnknown()],
     [TAG_SRC_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "<group_name> tag...", "Remove tags from the given group"),
+    "<group> <tag>...", "Remove tags from the given group"),
   "info": (
-    GroupInfo, ARGS_MANY_GROUPS, [], "[<group_name>...]",
+    GroupInfo, ARGS_MANY_GROUPS, [], "[<group>...]",
     "Show group information"),
   "show-ispecs-cmd": (
     ShowCreateCommand, ARGS_MANY_GROUPS, [INCLUDEDEFAULTS_OPT],
-    "[--include-defaults] [<group_name>...]",
+    "[--include-defaults] [<group>...]",
     "Show the command line to re-create a group"),
   }
 

--- a/lib/client/gnt_instance.py
+++ b/lib/client/gnt_instance.py
@@ -885,7 +885,7 @@ def ConnectToInstanceConsole(opts, args):
 
   del cl
 
-  ((console_data, oper_state), ) = idata
+  (console_data, oper_state) = idata[0]
   if not console_data:
     if oper_state:
       # Instance is running
@@ -1576,7 +1576,7 @@ commands = {
   "add": (
     AddInstance, [ArgHost(min=1, max=1)],
     COMMON_CREATE_OPTS + add_opts,
-    "[...] -t disk-type -n node[:secondary-node] -o os-type <name>",
+    "[...] -t disk-type -n node[:secondary-node] -o os-type <instance-name>",
     "Creates and adds a new instance to the cluster"),
   "batch-create": (
     BatchCreate, [ArgFile(min=1, max=1)],
@@ -1586,14 +1586,15 @@ commands = {
   "console": (
     ConnectToInstanceConsole, ARGS_ONE_INSTANCE,
     [SHOWCMD_OPT, PRIORITY_OPT],
-    "[--show-cmd] <instance>", "Opens a console on the specified instance"),
+    "[--show-cmd] <instance-name>",
+    "Opens a console on the specified instance"),
   "failover": (
     FailoverInstance, ARGS_ONE_INSTANCE,
     [FORCE_OPT, IGNORE_CONSIST_OPT] + SUBMIT_OPTS +
     [SHUTDOWN_TIMEOUT_OPT,
      DRY_RUN_OPT, PRIORITY_OPT, DST_NODE_OPT, IALLOCATOR_OPT,
      IGNORE_IPOLICY_OPT, CLEANUP_OPT],
-    "[-f] <instance>", "Stops the instance, changes its primary node and"
+    "[-f] <instance-name>", "Stops the instance, changes its primary node and"
     " (if it was originally running) starts it on the new node"
     " (the secondary for mirrored instances or any node"
     " for shared storage)."),
@@ -1603,7 +1604,7 @@ commands = {
      PRIORITY_OPT, DST_NODE_OPT, IALLOCATOR_OPT, ALLOW_FAILOVER_OPT,
      IGNORE_IPOLICY_OPT, IGNORE_HVVERSIONS_OPT, NORUNTIME_CHGS_OPT]
     + SUBMIT_OPTS,
-    "[-f] <instance>", "Migrate instance to its secondary node"
+    "[-f] <instance-name>", "Migrate instance to its secondary node"
     " (only for mirrored instances)"),
   "move": (
     MoveInstance, ARGS_ONE_INSTANCE,
@@ -1611,18 +1612,18 @@ commands = {
     [SINGLE_NODE_OPT, COMPRESS_OPT,
      SHUTDOWN_TIMEOUT_OPT, DRY_RUN_OPT, PRIORITY_OPT, IGNORE_CONSIST_OPT,
      IGNORE_IPOLICY_OPT],
-    "[-f] <instance>", "Move instance to an arbitrary node"
+    "[-f] <instance-name>", "Move instance to an arbitrary node"
     " (only for instances of type file and lv)"),
   "info": (
     ShowInstanceConfig, ARGS_MANY_INSTANCES,
     [STATIC_OPT, ALL_OPT, ROMAN_OPT, PRIORITY_OPT],
-    "[-s] {--all | <instance>...}",
+    "[-s] {--all | <instance-name>...}",
     "Show information on the specified instance(s)"),
   "list": (
     ListInstances, ARGS_MANY_INSTANCES,
     [NOHDR_OPT, SEP_OPT, USEUNITS_OPT, FIELDS_OPT, VERBOSE_OPT,
      FORCE_FILTER_OPT],
-    "[<instance>...]",
+    "[<instance-name>...]",
     "Lists the instances and their status. The available fields can be shown"
     " using the \"list-fields\" command (see the man page for details)."
     " The default field list is (in order): %s." %
@@ -1645,19 +1646,19 @@ commands = {
     RemoveInstance, ARGS_ONE_INSTANCE,
     [FORCE_OPT, SHUTDOWN_TIMEOUT_OPT, IGNORE_FAILURES_OPT] + SUBMIT_OPTS
     + [DRY_RUN_OPT, PRIORITY_OPT],
-    "[-f] <instance>", "Shuts down the instance and removes it"),
+    "[-f] <instance-name>", "Shuts down the instance and removes it"),
   "rename": (
     RenameInstance,
     [ArgInstance(min=1, max=1), ArgHost(min=1, max=1)],
     [FORCE_OPT, NOIPCHECK_OPT, NONAMECHECK_OPT] + SUBMIT_OPTS
     + [DRY_RUN_OPT, PRIORITY_OPT],
-    "<instance> <new_name>", "Rename the instance"),
+    "<old-name> <new-name>", "Rename the instance"),
   "replace-disks": (
     ReplaceDisks, ARGS_ONE_INSTANCE,
     [AUTO_REPLACE_OPT, DISKIDX_OPT, IALLOCATOR_OPT, EARLY_RELEASE_OPT,
      NEW_SECONDARY_OPT, ON_PRIMARY_OPT, ON_SECONDARY_OPT] + SUBMIT_OPTS
     + [DRY_RUN_OPT, PRIORITY_OPT, IGNORE_IPOLICY_OPT],
-    "[-s|-p|-a|-n NODE|-I NAME] <instance>",
+    "[-s|-p|-a|-n NODE|-I NAME] <instance-name>",
     "Replaces disks for the instance"),
   "modify": (
     SetInstanceParams, ARGS_ONE_INSTANCE,
@@ -1669,7 +1670,7 @@ commands = {
      NOCONFLICTSCHECK_OPT, NEW_PRIMARY_OPT, HOTPLUG_OPT,
      HOTPLUG_IF_POSSIBLE_OPT, INSTANCE_COMMUNICATION_OPT,
      EXT_PARAMS_OPT, FILESTORE_DRIVER_OPT, FILESTORE_DIR_OPT],
-    "<instance>", "Alters the parameters of an instance"),
+    "<instance-name>", "Alters the parameters of an instance"),
   "shutdown": (
     GenericManyOps("shutdown", _ShutdownInstance), [ArgInstance()],
     [FORCE_OPT, m_node_opt, m_pri_node_opt, m_sec_node_opt, m_clust_opt,
@@ -1696,40 +1697,41 @@ commands = {
   "activate-disks": (
     ActivateDisks, ARGS_ONE_INSTANCE,
     SUBMIT_OPTS + [IGNORE_SIZE_OPT, PRIORITY_OPT, WFSYNC_OPT],
-    "<instance>", "Activate an instance's disks"),
+    "<instance-name>", "Activate an instance's disks"),
   "deactivate-disks": (
     DeactivateDisks, ARGS_ONE_INSTANCE,
     [FORCE_OPT] + SUBMIT_OPTS + [DRY_RUN_OPT, PRIORITY_OPT],
-    "[-f] <instance>", "Deactivate an instance's disks"),
+    "[-f] <instance-name>", "Deactivate an instance's disks"),
   "recreate-disks": (
     RecreateDisks, ARGS_ONE_INSTANCE,
     SUBMIT_OPTS +
     [DISK_OPT, NODE_PLACEMENT_OPT, DRY_RUN_OPT, PRIORITY_OPT,
      IALLOCATOR_OPT],
-    "<instance>", "Recreate an instance's disks"),
+    "<instance-name>", "Recreate an instance's disks"),
   "grow-disk": (
     GrowDisk,
     [ArgInstance(min=1, max=1), ArgUnknown(min=1, max=1),
      ArgUnknown(min=1, max=1)],
     SUBMIT_OPTS +
     [NWSYNC_OPT, DRY_RUN_OPT, PRIORITY_OPT, ABSOLUTE_OPT, IGNORE_IPOLICY_OPT],
-    "<instance> <disk> <size>", "Grow an instance's disk"),
+    "<instance-name> <disk> <size>", "Grow an instance's disk"),
   "change-group": (
     ChangeGroup, ARGS_ONE_INSTANCE,
     [TO_GROUP_OPT, IALLOCATOR_OPT, EARLY_RELEASE_OPT, PRIORITY_OPT]
     + SUBMIT_OPTS,
-    "[-I <iallocator>] [--to <group>]", "Change group of instance"),
+    "[-I <iallocator>] [--to <group>] <instance-name>",
+    "Change group of instance"),
   "list-tags": (
     ListTags, ARGS_ONE_INSTANCE, [],
-    "<instance_name>", "List the tags of the given instance"),
+    "<instance-name>", "List the tags of the given instance"),
   "add-tags": (
     AddTags, [ArgInstance(min=1, max=1), ArgUnknown()],
     [TAG_SRC_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "<instance_name> tag...", "Add tags to the given instance"),
+    "<instance-name> <tag>...", "Add tags to the given instance"),
   "remove-tags": (
     RemoveTags, [ArgInstance(min=1, max=1), ArgUnknown()],
     [TAG_SRC_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "<instance_name> tag...", "Remove tags from given instance"),
+    "<instance-name> <tag>...", "Remove tags from given instance"),
   }
 
 #: dictionary with aliases for commands

--- a/lib/client/gnt_job.py
+++ b/lib/client/gnt_job.py
@@ -195,7 +195,7 @@ def AutoArchiveJobs(opts, args):
 
 
 def _MultiJobAction(opts, args, cl, stdout_fn, ask_fn, question, action_fn):
-  """Applies a function to multipe jobs.
+  """Applies a function to multiple jobs.
 
   @param opts: Command line options
   @type args: list
@@ -527,7 +527,7 @@ commands = {
     ListJobs, [ArgJobId()],
     [NOHDR_OPT, SEP_OPT, FIELDS_OPT, VERBOSE_OPT, FORCE_FILTER_OPT,
      _PENDING_OPT, _RUNNING_OPT, _ERROR_OPT, _FINISHED_OPT, _ARCHIVED_OPT],
-    "[job_id ...]",
+    "[<job-id>...]",
     "Lists the jobs and their status. The available fields can be shown"
     " using the \"list-fields\" command (see the man page for details)."
     " The default field list is (in order): %s." %
@@ -535,11 +535,11 @@ commands = {
   "list-fields": (
     ListJobFields, [ArgUnknown()],
     [NOHDR_OPT, SEP_OPT],
-    "[fields...]",
+    "[<fields>...]",
     "Lists all available fields for jobs"),
   "archive": (
     ArchiveJobs, [ArgJobId(min=1)], [],
-    "<job-id> [<job-id> ...]", "Archive specified jobs"),
+    "<job-id> [<job-id>...]", "Archive specified jobs"),
   "autoarchive": (
     AutoArchiveJobs,
     [ArgSuggest(min=1, max=1, choices=["1d", "1w", "4w", "all"])],
@@ -550,11 +550,11 @@ commands = {
     [FORCE_OPT, _KILL_OPT, _PENDING_OPT, _QUEUED_OPT, _WAITING_OPT,
      _YES_DOIT_OPT],
     "{[--force] [--kill --yes-do-it] {--pending | --queued | --waiting} |"
-    " <job-id> [<job-id> ...]}",
+    " <job-id> [<job-id>...]}",
     "Cancel jobs"),
   "info": (
     ShowJobs, [ArgJobId(min=1)], [],
-    "<job-id> [<job-id> ...]",
+    "<job-id> [<job-id>...]",
     "Show detailed information about the specified jobs"),
   "wait": (
     WaitJob, [ArgJobId(min=1, max=1)], [],
@@ -566,7 +566,7 @@ commands = {
     ChangePriority, [ArgJobId()],
     [PRIORITY_OPT, FORCE_OPT, _PENDING_OPT, _QUEUED_OPT, _WAITING_OPT],
     "--priority <priority> {[--force] {--pending | --queued | --waiting} |"
-    " <job-id> [<job-id> ...]}",
+    " <job-id> [<job-id>...]}",
     "Change the priority of jobs"),
   }
 

--- a/lib/client/gnt_network.py
+++ b/lib/client/gnt_network.py
@@ -265,10 +265,8 @@ def ShowNetworkConfig(_, args):
     if instances:
       ToStdout("  used by %d instances:", len(instances))
       for name in instances:
-        ((ips, networks), ) = cl.QueryInstances([name],
-                                                ["nic.ips", "nic.networks"],
-                                                use_locking=False)
-
+        (ips, networks) = cl.QueryInstances([name], ["nic.ips", "nic.networks"],
+                                            use_locking=False)[0]
         l = lambda value: ", ".join(str(idx) + ":" + str(ip)
                                     for idx, (ip, net) in enumerate(value)
                                       if net == uuid)
@@ -330,57 +328,57 @@ commands = {
     [DRY_RUN_OPT, NETWORK_OPT, GATEWAY_OPT, ADD_RESERVED_IPS_OPT,
      MAC_PREFIX_OPT, NETWORK6_OPT, GATEWAY6_OPT,
      NOCONFLICTSCHECK_OPT, TAG_ADD_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "<network_name>", "Add a new IP network to the cluster"),
+    "<network-name>", "Add a new IP network to the cluster"),
   "list": (
     ListNetworks, ARGS_MANY_NETWORKS,
     [NOHDR_OPT, SEP_OPT, FIELDS_OPT, VERBOSE_OPT],
-    "[<network_id>...]",
+    "[<network-name>...]",
     "Lists the IP networks in the cluster. The available fields can be shown"
     " using the \"list-fields\" command (see the man page for details)."
     " The default list is (in order): %s." % utils.CommaJoin(_LIST_DEF_FIELDS)),
   "list-fields": (
-    ListNetworkFields, [ArgUnknown()], [NOHDR_OPT, SEP_OPT], "[fields...]",
+    ListNetworkFields, [ArgUnknown()], [NOHDR_OPT, SEP_OPT], "[<fields>...]",
     "Lists all available fields for networks"),
   "info": (
     ShowNetworkConfig, ARGS_MANY_NETWORKS, [],
-    "[<network_name>...]", "Show information about the network(s)"),
+    "[<network>...]", "Show information about the network(s)"),
   "modify": (
     SetNetworkParams, ARGS_ONE_NETWORK,
     [DRY_RUN_OPT] + SUBMIT_OPTS +
     [ADD_RESERVED_IPS_OPT,
      REMOVE_RESERVED_IPS_OPT, GATEWAY_OPT, MAC_PREFIX_OPT, NETWORK6_OPT,
      GATEWAY6_OPT, PRIORITY_OPT],
-    "<network_name>", "Alters the parameters of a network"),
+    "<network>", "Alters the parameters of a network"),
   "connect": (
     ConnectNetwork,
     [ArgNetwork(min=1, max=1),
      ArgGroup()],
     [NOCONFLICTSCHECK_OPT, PRIORITY_OPT, NIC_PARAMS_OPT],
-    "<network_name> [<node_group>...]",
+    "<network> [<group>...]",
     "Map a given network to the specified node group"
     " with given mode and link (netparams)"),
   "disconnect": (
     DisconnectNetwork,
     [ArgNetwork(min=1, max=1), ArgGroup()],
     [PRIORITY_OPT],
-    "<network_name> [<node_group>...]",
+    "<network> [<group>...]",
     "Unmap a given network from a specified node group"),
   "remove": (
     RemoveNetwork, ARGS_ONE_NETWORK,
     [FORCE_OPT, DRY_RUN_OPT] + SUBMIT_OPTS + [PRIORITY_OPT],
-    "[--dry-run] <network_id>",
+    "[--dry-run] <network>",
     "Remove an (empty) network from the cluster"),
   "list-tags": (
     ListTags, ARGS_ONE_NETWORK, [],
-    "<network_name>", "List the tags of the given network"),
+    "<network>", "List the tags of the given network"),
   "add-tags": (
     AddTags, [ArgNetwork(min=1, max=1), ArgUnknown()],
     [TAG_SRC_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "<network_name> tag...", "Add tags to the given network"),
+    "<network> <tag>...", "Add tags to the given network"),
   "remove-tags": (
     RemoveTags, [ArgNetwork(min=1, max=1), ArgUnknown()],
     [TAG_SRC_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "<network_name> tag...", "Remove tags from given network"),
+    "<network> <tag>...", "Remove tags from given network"),
 }
 
 

--- a/lib/client/gnt_node.py
+++ b/lib/client/gnt_node.py
@@ -1161,7 +1161,7 @@ commands = {
      CAPAB_MASTER_OPT, CAPAB_VM_OPT, NODE_PARAMS_OPT, HV_STATE_OPT,
      DISK_STATE_OPT],
     "[-s ip] [--readd] [--no-ssh-key-check] [--force-join]"
-    " [--no-node-setup] [--verbose] [--network] <node_name>",
+    " [--no-node-setup] [--verbose] [--network] <node-name>",
     "Add a node to the cluster"),
   "evacuate": (
     EvacuateNode, ARGS_ONE_NODE,
@@ -1186,12 +1186,12 @@ commands = {
     " (only for instances of type drbd)"),
   "info": (
     ShowNodeConfig, ARGS_MANY_NODES, [],
-    "[<node_name>...]", "Show information about the node(s)"),
+    "[<node>...]", "Show information about the node(s)"),
   "list": (
     ListNodes, ARGS_MANY_NODES,
     [NOHDR_OPT, SEP_OPT, USEUNITS_OPT, FIELDS_OPT, VERBOSE_OPT,
      FORCE_FILTER_OPT],
-    "[nodes...]",
+    "[<node-name>...]",
     "Lists the nodes in the cluster. The available fields can be shown using"
     " the \"list-fields\" command (see the man page for details)."
     " The default field list is (in order): %s." %
@@ -1208,11 +1208,11 @@ commands = {
      CAPAB_MASTER_OPT, CAPAB_VM_OPT, SECONDARY_IP_OPT,
      AUTO_PROMOTE_OPT, DRY_RUN_OPT, PRIORITY_OPT, NODE_PARAMS_OPT,
      NODE_POWERED_OPT, HV_STATE_OPT, DISK_STATE_OPT],
-    "<node_name>", "Alters the parameters of a node"),
+    "<node-name>", "Alters the parameters of a node"),
   "powercycle": (
     PowercycleNode, ARGS_ONE_NODE,
     [FORCE_OPT, CONFIRM_OPT, DRY_RUN_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "<node_name>", "Tries to forcefully powercycle a node"),
+    "<node-name>", "Tries to forcefully powercycle a node"),
   "power": (
     PowerNode,
     [ArgChoice(min=1, max=1, choices=_LIST_POWER_COMMANDS),
@@ -1221,20 +1221,20 @@ commands = {
     [AUTO_PROMOTE_OPT, PRIORITY_OPT,
      IGNORE_STATUS_OPT, FORCE_OPT, NOHDR_OPT, SEP_OPT, OOB_TIMEOUT_OPT,
      POWER_DELAY_OPT],
-    "on|off|cycle|status [nodes...]",
+    "on|off|cycle|status [<node-name>...]",
     "Change power state of node by calling out-of-band helper."),
   "remove": (
     RemoveNode, ARGS_ONE_NODE, [DRY_RUN_OPT, PRIORITY_OPT],
-    "<node_name>", "Removes a node from the cluster"),
+    "<node-name>", "Removes a node from the cluster"),
   "volumes": (
     ListVolumes, [ArgNode()],
     [NOHDR_OPT, SEP_OPT, USEUNITS_OPT, FIELDS_OPT, PRIORITY_OPT],
-    "[<node_name>...]", "List logical volumes on node(s)"),
+    "[<node-name>...]", "List logical volumes on node(s)"),
   "list-storage": (
     ListStorage, ARGS_MANY_NODES,
     [NOHDR_OPT, SEP_OPT, USEUNITS_OPT, FIELDS_OPT, _STORAGE_TYPE_OPT,
      PRIORITY_OPT],
-    "[<node_name>...]", "List physical volumes on node(s). The available"
+    "[<node-name>...]", "List physical volumes on node(s). The available"
     " fields are (see the man page for details): %s." %
     (utils.CommaJoin(_LIST_STOR_HEADERS))),
   "modify-storage": (
@@ -1243,38 +1243,39 @@ commands = {
      ArgChoice(min=1, max=1, choices=_MODIFIABLE_STORAGE_TYPES),
      ArgFile(min=1, max=1)],
     [ALLOCATABLE_OPT, DRY_RUN_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "<node_name> <storage_type> <name>", "Modify storage volume on a node"),
+    "<node-name> <storage-type> <volume-name>",
+    "Modify storage volume on a node"),
   "repair-storage": (
     RepairStorage,
     [ArgNode(min=1, max=1),
      ArgChoice(min=1, max=1, choices=_REPAIRABLE_STORAGE_TYPES),
      ArgFile(min=1, max=1)],
     [IGNORE_CONSIST_OPT, DRY_RUN_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "<node_name> <storage_type> <name>",
+    "<node-name> <storage-type> <volume-name>",
     "Repairs a storage volume on a node"),
   "list-tags": (
     ListTags, ARGS_ONE_NODE, [],
-    "<node_name>", "List the tags of the given node"),
+    "<node-name>", "List the tags of the given node"),
   "add-tags": (
     AddTags, [ArgNode(min=1, max=1), ArgUnknown()],
     [TAG_SRC_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "<node_name> tag...", "Add tags to the given node"),
+    "<node-name> <tag>...", "Add tags to the given node"),
   "remove-tags": (
     RemoveTags, [ArgNode(min=1, max=1), ArgUnknown()],
     [TAG_SRC_OPT, PRIORITY_OPT] + SUBMIT_OPTS,
-    "<node_name> tag...", "Remove tags from the given node"),
+    "<node-name> <tag>...", "Remove tags from the given node"),
   "health": (
     Health, ARGS_MANY_NODES,
     [NOHDR_OPT, SEP_OPT, PRIORITY_OPT, OOB_TIMEOUT_OPT],
-    "[<node_name>...]", "List health of node(s) using out-of-band"),
+    "[<node-name>...]", "List health of node(s) using out-of-band"),
   "list-drbd": (
     ListDrbd, ARGS_ONE_NODE,
     [NOHDR_OPT, SEP_OPT],
-    "[<node_name>]", "Query the list of used DRBD minors on the given node"),
+    "<node>", "Query the list of used DRBD minors on the given node"),
   "restricted-command": (
     RestrictedCommand, [ArgUnknown(min=1, max=1)] + ARGS_MANY_NODES,
     [SYNC_OPT, PRIORITY_OPT] + SUBMIT_OPTS + [SHOW_MACHINE_OPT, NODEGROUP_OPT],
-    "<command> <node_name> [<node_name>...]",
+    "<command> <node-name>...",
     "Executes a restricted command on node(s)"),
   }
 

--- a/lib/cmdlib/instance_utils.py
+++ b/lib/cmdlib/instance_utils.py
@@ -335,6 +335,11 @@ def RemoveDisks(lu, instance, disks=None,
     disks = all_disks
 
   anno_disks = AnnotateDiskParams(instance, disks, lu.cfg)
+
+  uuid_idx_map = {}
+  for (idx, device) in enumerate(all_disks):
+    uuid_idx_map[device.uuid] = idx
+
   for (idx, device) in enumerate(anno_disks):
     if target_node_uuid:
       edata = [(target_node_uuid, device)]
@@ -344,7 +349,7 @@ def RemoveDisks(lu, instance, disks=None,
       result = lu.rpc.call_blockdev_remove(node_uuid, (disk, instance))
       if result.fail_msg:
         lu.LogWarning("Could not remove disk %s on node %s,"
-                      " continuing anyway: %s", idx,
+                      " continuing anyway: %s", uuid_idx_map.get(device.uuid),
                       lu.cfg.GetNodeName(node_uuid), result.fail_msg)
         if not (result.offline and node_uuid != instance.primary_node):
           all_result = False

--- a/lib/masterd/instance.py
+++ b/lib/masterd/instance.py
@@ -1220,6 +1220,7 @@ class ExportInstanceHelper(object):
         else:
           dev_type = constants.DT_PLAIN
         disk_params = constants.DISK_LD_DEFAULTS[dev_type].copy()
+        disk_params.update(disk.params)
         new_dev = objects.Disk(dev_type=dev_type, size=disk.size,
                                logical_id=disk_id, iv_name=disk.iv_name,
                                params=disk_params)

--- a/lib/rapi/rlib2.py
+++ b/lib/rapi/rlib2.py
@@ -1575,8 +1575,9 @@ class R_2_instances_name_console(baserlib.ResourceBase):
     instance_name = self.items[0]
     client = self.GetClient()
 
-    ((console, oper_state), ) = \
-        client.QueryInstances([instance_name], ["console", "oper_state"], False)
+    (console, oper_state) = \
+      client.QueryInstances([instance_name], ["console", "oper_state"],
+                            False)[0]
 
     if not oper_state:
       raise http.HttpServiceUnavailable("Instance console unavailable")

--- a/lib/tools/burnin.py
+++ b/lib/tools/burnin.py
@@ -803,7 +803,7 @@ class Burner(JobHandler):
     for pnode, snode, enode, instance in mytor:
       Log("instance %s", instance, indent=1)
       # read the full name of the instance
-      ((full_name, ), ) = qcl.QueryInstances([instance], ["name"], False)
+      (full_name, ) = qcl.QueryInstances([instance], ["name"], False)[0]
 
       if self.opts.iallocator:
         pnode = snode = None

--- a/man/gnt-backup.rst
+++ b/man/gnt-backup.rst
@@ -24,13 +24,13 @@ COMMANDS
 EXPORT
 ~~~~~~
 
-| **export** {-n *node*}
+| **export** {-n *node-name*}
 | [\--shutdown-timeout=*N*] [\--noshutdown] [\--remove-instance]
 | [\--ignore-remove-failures] [\--submit] [\--print-jobid]
 | [\--transport-compression=*compression-mode*]
 | [\--zero-free-space] [\--zeroing-timeout-fixed]
 | [\--zeroing-timeout-per-mib] [\--long-sleep]
-| {*instance*}
+| {*instance-name*}
 
 Exports an instance to the target node. All the instance data and
 its configuration will be exported under the
@@ -98,10 +98,10 @@ IMPORT
 | [\--identify-defaults]
 | [\--ignore-ipolicy]
 | [\--submit] [\--print-jobid]
-| {*instance*}
+| {*instance-name*}
 
 Imports a new instance from an export residing on *source-node* in
-*source-dir*. *instance* must be in DNS and resolve to a IP in the
+*source-dir*. *instance-name* must be in DNS and resolve to a IP in the
 same network as the nodes in the cluster. If the source node and
 directory are not passed, the last backup in the cluster is used,
 as visible with the **list** command.
@@ -292,7 +292,7 @@ Lists available fields for exports.
 REMOVE
 ~~~~~~
 
-**remove** {instance_name}
+**remove** {*instance-name*}
 
 Removes the backup for the given instance name, if any. If the backup
 was for a deleted instance, it is needed to pass the FQDN of the

--- a/man/gnt-cluster.rst
+++ b/man/gnt-cluster.rst
@@ -30,7 +30,7 @@ Activates the master IP on the master node.
 COMMAND
 ~~~~~~~
 
-**command** [-n *node*] [-g *group*] [-M] {*command*}
+**command** [-n *node-name*] [-g *group*] [-M] {*command*}
 
 Executes a command on all nodes. This command is designed for simple
 usage. For more complex use cases the commands **dsh**\(1) or **cssh**\(1)
@@ -72,7 +72,7 @@ and the command which will be executed will be ``ls -l /etc``.
 COPYFILE
 ~~~~~~~~
 
-| **copyfile** [\--use-replication-network] [-n *node*] [-g *group*]
+| **copyfile** [\--use-replication-network] [-n *node-name*] [-g *group*]
 | {*file*}
 
 Copies a file to all or to some nodes. The argument specifies the
@@ -208,14 +208,14 @@ INIT
 | [\--user-shutdown {yes \| no}]
 | [\--ssh-key-type *type*]
 | [\--ssh-key-bits *bits*]
-| {*clustername*}
+| {*cluster-name*}
 
 This commands is only run once initially on the first node of the
 cluster. It will initialize the cluster configuration, setup the
 ssh-keys, start the daemons on the master node, etc. in order to have
 a working one-node cluster.
 
-Note that the *clustername* is not any random name. It has to be
+Note that the *cluster-name* is not any random name. It has to be
 resolvable to an IP address using DNS, and it is best if you give the
 fully-qualified domain name. This hostname must resolve to an IP
 address reserved exclusively for this purpose, i.e. not already in
@@ -870,7 +870,7 @@ options.
 RENAME
 ~~~~~~
 
-**rename** [-f] {*name*}
+**rename** [-f] {*new-name*}
 
 Renames the cluster and in the process updates the master IP
 address to the one the new name resolves to. At least one of either
@@ -941,7 +941,7 @@ in the ``init`` option description.
 REPAIR-DISK-SIZES
 ~~~~~~~~~~~~~~~~~
 
-**repair-disk-sizes** [instance...]
+**repair-disk-sizes** [instance-name...]
 
 This command checks that the recorded size of the given instance's
 disks matches the actual size and updates any mismatches found.

--- a/man/gnt-debug.rst
+++ b/man/gnt-debug.rst
@@ -22,20 +22,20 @@ COMMANDS
 IALLOCATOR
 ~~~~~~~~~~
 
-**iallocator** [\--debug] [\--dir *DIRECTION*] {\--algorithm
-*ALLOCATOR* } [\--mode *MODE*] [\--mem *MEMORY*] [\--disks *DISKS*]
-[\--disk-template *TEMPLATE*] [\--nics *NICS*] [\--os-type *OS*]
-[\--vcpus *VCPUS*] [\--tags *TAGS*] {*instance*}
+**iallocator** [\--debug] [\--dir *direction*] {\--algorithm
+*allocator* } [\--mode *mode*] [\--mem *memory*] [\--disks *diskS*]
+[\--disk-template *template*] [\--nics *nics*] [\--os-type *OS*]
+[\--vcpus *vcpus*] [\--tags *tags*] {*instance-name*}
 
 Executes a test run of the *iallocator* framework.
 
 The command will build input for a given iallocator script (named
 with the ``--algorithm`` option), and either show this input data
-(if *DIRECTION* is ``in``) or run the iallocator script and show its
-output (if *DIRECTION* is ``out``).
+(if *direction* is ``in``) or run the iallocator script and show its
+output (if *direction* is ``out``).
 
-If the *MODE* is ``allocate``, then an instance definition is built
-from the other arguments and sent to the script, otherwise (*MODE* is
+If the *mode* is ``allocate``, then an instance definition is built
+from the other arguments and sent to the script, otherwise (*mode* is
 ``relocate``) an existing instance name must be passed as the first
 argument.
 
@@ -46,7 +46,7 @@ this framework, see the HTML or PDF documentation.
 DELAY
 ~~~~~
 
-**delay** [\--debug] [\--no-master] [\--interruptible] [-n *NODE*...]
+**delay** [\--debug] [\--no-master] [\--interruptible] [-n *node-name*...]
 {*duration*}
 
 Run a test opcode (a sleep) on the master and on selected nodes
@@ -68,8 +68,8 @@ number.
 SUBMIT-JOB
 ~~~~~~~~~~
 
-**submit-job** [\--verbose] [\--timing-stats] [\--job-repeat *N*]
-[\--op-repeat *N*] [\--each] {opcodes_file...}
+**submit-job** [\--verbose] [\--timing-stats] [\--job-repeat *n*]
+[\--op-repeat *n*] [\--each] {opcodes_file...}
 
 This command builds a list of opcodes from files in JSON format and
 submits a job per file to the master daemon. It can be used to test
@@ -109,8 +109,8 @@ Tests secret os parameter transmission.
 LOCKS
 ~~~~~
 
-| **locks** [\--no-headers] [\--separator=*SEPARATOR*] [-v]
-| [-o *[+]FIELD,...*] [\--interval=*SECONDS*]
+| **locks** [\--no-headers] [\--separator=*separator*] [-v]
+| [-o *[+]field,...*] [\--interval=*seconds*]
 
 Shows a list of locks in the master daemon.
 
@@ -159,7 +159,7 @@ printed to the console.
 
 A request to clean up all stale locks is sent to WConfd.
 
-| **wconfd** listlocks *jid*
+| **wconfd** listlocks *job-id*
 
 A request to list the locks owned by the given job id is
 sent to WConfd and the answer is displayed.

--- a/man/gnt-filter.rst
+++ b/man/gnt-filter.rst
@@ -91,9 +91,9 @@ ADD
 ~~~
 
 | **add**
-| [\--priority=*PRIORITY*]
-| [\--predicates=*PREDICATES*]
-| [\--action=*ACTION*]
+| [\--priority=*priority*]
+| [\--predicates=*predicates*]
+| [\--action=*action*]
 
 Creates a new filter rule. A UUID is automatically assigned.
 
@@ -118,11 +118,11 @@ REPLACE
 ~~~~~~~
 
 | **replace**
-| [\--priority=*PRIORITY*]
-| [\--predicates=*PREDICATES*]
-| [\--action=*ACTION*]
-| [\--reason=*REASON*]
-| {*filter_uuid*}
+| [\--priority=*priority*]
+| [\--predicates=*predicates*]
+| [\--action=*action*]
+| [\--reason=*reason*]
+| {*filter-uuid*}
 
 Replaces a filter rule, or creates one if it doesn't already exist.
 
@@ -136,15 +136,15 @@ options.
 DELETE
 ~~~~~~
 
-| **delete** {*filter_uuid*}
+| **delete** {*filter-uuid*}
 
 Deletes the indicated filter rule.
 
 LIST
 ~~~~
 
-| **list** [\--no-headers] [\--separator=*SEPARATOR*] [-v]
-| [-o *[+]FIELD,...*] [filter_uuid...]
+| **list** [\--no-headers] [\--separator=*separator*] [-v]
+| [-o *[+]field,...*] [filter-uuid...]
 
 Lists all existing filters in the cluster. If no filter UUIDs are given,
 then all filters are included. Otherwise, only the given filters will be
@@ -177,7 +177,7 @@ List available fields for filters.
 INFO
 ~~~~
 
-| **info** [filter_uuid...]
+| **info** [filter-uuid...]
 
 Displays information about a given filter.
 

--- a/man/gnt-group.rst
+++ b/man/gnt-group.rst
@@ -33,7 +33,7 @@ ADD
 | [\--ipolicy-vcpu-ratio *ratio*]
 | [\--disk-state *diskstate*]
 | [\--hypervisor-state *hvstate*]
-| {*group*}
+| {*group-name*}
 
 Creates a new group with the given name. The node group will be
 initially empty; to add nodes to it, use ``gnt-group assign-nodes``.
@@ -76,7 +76,7 @@ ASSIGN-NODES
 
 | **assign-nodes**
 | [\--force] [\--submit] [\--print-jobid]
-| {*group*} {*node*...}
+| {*group-name*} {*node-name*...}
 
 Assigns one or more nodes to the specified group, moving them from their
 original group (or groups).
@@ -136,7 +136,7 @@ LIST
 ~~~~
 
 | **list** [\--no-headers] [\--separator=*SEPARATOR*] [-v]
-| [-o *[+]FIELD,...*] [\--filter] [group...]
+| [-o *[+]FIELD,...*] [\--filter] [*group-name*...]
 
 Lists all existing node groups in the cluster.
 
@@ -188,7 +188,7 @@ EVACUATE
 ~~~~~~~~
 
 | **evacuate** [\--submit] [\--print-jobid] [\--sequential] [\--force-failover]
-| [\--iallocator *NAME*] [\--to *GROUP*...] {*group*}
+| [\--iallocator *name*] [\--to *group*...] {*source-group*}
 
 This command will move all instances out of the given node group.
 Instances are placed in a new group by an iallocator, either given on
@@ -219,7 +219,7 @@ Tags
 ADD-TAGS
 ^^^^^^^^
 
-**add-tags** [\--from *file*] {*groupname*} {*tag*...}
+**add-tags** [\--from *file*] {*group*} {*tag*...}
 
 Add tags to the given node group. If any of the tags contains invalid
 characters, the entire operation will abort.
@@ -233,14 +233,14 @@ stdin.
 LIST-TAGS
 ^^^^^^^^^
 
-**list-tags** {*groupname*}
+**list-tags** {*group*}
 
 List the tags of the given node group.
 
 REMOVE-TAGS
 ^^^^^^^^^^^
 
-**remove-tags** [\--from *file*] {*groupname*} {*tag*...}
+**remove-tags** [\--from *file*] {*group*} {*tag*...}
 
 Remove tags from the given node group. If any of the tags are not
 existing on the node, the entire operation will abort.

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -47,9 +47,9 @@ ADD
 | [\--ignore-ipolicy]
 | [\--no-wait-for-sync]
 | [{-c|\--communication=yes|no}]
-| {*instance*}
+| {*instance-name*}
 
-Creates a new instance on the specified host. The *instance* argument
+Creates a new instance on the specified host. The *instance-name* argument
 must be in DNS, but depending on the bridge/routing setup, need not be
 in the same network as the nodes in the cluster.
 
@@ -1258,7 +1258,7 @@ REMOVE
 ^^^^^^
 
 | **remove** [\--ignore-failures] [\--shutdown-timeout=*N*] [\--submit]
-| [\--print-jobid] [\--force] {*instance*}
+| [\--print-jobid] [\--force] {*instance-name*}
 
 Remove an instance. This will remove all data from the instance and
 there is *no way back*. If you are not sure if you use an instance
@@ -1290,7 +1290,7 @@ LIST
 
 | **list**
 | [\--no-headers] [\--separator=*SEPARATOR*] [\--units=*UNITS*] [-v]
-| [{-o|\--output} *[+]FIELD,...*] [\--filter] [instance...]
+| [{-o|\--output} *[+]FIELD,...*] [\--filter] [*instance-name*...]
 
 Shows the currently configured instances with memory usage, disk
 usage, the node they are running on, and their run status.
@@ -1350,7 +1350,7 @@ Lists available fields for instances.
 INFO
 ^^^^
 
-**info** [-s \| \--static] [\--roman] {\--all \| *instance*}
+**info** [-s \| \--static] [\--roman] {\--all \| *instance-name*}
 
 Show detailed information about the given instance(s). This is
 different from **list** as it shows detailed data about the instance's
@@ -1399,7 +1399,7 @@ MODIFY
 | [\--ignore-ipolicy]
 | [\--hotplug]
 | [\--hotplug-if-possible]
-| {*instance*}
+| {*instance-name*}
 
 Modifies the memory size, number of vcpus, ip address, MAC address
 and/or NIC parameters for an instance. It can also add and remove
@@ -1556,10 +1556,9 @@ options.
 
 RENAME
 ^^^^^^
-
 | **rename** [\--no-ip-check] [\--no-name-check] [\--force]
 | [\--submit] [\--print-jobid]
-| {*instance*} {*new\_name*}
+| {*instance*} {*new_name*}
 
 Renames the given instance. The instance must be stopped when running
 this command. The requirements for the new name are the same as for
@@ -1598,7 +1597,7 @@ STARTUP
 | [{-H|\--hypervisor-parameters} ``key=value...``]
 | [{-B|\--backend-parameters} ``key=value...``]
 | [\--submit] [\--print-jobid] [\--paused]
-| {*name*...}
+| {*instance*...}
 
 Starts one or more instances, depending on the following options.  The
 four available modes are:
@@ -1696,7 +1695,7 @@ SHUTDOWN
 | [\--instance \| \--node \| \--primary \| \--secondary \| \--all \|
 | \--tags \| \--node-tags \| \--pri-node-tags \| \--sec-node-tags]
 | [\--submit] [\--print-jobid]
-| {*name*...}
+| {*instance*...}
 
 Stops one or more instances. If the instance cannot be cleanly stopped
 during a hardcoded interval (currently 2 minutes), it will forcibly
@@ -1750,7 +1749,7 @@ REBOOT
 | [\--instance \| \--node \| \--primary \| \--secondary \| \--all \|
 | \--tags \| \--node-tags \| \--pri-node-tags \| \--sec-node-tags]
 | [\--submit] [\--print-jobid]
-| [*name*...]
+| [*instance*...]
 
 Reboots one or more instances. The type of reboot depends on the value
 of ``-t (--type)``. A soft reboot does a hypervisor reboot, a hard reboot
@@ -1814,17 +1813,18 @@ REPLACE-DISKS
 ^^^^^^^^^^^^^
 
 | **replace-disks** [\--submit] [\--print-jobid] [\--early-release]
-| [\--ignore-ipolicy] {-p} [\--disks *idx*] {*instance*}
+| [\--ignore-ipolicy] {-p} [\--disks *idx*] {*instance-name*}
 
 | **replace-disks** [\--submit] [\--print-jobid] [\--early-release]
-| [\--ignore-ipolicy] {-s} [\--disks *idx*] {*instance*}
+| [\--ignore-ipolicy] {-s} [\--disks *idx*] {*instance-name*}
 
 | **replace-disks** [\--submit] [\--print-jobid] [\--early-release]
 | [\--ignore-ipolicy]
-| {{-I\|\--iallocator} *name* \| {{-n|\--new-secondary} *node* } {*instance*}
+| {{-I\|\--iallocator} *name* \| {{-n|\--new-secondary} *node* }
+| {*instance-name*}
 
 | **replace-disks** [\--submit] [\--print-jobid] [\--early-release]
-| [\--ignore-ipolicy] {-a\|\--auto} {*instance*}
+| [\--ignore-ipolicy] {-a\|\--auto} {*instance-name*}
 
 This command is a generalized form for replacing disks. It is
 currently only valid for the mirrored (DRBD) disk template.
@@ -1873,7 +1873,7 @@ ACTIVATE-DISKS
 ^^^^^^^^^^^^^^
 
 | **activate-disks** [\--submit] [\--print-jobid] [\--ignore-size]
-| [\--wait-for-sync] {*instance*}
+| [\--wait-for-sync] {*instance-name*}
 
 Activates the block devices of the given instance. If successful, the
 command will show the location and name of the block devices::
@@ -1911,7 +1911,7 @@ options.
 DEACTIVATE-DISKS
 ^^^^^^^^^^^^^^^^
 
-**deactivate-disks** [-f] [\--submit] [\--print-jobid] {*instance*}
+**deactivate-disks** [-f] [\--submit] [\--print-jobid] {*instance-name*}
 
 De-activates the block devices of the given instance. Note that if you
 run this command for an instance with a drbd disk template, while it
@@ -1934,7 +1934,7 @@ GROW-DISK
 
 | **grow-disk** [\--no-wait-for-sync] [\--submit] [\--print-jobid]
 | [\--absolute]
-| {*instance*} {*disk*} {*amount*}
+| {*instance-name*} {*disk*} {*amount*}
 
 Grows an instance's disk. This is only possible for instances having a
 plain, drbd, file, sharedfile, rbd or ext disk template. For the ext
@@ -1993,7 +1993,8 @@ RECREATE-DISKS
 
 | **recreate-disks** [\--submit] [\--print-jobid]
 | [{-n node1:[node2] \| {-I\|\--iallocator *name*}}]
-| [\--disk=*N*[:[size=*VAL*][,spindles=*VAL*][,mode=*ro\|rw*]]] {*instance*}
+| [\--disk=*N*[:[size=*VAL*][,spindles=*VAL*][,mode=*ro\|rw*]]]
+| {*instance-name*}
 
 Recreates all or a subset of disks of the given instance.
 
@@ -2037,7 +2038,7 @@ FAILOVER
 | [{-n|\--target-node} *node* \| {-I|\--iallocator} *name*]
 | [\--cleanup]
 | [\--submit] [\--print-jobid]
-| {*instance*}
+| {*instance-name*}
 
 Failover will stop the instance (if running), change its primary node,
 and if it was originally running it will start it again (on the new
@@ -2098,9 +2099,9 @@ MIGRATE
 | **migrate** [-f] [\--allow-failover] [\--non-live]
 | [\--migration-mode=live\|non-live] [\--ignore-ipolicy] [\--ignore-hvversions]
 | [\--no-runtime-changes] [\--submit] [\--print-jobid]
-| [{-n|\--target-node} *node* \| {-I|\--iallocator} *name*] {*instance*}
+| [{-n|\--target-node} *node* \| {-I|\--iallocator} *name*] {*instance-name*}
 
-| **migrate** [-f] \--cleanup [\--submit] [\--print-jobid] {*instance*}
+| **migrate** [-f] \--cleanup [\--submit] [\--print-jobid] {*instance-name*}
 
 Migrate will move the instance to its secondary node without shutdown.
 As with failover, it works for instances having the drbd disk template
@@ -2196,7 +2197,7 @@ MOVE
 | **move** [-f] [\--ignore-consistency]
 | [-n *node*] [\--compress=*compression-mode*] [\--shutdown-timeout=*N*]
 | [\--submit] [\--print-jobid] [\--ignore-ipolicy]
-| {*instance*}
+| {*instance-name*}
 
 Move will move the instance to an arbitrary node in the cluster. This
 works only for instances having a plain or file disk template.
@@ -2233,7 +2234,7 @@ CHANGE-GROUP
 ^^^^^^^^^^^^
 
 | **change-group** [\--submit] [\--print-jobid]
-| [\--iallocator *NAME*] [\--to *GROUP*...] {*instance*}
+| [\--iallocator *name*] [\--to *group*...] {*instance-name*}
 
 This command moves an instance to another node group. The move is
 calculated by an iallocator, either given on the command line or as a
@@ -2258,7 +2259,7 @@ Tags
 ADD-TAGS
 ^^^^^^^^
 
-**add-tags** [\--from *file*] {*instancename*} {*tag*...}
+**add-tags** [\--from *file*] {*instance-name*} {*tag*...}
 
 Add tags to the given instance. If any of the tags contains invalid
 characters, the entire operation will abort.
@@ -2272,14 +2273,14 @@ as stdin.
 LIST-TAGS
 ^^^^^^^^^
 
-**list-tags** {*instancename*}
+**list-tags** {*instance-name*}
 
 List the tags of the given instance.
 
 REMOVE-TAGS
 ^^^^^^^^^^^
 
-**remove-tags** [\--from *file*] {*instancename*} {*tag*...}
+**remove-tags** [\--from *file*] {*instance-name*} {*tag*...}
 
 Remove tags from the given instance. If any of the tags are not
 existing on the node, the entire operation will abort.

--- a/man/gnt-job.rst
+++ b/man/gnt-job.rst
@@ -23,7 +23,7 @@ COMMANDS
 ARCHIVE
 ~~~~~~~
 
-**archive** {id...}
+**archive** {job-id...}
 
 This command can be used to archive job by their IDs. Only jobs
 that have finished execution (i.e either *success*, *error* or
@@ -60,8 +60,7 @@ CHANGE-PRIORITY
 ~~~~~~~~~~~~~~~
 
 | **change-priority** \--priority {low | normal | high}
-| {[\--force] {\--pending | \--queued | \--waiting} |
-|  *job-id* ...}
+| {[\--force] {\--pending | \--queued | \--waiting} | *job-id*...}
 
 Changes the priority of one or multiple pending jobs. Jobs currently
 running have only the priority of remaining opcodes changed.
@@ -72,7 +71,7 @@ includes both. To skip a confirmation, pass ``--force``.
 INFO
 ~~~~
 
-**info** {*id*...}
+**info** {*job-id*...}
 
 Show detailed information about the given job id(s). If no job id
 is given, all jobs are examined (warning, this is a lot of
@@ -134,17 +133,17 @@ Lists available fields for jobs.
 WAIT
 ~~~~~
 
-**wait** {id}
+**wait** {*job-id*}
 
-Wait for the job by the given *id* to finish; do not produce
+Wait for the job by the given *job-id* to finish; do not produce
 any output.
 
 WATCH
 ~~~~~
 
-**watch** {id}
+**watch** {*job-id*}
 
-This command follows the output of the job by the given *id* and
+This command follows the output of the job by the given *job-id* and
 prints it.
 
 .. vim: set textwidth=72 :

--- a/man/gnt-network.rst
+++ b/man/gnt-network.rst
@@ -34,15 +34,15 @@ ADD
 ~~~
 
 | **add**
-| --network=*NETWORK*
-| [\--gateway=*GATEWAY*]
-| [\--add-reserved-ips=*RESERVEDIPS*]
-| [\--network6=*NETWORK6*]
-| [\--gateway6=*GATEWAY6*]
-| [\--mac-prefix=*MACPREFIX*]
+| --network=*network*
+| [\--gateway=*gateway*]
+| [\--add-reserved-ips=*reserved-ips*]
+| [\--network6=*network6*]
+| [\--gateway6=*gateway6*]
+| [\--mac-prefix=*macprefix*]
 | [\--submit] [\--print-jobid]
 | [\--no-conflicts-check]
-| {*network*}
+| {*network-name*}
 
 Creates a new network with the given name. The network will be unused
 initially. To connect it to a node group, use ``gnt-network connect``.
@@ -74,12 +74,12 @@ MODIFY
 ~~~~~~
 
 | **modify**
-| [\--gateway=*GATEWAY*]
-| [\--add-reserved-ips=*RESERVEDIPS*]
-| [\--remove-reserved-ips=*RESERVEDIPS*]
-| [\--network6=*NETWORK6*]
-| [\--gateway6=*GATEWAY6*]
-| [\--mac-prefix=*MACPREFIX*]
+| [\--gateway=*gateway*]
+| [\--add-reserved-ips=*reserved-ips*]
+| [\--remove-reserved-ips=*reserved-ips*]
+| [\--network6=*network6*]
+| [\--gateway6=*gateway6*]
+| [\--mac-prefix=*macprefix*]
 | [\--submit] [\--print-jobid]
 | {*network*}
 
@@ -104,8 +104,8 @@ See **ganeti**\(7) for a description of ``--submit`` and other common options.
 LIST
 ~~~~
 
-| **list** [\--no-headers] [\--separator=*SEPARATOR*] [-v]
-| [-o *[+]FIELD,...*] [network...]
+| **list** [\--no-headers] [\--separator=*separator*] [-v]
+| [-o *[+]field,...*] [network-name...]
 
 Lists all existing networks in the cluster. If no group names are given,
 then all groups are included. Otherwise, only the named groups will be
@@ -175,7 +175,7 @@ Tags
 ADD-TAGS
 ^^^^^^^^
 
-**add-tags** [\--from *file*] {*networkname*} {*tag*...}
+**add-tags** [\--from *file*] {*network*} {*tag*...}
 
 Add tags to the given network. If any of the tags contains invalid
 characters, the entire operation will abort.
@@ -189,14 +189,14 @@ stdin.
 LIST-TAGS
 ^^^^^^^^^
 
-**list-tags** {*networkname*}
+**list-tags** {*network*}
 
 List the tags of the given network.
 
 REMOVE-TAGS
 ^^^^^^^^^^^
 
-**remove-tags** [\--from *file*] {*networkname*} {*tag*...}
+**remove-tags** [\--from *file*] {*network*} {*tag*...}
 
 Remove tags from the given network. If any of the tags are not existing
 on the network, the entire operation will abort.

--- a/man/gnt-node.rst
+++ b/man/gnt-node.rst
@@ -30,7 +30,7 @@ ADD
 | [\--disk-state *diskstate*]
 | [\--hypervisor-state *hvstate*]
 | [\--no-node-setup]
-| {*nodename*}
+| {*node-name*}
 
 Adds the given node to the cluster.
 
@@ -98,7 +98,7 @@ EVACUATE
 ~~~~~~~~
 
 | **evacuate** [-f] [\--early-release] [\--submit] [\--print-jobid]
-| [{-I|\--iallocator} *NAME* \| {-n|\--new-secondary} *destination\_node*]
+| [{-I|\--iallocator} *name* \| {-n|\--new-secondary} *destination\_node*]
 | [--ignore-soft-errors]
 | [{-p|\--primary-only} \| {-s|\--secondary-only} ]
 |  {*node*}
@@ -202,7 +202,7 @@ LIST
 | [\--no-headers] [\--separator=*SEPARATOR*]
 | [\--units=*UNITS*] [-v] [{-o|\--output} *[+]FIELD,...*]
 | [\--filter]
-| [node...]
+| [*node-name*...]
 
 Lists the nodes in the cluster.
 
@@ -266,7 +266,7 @@ only the given nodes will be listed.
 LIST-DRBD
 ~~~~~~~~~
 
-**list-drbd** [\--no-headers] [\--separator=*SEPARATOR*] node
+**list-drbd** [\--no-headers] [\--separator=*SEPARATOR*] *node*
 
 Lists the mapping of DRBD minors for a given node. This outputs a static
 list of fields (it doesn't accept the ``--output`` option), as follows:
@@ -339,7 +339,7 @@ MODIFY
 | [\--node-powered=``yes|no``]
 | [\--hypervisor-state *hvstate*]
 | [\--disk-state *diskstate*]
-| {*node*}
+| {*node-name*}
 
 This command changes the role of the node. Each options takes
 either a literal yes or no, and only one option should be given as
@@ -383,7 +383,7 @@ Example (setting the node back to online and master candidate)::
 REMOVE
 ~~~~~~
 
-**remove** {*nodename*}
+**remove** {*node-name*}
 
 Removes a node from the cluster. Instances must be removed or
 migrated to another cluster before.
@@ -398,7 +398,7 @@ VOLUMES
 
 | **volumes** [\--no-headers] [\--human-readable]
 | [\--separator=*SEPARATOR*] [{-o|\--output} *FIELDS*]
-| [*node*...]
+| [*node-name*...]
 
 Lists all logical volumes and their physical disks from the node(s)
 provided.
@@ -452,7 +452,7 @@ LIST-STORAGE
 | **list-storage** [\--no-headers] [\--human-readable]
 | [\--separator=*SEPARATOR*] [\--storage-type=*STORAGE\_TYPE*]
 | [{-o|\--output} *FIELDS*]
-| [*node*...]
+| [*node-name*...]
 
 Lists the available storage units and their details for the given
 node(s).
@@ -521,7 +521,7 @@ MODIFY-STORAGE
 ~~~~~~~~~~~~~~
 
 | **modify-storage** [\--allocatable={yes|no}] [\--submit] [\--print-jobid]
-| {*node*} {*storage-type*} {*volume-name*}
+| {*node-name*} {*storage-type*} {*volume-name*}
 
 Modifies storage volumes on a node. Only LVM physical volumes can
 be modified at the moment. They have a storage type of "lvm-pv".
@@ -535,7 +535,7 @@ REPAIR-STORAGE
 ~~~~~~~~~~~~~~
 
 | **repair-storage** [\--ignore-consistency] ]\--submit]
-| {*node*} {*storage-type*} {*volume-name*}
+| {*node-name*} {*storage-type*} {*volume-name*}
 
 Repairs a storage volume on a node. Only LVM volume groups can be
 repaired at this time. They have the storage type "lvm-vg".
@@ -560,7 +560,7 @@ Example::
 POWERCYCLE
 ~~~~~~~~~~
 
-**powercycle** [\--yes] [\--force] [\--submit] [\--print-jobid] {*node*}
+**powercycle** [\--yes] [\--force] [\--submit] [\--print-jobid] {*node-name*}
 
 This command (tries to) forcefully reboot a node. It is a command
 that can be used if the node environment is broken, such that the
@@ -583,7 +583,7 @@ POWER
 ~~~~~
 
 **power** [``--force``] [``--ignore-status``] [``--all``]
-[``--power-delay``] on|off|cycle|status [*nodes*]
+[``--power-delay``] on|off|cycle|status [*node-name*...]
 
 This command calls out to out-of-band management to change the power
 state of given node. With ``status`` you get the power status as reported
@@ -608,15 +608,15 @@ and continue with power off.
 waited between powering on the next node. This is by default 2 seconds
 but can increased if needed with this option.
 
-*nodes* are optional. If not provided it will call out for every node in
-the cluster. Except for the ``off`` and ``cycle`` command where you've
+The list of node names is optional. If not provided it will call out for every
+node in the cluster. Except for the ``off`` and ``cycle`` command where you've
 to explicit use ``--all`` to select all.
 
 
 HEALTH
 ~~~~~~
 
-**health** [*nodes*]
+**health** [*node-name*...]
 
 This command calls out to out-of-band management to ask for the health status
 of all or given nodes. The health contains the node name and then the items
@@ -630,7 +630,7 @@ RESTRICTED-COMMAND
 ~~~~~~~~~~~~~~~~~~
 
 | **restricted-command** [-M] [\--sync]
-| { -g *group* *command* | *command* *nodes*... }
+| { -g *group* *command* | *command* *node-name*... }
 
 Executes a restricted command on the specified nodes. Restricted commands are
 not arbitrary, but must reside in
@@ -660,7 +660,7 @@ Tags
 ADD-TAGS
 ^^^^^^^^
 
-**add-tags** [\--from *file*] {*nodename*} {*tag*...}
+**add-tags** [\--from *file*] {*node-name*} {*tag*...}
 
 Add tags to the given node. If any of the tags contains invalid
 characters, the entire operation will abort.
@@ -674,14 +674,14 @@ interpreted as stdin.
 LIST-TAGS
 ^^^^^^^^^
 
-**list-tags** {*nodename*}
+**list-tags** {*node-name*}
 
 List the tags of the given node.
 
 REMOVE-TAGS
 ^^^^^^^^^^^
 
-**remove-tags** [\--from *file*] {*nodename*} {*tag*...}
+**remove-tags** [\--from *file*] {*node-name*} {*tag*...}
 
 Remove tags from the given node. If any of the tags are not
 existing on the node, the entire operation will abort.

--- a/man/gnt-os.rst
+++ b/man/gnt-os.rst
@@ -46,12 +46,13 @@ are or are not valid.
 INFO
 ~~~~
 
-**info**
+**info** {*OS*}
 
 This command will list detailed information about each OS available
 in the cluster, including its validity status, the supported API
 versions, the supported parameters and variants (if any), and their
-documentation, etc.
+documentation, etc. If an *OS* name is given, then only the specified
+OS details will be shown.
 
 Note that this command besides the information about the given OS(es),
 shows detailed information about the given available/supported OS

--- a/man/mon-collector.rst
+++ b/man/mon-collector.rst
@@ -80,7 +80,7 @@ one:
   The IP address the ConfD daemon is listening on.
 
 -p *port-number*, \--port=*port-number*
-  The port the ConfD deamon is listening on.
+  The port the ConfD daemon is listening on.
 
 LOGICAL VOLUMES
 ~~~~~~~~~~~~~~~
@@ -100,7 +100,7 @@ where the daemon is listening, in case it's not the default one:
   The IP address the ConfD daemon is listening on.
 
 -p *port-number*, \--port=*port-number*
-  The port the ConfD deamon is listening on.
+  The port the ConfD daemon is listening on.
 
 Instead of accessing the live data on the cluster, the tool can also read data
 serialized on files (mainly for testing purposes). Namely:

--- a/src/Ganeti/Confd/Server.hs
+++ b/src/Ganeti/Confd/Server.hs
@@ -175,7 +175,7 @@ buildResponse cdata req@(ConfdRequest { confdRqType = ReqNodeRoleByName }) = do
           clusterSerial . configCluster $ fst cdata)
 
 buildResponse cdata (ConfdRequest { confdRqType = ReqNodePipList }) =
-  -- note: we use foldlWithKey because that's present accross more
+  -- note: we use foldlWithKey because that's present across more
   -- versions of the library
   return (ReplyStatusOk, J.showJSON $
           M.foldlWithKey (\accu _ n -> nodePrimaryIp n:accu) []
@@ -183,7 +183,7 @@ buildResponse cdata (ConfdRequest { confdRqType = ReqNodePipList }) =
           clusterSerial . configCluster $ fst cdata)
 
 buildResponse cdata (ConfdRequest { confdRqType = ReqMcPipList }) =
-  -- note: we use foldlWithKey because that's present accross more
+  -- note: we use foldlWithKey because that's present across more
   -- versions of the library
   return (ReplyStatusOk, J.showJSON $
           M.foldlWithKey (\accu _ n -> if nodeMasterCandidate n

--- a/src/Ganeti/HTools/Cluster.hs
+++ b/src/Ganeti/HTools/Cluster.hs
@@ -964,7 +964,7 @@ getMoves (Table _ initial_il _ initial_plc, Table final_nl _ _ final_plc) =
           (_, cmds) = computeMoves inst inst_name mv np ns
       in (affected, idx, mv, cmds)
   in map plctoMoves . reverse . drop (length initial_plc) $ reverse final_plc
-             
+
 -- | Inner function for splitJobs, that either appends the next job to
 -- the current jobset, or starts a new jobset.
 mergeJobs :: ([JobSet], [Ndx]) -> MoveJob -> ([JobSet], [Ndx])

--- a/src/Ganeti/HTools/Cluster/AllocatePrimitives.hs
+++ b/src/Ganeti/HTools/Cluster/AllocatePrimitives.hs
@@ -75,7 +75,7 @@ allocateOnPair opts stats nl inst new_pdx new_sdx =
   in do
     Instance.instMatchesPolicy inst (Node.iPolicy tgt_p)
       (Node.exclStorage tgt_p)
-    let new_inst = Instance.setBoth (setInstanceLocationScore inst tgt_p tgt_s)
+    let new_inst = Instance.setBoth (setInstanceLocationScore inst tgt_p (Just tgt_s))
                    new_pdx new_sdx
     new_p <- Node.addPriEx force tgt_p new_inst
     new_s <- Node.addSec tgt_s new_inst new_pdx

--- a/src/Ganeti/HTools/Container.hs
+++ b/src/Ganeti/HTools/Container.hs
@@ -49,6 +49,7 @@ module Ganeti.HTools.Container
   , find
   , IntMap.findMax
   , IntMap.member
+  , IntMap.lookup
   -- * Update
   , add
   , addTwo

--- a/src/Ganeti/HTools/Loader.hs
+++ b/src/Ganeti/HTools/Loader.hs
@@ -177,7 +177,7 @@ setMaster node_names node_idx master = do
 setLocationScore :: Node.List -> Instance.Instance -> Instance.Instance
 setLocationScore nl inst =
   let pnode = Container.find (Instance.pNode inst) nl
-      snode = Container.find (Instance.sNode inst) nl
+      snode = Container.lookup (Instance.sNode inst) nl
   in Moves.setInstanceLocationScore inst pnode snode
 
 -- | For each instance, add its index to its primary and secondary nodes.

--- a/src/Ganeti/THH.hs
+++ b/src/Ganeti/THH.hs
@@ -1062,7 +1062,7 @@ buildLens (fnm, fdnm) (rnm, rdnm) nm pfx ar (field, i) = do
 -- be a JSON object, dispatching on the "forthcoming" key.
 buildObjectWithForthcoming ::
   String -- ^ Name of the newly defined type
-  -> String -- ^ base prefix for field names; for the real and fortcoming
+  -> String -- ^ base prefix for field names; for the real and forthcoming
             -- variant, with base prefix will be prefixed with "real"
             -- and forthcoming, respectively.
   -> [Field] -- ^ List of fields in the real version

--- a/src/Ganeti/WConfd/ConfigState.hs
+++ b/src/Ganeti/WConfd/ConfigState.hs
@@ -70,7 +70,7 @@ bumpSerial :: (SerialNoObjectL a, TimeStampObjectL a) => ClockTime -> a -> a
 bumpSerial now = set mTimeL now . over serialL succ
 
 -- | Given two versions of the configuration, determine if its distribution
--- needs to be fully commited before returning the corresponding call to
+-- needs to be fully committed before returning the corresponding call to
 -- WConfD.
 needsFullDist :: ConfigState -> ConfigState -> Bool
 needsFullDist = on (/=) (watched . csConfigData)

--- a/tools/move-instance
+++ b/tools/move-instance
@@ -52,6 +52,7 @@ from ganeti import rapi
 from ganeti import errors
 
 from ganeti.rapi.client import UsesRapiClient
+import ganeti.rapi.client_utils # pylint: disable=W0611
 
 
 SRC_RAPI_PORT_OPT = \


### PR DESCRIPTION
* stable-2.15
  Add test for removing disk on a live instance
  Prohibit disk removal w/o hotplug on live instance
  Fix tuple-unpacking from QueryInstances result
  Fix idx in RemoveDisks warning
  Make man pages more consistent in parameter format
  Re-add 2 imports incorrectly removed during cleanup
  Add status and "version implemented" fields to design docs
  Fix typo in cli_opts.py IGNORE_HVVERSIONS_OPT flag
  Fix coexistence of location tags and non-DRBD instances
  Fix backup export in case of ext disk template
  Fix miscellaneous typos found when reading design docs

Merge conflicts:

  src/Ganeti/HTools/Cluster.hs # removed block, kept 2.16 version
  man/gnt-instance.rst # slash in new_name
  man/gnt-cluster.rst # dash in cluster-name
  lib/client/gnt_cluster.py # angle brackets
  doc/design-shared-storage-redundancy.rst # removed blcok, kept 2.16 version
  doc/design-draft.rst # kept 2.16 specific list

Merge-related fixes:
  Fixes a build error caused by the change of the interface of
    setInstanceLocationScore

Signed-off-by: Rafael Marinheiro <marinheiro@google.com>
Reviewed-by: Viktor Bachraty <vbachraty@google.com>