### PR TITLE
kvm: Make use of the -D option

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -1282,6 +1282,10 @@ class KVMHypervisor(hv_base.BaseHypervisor):
 
     kvm_cmd.extend(["-balloon", "virtio"])
     kvm_cmd.extend(["-daemonize"])
+    # logfile for qemu
+    qemu_logfile = utils.PathJoin(pathutils.LOG_KVM_DIR,
+                                  "%s.log" % instance.name)
+    kvm_cmd.extend(["-D", qemu_logfile])
     if not instance.hvparams[constants.HV_ACPI]:
       kvm_cmd.extend(["-no-acpi"])
     if instance.hvparams[constants.HV_REBOOT_BEHAVIOR] == \

--- a/lib/pathutils.py
+++ b/lib/pathutils.py
@@ -168,6 +168,8 @@ LOG_OS_DIR = LOG_DIR + "/os"
 LOG_ES_DIR = LOG_DIR + "/extstorage"
 #: Directory for storing Xen config files after failed instance starts
 LOG_XEN_DIR = LOG_DIR + "/xen"
+# Directory to store the output of kvm instances
+LOG_KVM_DIR = LOG_DIR + "/kvm"
 
 # Job queue paths
 JOB_QUEUE_LOCK_FILE = QUEUE_DIR + "/lock"

--- a/lib/tools/ensure_dirs.py
+++ b/lib/tools/ensure_dirs.py
@@ -213,6 +213,7 @@ def GetPaths():
     (mond_log, FILE, 0600, getent.mond_uid, getent.masterd_gid, False),
     (pathutils.LOG_OS_DIR, DIR, 0750, getent.noded_uid, getent.daemons_gid),
     (pathutils.LOG_XEN_DIR, DIR, 0750, getent.noded_uid, getent.daemons_gid),
+    (pathutils.LOG_KVM_DIR, DIR, 0750, getent.noded_uid, getent.daemons_gid),
     (cleaner_log_dir, DIR, 0750, getent.noded_uid, getent.noded_gid),
     (master_cleaner_log_dir, DIR, 0750, getent.masterd_uid, getent.masterd_gid),
     (pathutils.INSTANCE_REASON_DIR, DIR, 0755, getent.noded_uid,


### PR DESCRIPTION
Use a dedicated directory for the QEMU logs (i.e.
/var/log/ganeti/kvm). Along with the -daemonize option
pass the -D option in the KVM command line. QEMU instead
of redirecting stdout/stderr to /dev/null will use the
specified file (i.e. /var/log/ganeti/kvm/<instance name>.log).

Signed-off-by: Dimitris Aragiorgis <dimitris.aragiorgis@gmail.com>
Signed-off-by: Yiannis Tsiouris <tsiou@grnet.gr>