### PR TITLE
hv_xen: generate correct type for paravirtualized nic

### DIFF
--- a/lib/hypervisor/hv_xen.py
+++ b/lib/hypervisor/hv_xen.py
@@ -737,7 +737,7 @@ class XenHypervisor(hv_base.BaseHypervisor):
         if vif_type:
           nic_type_str = ", type=%s" % vif_type
       elif nic_type == constants.HT_NIC_PARAVIRTUAL:
-        nic_type_str = ", type=paravirtualized"
+        nic_type_str = ", type=%s" % constants.HT_HVM_VIF_VIF
       else:
         # parameter 'model' is only valid with type 'ioemu'
         nic_type_str = ", model=%s, type=%s" % \


### PR DESCRIPTION
With debian stretch (ganeti 2.15 and xen 4.8) the configuration file generated by ganeti is not correct, type=vif should be specified instead of type=paravirtualized when using paravirtual nics. This is the same with latest ganeti.