### PR TITLE
utils.livelock: use portable struct flock type

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1995,6 +1995,7 @@ python_tests = \
 	test/py/ganeti.utils.io_unittest-runasroot.py \
 	test/py/ganeti.utils.io_unittest.py \
 	test/py/ganeti.utils.log_unittest.py \
+	test/py/ganeti.utils.livelock_unittest.py \
 	test/py/ganeti.utils.lvm_unittest.py \
 	test/py/ganeti.utils.mlock_unittest.py \
 	test/py/ganeti.utils.nodesetup_unittest.py \

--- a/lib/utils/livelock.py
+++ b/lib/utils/livelock.py
@@ -72,8 +72,16 @@ class LiveLock(object):
     name = "%s_%d" % (name, int(time.time()))
     fname = os.path.join(pathutils.LIVELOCK_DIR, name)
     self.lockfile = open(fname, 'w')
+
+    # with LFS enabled, off_t is 64 bits even on 32-bit platforms
+    try:
+      os.O_LARGEFILE
+      struct_flock = 'hhqqhh'
+    except AttributeError:
+      struct_flock = 'hhllhh'
+
     fcntl.fcntl(self.lockfile, fcntl.F_SETLKW,
-                struct.pack('hhllhh', fcntl.F_WRLCK, 0, 0, 0, 0, 0))
+                struct.pack(struct_flock, fcntl.F_WRLCK, 0, 0, 0, 0, 0))
 
   def GetPath(self):
     return self.lockfile.name

--- a/test/py/ganeti.utils.livelock_unittest.py
+++ b/test/py/ganeti.utils.livelock_unittest.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+#
+
+# Copyright (C) 2018 Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+"""Script for testing utils.LiveLock
+
+"""
+
+import os
+import unittest
+
+from ganeti.utils.livelock import LiveLock
+from ganeti import pathutils
+
+import testutils
+
+
+class TestLiveLock(unittest.TestCase):
+  """Whether LiveLock() works
+
+  """
+  @testutils.patch_object(pathutils, 'LIVELOCK_DIR', '/tmp')
+  def test(self):
+    lock = LiveLock()
+    lock_path = lock.GetPath()
+    self.assertTrue(os.path.exists(lock_path))
+    self.assertTrue(lock_path.startswith('/tmp/pid'))
+    lock.close()
+    self.assertFalse(os.path.exists(lock_path))
+
+  @testutils.patch_object(pathutils, 'LIVELOCK_DIR', '/tmp')
+  def testName(self):
+    lock = LiveLock('unittest.lock')
+    lock_path = lock.GetPath()
+    self.assertTrue(os.path.exists(lock_path))
+    self.assertTrue(lock_path.startswith('/tmp/unittest.lock_'))
+    lock.close()
+    self.assertFalse(os.path.exists(lock_path))
+
+
+if __name__ == "__main__":
+  testutils.GanetiTestProgram()


### PR DESCRIPTION
From `fcntl(2)`:
```
struct flock {
    ...
    short l_type;    /* Type of lock: F_RDLCK,
                        F_WRLCK, F_UNLCK */
    short l_whence;  /* How to interpret l_start:
                        SEEK_SET, SEEK_CUR, SEEK_END */
    off_t l_start;   /* Starting offset for lock */
    off_t l_len;     /* Number of bytes to lock */
    pid_t l_pid;     /* PID of process blocking our lock
                        (set by F_GETLK and F_OFD_GETLK) */
    ...
};
```
On 64-bit systems, `off_t` is always 64 bits long (`long`/`long long`). On
32-bit systems however, depending on whether large file support is
enabled or not, it may be 64 bits (`long long`) or 32 bits (`long`)
long.

The code in `LiveLock.__init__` would always assume `off_t` to be `long`,
breaking on 32-bit systems with LFS support. Fix this by picking the
correct type to use depending on the existence of `os.O_LARGEFILE`.

Note that LFS is enabled almost universally these days and it would be
safe to just use `long long` unconditionally, but it doesn't harm to
make the actual check.