### PR TITLE
Force cache=none for KVM when aio=native

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -1123,6 +1123,12 @@ class KVMHypervisor(hv_base.BaseHypervisor):
                           " to prevent shared storage corruption on migration",
                           disk_cache)
         cache_val = ",cache=none"
+      elif aio_mode == constants.HT_KVM_AIO_NATIVE and disk_cache != "none":
+        # TODO: make this a hard error, instead of a silent overwrite
+        logging.warning("KVM: overriding disk_cache setting '%s' with 'none'"
+                        " to prevent QEMU failures in version 2.6+",
+                        disk_cache)
+        cache_val = ",cache=none"
       elif disk_cache != constants.HT_CACHE_DEFAULT:
         cache_val = ",cache=%s" % disk_cache
       else:


### PR DESCRIPTION
Starting with version 2.6, QEMU will fail to start with an error when
aio=native and no cache=none is present. This is documented in
http://wiki.qemu.org/ChangeLog/2.6. QEMU has been complaining about this
since 2.3. Detect this in the hypervisor setup and force the disk_cache
setting, logging it at the same time.