### PR TITLE
Fix #1260 ganeti-cleaner accepts REMOVE_AFTER as env var

### DIFF
--- a/daemons/ganeti-cleaner.in
+++ b/daemons/ganeti-cleaner.in
@@ -106,7 +106,7 @@ cleanup_master() {
 }
 
 # Define how many days archived jobs should be left alone
-REMOVE_AFTER=21
+REMOVE_AFTER=${REMOVE_AFTER:-21}
 
 # Define how many log files to keep around (usually one per day)
 KEEP_LOGS=50

--- a/doc/examples/ganeti.cron.in
+++ b/doc/examples/ganeti.cron.in
@@ -10,7 +10,7 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 */30 * * * * root [ -x @SBINDIR@/ganeti-watcher ] && @SBINDIR@/ganeti-watcher
 
 # Clean job archive (at 01:45 AM)
-45 1 * * * @GNTMASTERUSER@ [ -x @SBINDIR@/ganeti-cleaner ] && @SBINDIR@/ganeti-cleaner master
+45 1 * * * @GNTMASTERUSER@ [ -x @SBINDIR@/ganeti-cleaner ] && REMOVE_AFTER=21 @SBINDIR@/ganeti-cleaner master
 
 # Clean job archive (at 02:45 AM)
 45 2 * * * @GNTNODEDUSER@ [ -x @SBINDIR@/ganeti-cleaner ] && @SBINDIR@/ganeti-cleaner node

--- a/man/ganeti-cleaner.rst
+++ b/man/ganeti-cleaner.rst
@@ -22,8 +22,9 @@ certificates and keys from ``@LOCALSTATEDIR@/run/ganeti/crypto``, as
 well as outdated **ganeti-watcher** information.
 
 When called with ``master`` as argument, it will instead automatically
-remove all files older than 21 days from
-``@LOCALSTATEDIR@/lib/ganeti/queue/archive``.
+remove all files older than $REMOVE_AFTER days from
+``@LOCALSTATEDIR@/lib/ganeti/queue/archive``, with $REMOVE_AFTER
+defaulting to 21.
 
 .. vim: set textwidth=72 :
 .. Local Variables:


### PR DESCRIPTION
If REMOVE_AFTER is set before calling ganeti-cleaner master, it uses this env var. 
Otherwise defaults to 21, as before.