### PR TITLE
EnsureDirs: only change permissions if needed

### DIFF
--- a/lib/utils/io.py
+++ b/lib/utils/io.py
@@ -602,7 +602,8 @@ def EnsureDirs(dirs):
         raise errors.GenericError("Cannot create needed directory"
                                   " '%s': %s" % (dir_name, err))
     try:
-      os.chmod(dir_name, dir_mode)
+      if stat.S_IMODE(os.stat(dir_name).st_mode) != dir_mode:
+        os.chmod(dir_name, dir_mode)
     except EnvironmentError, err:
       raise errors.GenericError("Cannot change directory permissions on"
                                 " '%s' to 0%o: %s" % (dir_name, dir_mode, err))


### PR DESCRIPTION
This should work around issue #1231, by skipping the chmod if not
needed. It is an adaptation of the patch coming from the original
code.google.com issue 1178, but without original authorship data, so I
can't attribute it.

I've chosen to simplify to the patch to keep the 'stat' under the try
block as well, otherwiseerrors in the stat would result in unhandled
errors, rather than GenericError. The error message might be slightly
off, but the OS-level error description should be enough to understand
what happens.

Tested manually on the case in the bug: directory without permissions
but with the expected mode doesn't raise and exception. Rather than
unit-testing this, I'd prefer to remove the large duplication between
EnsureDirs, EnforcePermission and MakeDirWithPerm, probably on the
master branch.

Signed-off-by: Iustin Pop <iustin@google.com>