### PR TITLE
Adding links in readme to community resources

### DIFF
--- a/README
+++ b/README
@@ -1,8 +1,0 @@
-Ganeti 2.17
-===========
-
-For installation instructions, read the INSTALL and the doc/install.rst
-files.
-
-For a brief introduction, read the ganeti(7) manpage and the other pages
-it suggests.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+Ganeti 2.17
+===========
+
+For installation instructions, read the INSTALL and the doc/install.rst
+files.
+
+For a brief introduction, read the ganeti(7) manpage and the other pages
+it suggests.
+
+
+## Community Resources
+
+#### RPM packages
+
+[Packaged binary RPMs can be downloaded here: jfut/ganeti-rpm](https://github.com/jfut/ganeti-rpm)
+
+[RPM packages home page: jfut.integ.jp/linux/ganeti ](http://jfut.integ.jp/linux/ganeti/)
+
+#### OS definitions
+
+[OS Definitions - SourceForge](https://sourceforge.net/p/ganeti-os-defs/home/Home/)
+


### PR DESCRIPTION
I spent a lot of time installing haskell and cabal dependencies for building ganeti from sources in Centos 6.7 using Install instructions of Ganeti docs

When I discovered RPMs were already available - I realized could have saved a lot of time by using it. 

Also the debootstrap link pointing to code.google.com is broken. Since gnt-cluster verify warns that is required if we have guest debian OS I used the debootstrap rpm from the community site, which works well.