### PR TITLE
Force CleanupInstance always on InstanceShutdown

### DIFF
--- a/lib/backend.py
+++ b/lib/backend.py
@@ -2945,49 +2945,48 @@ def InstanceShutdown(instance, timeout, reason, store_reason=True):
 
   if not _GetInstanceInfo(instance):
     logging.info("Instance '%s' not running, doing nothing", instance.name)
-    return
+  else:
+    class _TryShutdown(object):
+      def __init__(self):
+        self.tried_once = False
 
-  class _TryShutdown(object):
-    def __init__(self):
-      self.tried_once = False
+      def __call__(self):
+        try:
+          hyper.StopInstance(instance, retry=self.tried_once, timeout=timeout)
+          if store_reason:
+            _StoreInstReasonTrail(instance.name, reason)
+        except errors.HypervisorError, err:
+          # if the instance does no longer exist, consider this success and go to
+          # cleanup, otherwise fail without retrying
+          if _GetInstanceInfo(instance):
+            _Fail("Failed to stop instance '%s': %s", instance.name, err)
+          return
 
-    def __call__(self):
-      try:
-        hyper.StopInstance(instance, retry=self.tried_once, timeout=timeout)
-        if store_reason:
-          _StoreInstReasonTrail(instance.name, reason)
-      except errors.HypervisorError, err:
-        # if the instance does no longer exist, consider this success and go to
-        # cleanup, otherwise fail without retrying
+        # TODO: Cleanup hypervisor implementations to prevent them from failing
+        # silently. We could easily decide if we want to retry or not by using
+        # HypervisorSoftError()/HypervisorHardError()
+        self.tried_once = True
         if _GetInstanceInfo(instance):
-          _Fail("Failed to stop instance '%s': %s", instance.name, err)
-        return
-
-      # TODO: Cleanup hypervisor implementations to prevent them from failing
-      # silently. We could easily decide if we want to retry or not by using
-      # HypervisorSoftError()/HypervisorHardError()
-      self.tried_once = True
-      if _GetInstanceInfo(instance):
-        raise utils.RetryAgain()
-
-  try:
-    utils.Retry(_TryShutdown(), 5, timeout)
-  except utils.RetryTimeout:
-    # the shutdown did not succeed
-    logging.error("Shutdown of '%s' unsuccessful, forcing", instance.name)
+          raise utils.RetryAgain()
 
     try:
-      hyper.StopInstance(instance, force=True)
-    except errors.HypervisorError, err:
-      # only raise an error if the instance still exists, otherwise
-      # the error could simply be "instance ... unknown"!
+      utils.Retry(_TryShutdown(), 5, timeout)
+    except utils.RetryTimeout:
+      # the shutdown did not succeed
+      logging.error("Shutdown of '%s' unsuccessful, forcing", instance.name)
+
+      try:
+        hyper.StopInstance(instance, force=True)
+      except errors.HypervisorError, err:
+        # only raise an error if the instance still exists, otherwise
+        # the error could simply be "instance ... unknown"!
+        if _GetInstanceInfo(instance):
+          _Fail("Failed to force stop instance '%s': %s", instance.name, err)
+
+      time.sleep(1)
+
       if _GetInstanceInfo(instance):
-        _Fail("Failed to force stop instance '%s': %s", instance.name, err)
-
-    time.sleep(1)
-
-    if _GetInstanceInfo(instance):
-      _Fail("Could not shutdown instance '%s' even by destroy", instance.name)
+        _Fail("Could not shutdown instance '%s' even by destroy", instance.name)
 
   try:
     hyper.CleanupInstance(instance.name)


### PR DESCRIPTION
This commit fixes the bug described in #52 by always trying to cleanup
an instance's runtime files and block devices on InstanceShutdown. The
buggy scenario is:
- A user issues a 'poweroff' from inside the VM
- The admin or a RAPI client does a 'gnt-instance shutdown' (or even
worse a 'gnt-instance remove' which, in turn, issues an instance
shutdown) *before* the watcher notices the 'ERROR_down' state of the
VM
- The instance status changes to 'ADMIN_down' (or gets removed) but the
cleanup is never performed. Thus, the CTRL_DIR, CONF_DIR, NIC_DIR,
instance_disks, etc. are left stale.

This can be reproduced on clusters that have the 'user_shutdown' option
disabled.

Signed-off-by: Yiannis Tsiouris <tsiou@grnet.gr>
Signed-off-by: Alexandros Kiousis <alexk@noc.grnet.gr>