### PR TITLE
kvm: Add missing 'driver' in 'hvinfo' dict

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -361,6 +361,8 @@ def _UpgradeSerializedRuntime(serialized_runtime):
       # handle old instances in the cluster properly.
       if "pci" in dev:
         # This is practically the old _GenerateDeviceKVMId()
+        hv_dev_type = _DEVICE_TYPE[dev_type](hvparams)
+        dev["hvinfo"]["driver"] = _DEVICE_DRIVER[dev_type](hv_dev_type)
         dev["hvinfo"]["id"] = "hot%s-%s-%s-%s" % (dev_type.lower(),
                                                   uuid.split("-")[0],
                                                   "pci",


### PR DESCRIPTION
This commit fixes a bug introduced in 28639115d7 where the 'driver'
option was missing from the 'hvinfo' dict when
'_UpgradeSerializedRuntime' was called. This raised a KeyError when
trying to migrate a running instance.

Signed-off-by: Yiannis Tsiouris <tsiou@grnet.gr>
Signed-off-by: Alexandros Afentoulis <alexaf@noc.grnet.gr>