### PR TITLE
Add cleanup of stale OS hvp data on cluster modify.

### DIFF
--- a/lib/cmdlib/cluster/__init__.py
+++ b/lib/cmdlib/cluster/__init__.py
@@ -1367,6 +1367,12 @@ class LUClusterSetParams(LogicalUnit):
             else:
               self.new_os_hvp[os_name][hv_name].update(hv_dict)
 
+      # Cleanup any OS that has an empty hypervisor parameter list, as we don't
+      # need them in the cluster config anymore.
+      for os_name, hvs in self.new_os_hvp.items():
+        if not hvs:
+          self.new_os_hvp.pop(os_name, None)
+
     # os parameters
     self._BuildOSParams(cluster)
 

--- a/test/py/cmdlib/cluster_unittest.py
+++ b/test/py/cmdlib/cluster_unittest.py
@@ -805,6 +805,22 @@ class TestLUClusterSetParams(CmdlibTestCase):
 
     assert constants.HT_FAKE not in self.cluster.os_hvp["mocked_os"]
 
+  def testRemoveOsFromOsHvpList(self):
+    os_hvp = {
+        "mocked_os_1": {
+            constants.HT_FAKE: {
+                constants.HV_MIGRATION_MODE: constants.HT_MIGRATION_NONLIVE
+            }
+        },
+        "mocked_os_2": {} # This is the one that needs to be removed.
+    }
+
+    op = opcodes.OpClusterSetParams(os_hvp=os_hvp)
+    self.ExecOpCode(op)
+
+    assert (constants.HT_FAKE in self.cluster.os_hvp["mocked_os_1"] and
+            "mocked_os_2" not in self.cluster.os_hvp)
+
   def testDefaultOsHvp(self):
     os_hvp = {"mocked_os": constants.HVC_DEFAULTS.copy()}
     self.cluster.os_hvp = {"mocked_os": {}}


### PR DESCRIPTION
Cluster config would keep track of old/stale OS data even if their
hypervisor parameters are already gone. This check makes sure to wipe
them from the config dictionary if they are empty.

Reviewed-on: https://github.com/ganeti/ganeti/pull/38
Signed-off-by: Federico Morg Pareschi <morg@google.com>
Reviewed-by: Rafael Marinheiro <marinheiro@google.com>