### PR TITLE
py-tests: update forgotten cert fingerprint

### DIFF
--- a/test/py/cmdlib/cluster_unittest.py
+++ b/test/py/cmdlib/cluster_unittest.py
@@ -2404,7 +2404,7 @@ class TestLUClusterRenewCrypto(CmdlibTestCase):
     self._client_node_cert = self._CreateTempFile()
     shutil.copy(testutils.TestDataFilename("cert2.pem"), self._client_node_cert)
     self._client_node_cert_digest = \
-        "BF:24:F7:57:50:60:43:87:83:E3:0D:7E:EF:DD:14:6C:13:43:20:4E"
+        "30:AF:82:D0:00:1C:F2:99:DE:A8:6D:31:7F:C9:D5:46:70:07:EC:4F"
 
   def tearDown(self):
     super(TestLUClusterRenewCrypto, self).tearDown()


### PR DESCRIPTION
This should have been part of 4314cfe5.