### PR TITLE
Implement basic automatic KVM postcopy migration

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -1900,7 +1900,8 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     # during instance startup anyway, and to avoid problems when soft
     # rebooting the instance.
     cpu_pinning = False
-    if up_hvp.get(constants.HV_CPU_MASK, None):
+    if up_hvp.get(constants.HV_CPU_MASK, None) \
+        and up_hvp[constants.HV_CPU_MASK] != constants.CPU_PINNING_ALL:
       cpu_pinning = True
 
     if security_model == constants.HT_SM_POOL:

--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -538,7 +538,7 @@ class KVMHypervisor(hv_base.BaseHypervisor):
   _VIRTIO_NET_PCI = "virtio-net-pci"
   _VIRTIO_BLK_PCI = "virtio-blk-pci"
 
-  _MIGRATION_STATUS_RE = re.compile(r"Migration\s+status:\s+(\w+)",
+  _MIGRATION_STATUS_RE = re.compile(r"Migration\s+status:\s+([-\w]+)",
                                     re.M | re.I)
   _MIGRATION_PROGRESS_RE = \
     re.compile(r"\s*transferred\s+ram:\s+(?P<transferred>\d+)\s+kbytes\s*\n.*"

--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -544,6 +544,8 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     re.compile(r"\s*transferred\s+ram:\s+(?P<transferred>\d+)\s+kbytes\s*\n.*"
                r"\s*remaining\s+ram:\s+(?P<remaining>\d+)\s+kbytes\s*\n"
                r"\s*total\s+ram:\s+(?P<total>\d+)\s+kbytes\s*\n", re.I)
+  _MIGRATION_PRECOPY_PASSES_RE = \
+    re.compile(r"\s*dirty sync count:\s+(\d+)", re.I | re.M)
 
   _MIGRATION_INFO_MAX_BAD_ANSWERS = 5
   _MIGRATION_INFO_RETRY_DELAY = 2
@@ -2485,12 +2487,54 @@ class KVMHypervisor(hv_base.BaseHypervisor):
 
     migration_caps = instance.hvparams[constants.HV_KVM_MIGRATION_CAPS]
     if migration_caps:
-      for c in migration_caps.split(_MIGRATION_CAPS_DELIM):
+      capabilities = migration_caps.split(_MIGRATION_CAPS_DELIM)
+      postcopy_enabled = ('x-postcopy-ram' in capabilities
+                          or 'postcopy-ram' in capabilities)
+      for c in capabilities:
         migrate_command = ("migrate_set_capability %s on" % c)
         self._CallMonitorCommand(instance_name, migrate_command)
+    else:
+      postcopy_enabled = False
 
     migrate_command = "migrate -d tcp:%s:%s" % (target, port)
     self._CallMonitorCommand(instance_name, migrate_command)
+
+    if postcopy_enabled:
+      self._PostcopyAfterPrecopy(instance)
+
+  def _PostcopyAfterPrecopy(self, instance):
+    """Enable postcopying RAM after one precopy pass.
+
+    Requires that an instance is currently migrating, and that the
+    postcopy-ram (x-postcopy-ram on QEMU version 2.5 and below)
+    migration capability is enabled in the instance's hypervisor
+    parameters.
+
+    @type instance: L{objects.Instance}
+    @param instance: The instance being migrated.
+
+    """
+    precopy_passes = 0
+    while precopy_passes < 2:
+      migration_status = \
+          self._CallMonitorCommand(instance.name, 'info migrate')
+
+      status_match = self._MIGRATION_STATUS_RE.search(migration_status.stdout)
+      if status_match and status_match.group(1) != 'active':
+        logging.debug('Did not attempt postcopy, migration status: %s'
+          % status_match.group(1))
+        break
+      if migration_status.stderr:
+        logging.debug('Error polling for dirty sync count in '
+          'hv_kvm._PostcopyAfterPrecopy(): %s' % migration_status.stderr)
+        break
+
+      passes_match = \
+          self._MIGRATION_PRECOPY_PASSES_RE.search(migration_status.stdout)
+      if passes_match:
+        precopy_passes = int(passes_match.group(1))
+    else:
+      self._CallMonitorCommand(instance.name, 'migrate_start_postcopy')
 
   def FinalizeMigrationSource(self, instance, success, _):
     """Finalize the instance migration on the source node.

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -866,10 +866,14 @@ migration\_caps
 
     Enable specific migration capabilities by providing a ":" separated
     list of supported capabilites. QEMU version 1.7.0 defines
-    x-rdma-pin-all, auto-converge, zero-blocks, and xbzrle. Please note
-    that while a combination of xbzrle and auto-converge might speed up
-    the migration process significantly, the first may cause BSOD on
-    Windows8r2 instances running on drbd.
+    x-rdma-pin-all, auto-converge, zero-blocks, and xbzrle. QEMU version
+    2.5 defines x-postcopy-ram and 2.6 renames this to postcopy-ram.
+    If x-postcopty-ram or postcopy-ram are enabled, Ganeti will
+    automatically move a migration to postcopy mode after one iteration
+    of precopying the instance's RAM.
+    Please note that while a combination of xbzrle and auto-converge
+    might speed up the migration process significantly, the first may
+    cause BSOD on Windows8r2 instances running on drbd.
 
 kvm\_path
     Valid for the KVM hypervisor.

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -868,7 +868,7 @@ migration\_caps
     list of supported capabilites. QEMU version 1.7.0 defines
     x-rdma-pin-all, auto-converge, zero-blocks, and xbzrle. QEMU version
     2.5 defines x-postcopy-ram and 2.6 renames this to postcopy-ram.
-    If x-postcopty-ram or postcopy-ram are enabled, Ganeti will
+    If x-postcopy-ram or postcopy-ram are enabled, Ganeti will
     automatically move a migration to postcopy mode after one iteration
     of precopying the instance's RAM.
     Please note that while a combination of xbzrle and auto-converge


### PR DESCRIPTION
Implementation of automatic postcopy migration when x-postcopy-ram or postcopy-ram migration capabilities are enabled, switching from precopy mode to postcopy after one iteration of precopying the RAM.