### PR TITLE
ssh: set connection timeout to 10s

### DIFF
--- a/lib/ssh.py
+++ b/lib/ssh.py
@@ -767,6 +767,7 @@ class SshRunner(object):
       "-oGlobalKnownHostsFile=%s" % pathutils.SSH_KNOWN_HOSTS_FILE,
       "-oUserKnownHostsFile=/dev/null",
       "-oCheckHostIp=no",
+      "-oConnectTimeout=10",
       ]
 
     if use_cluster_key:


### PR DESCRIPTION
We currently don't specify any explicit connection timeout for SSH
invocations. In many cases, SSH may wait up to 2 minutes (or even more)
before bailing out on an unreachable node, which may cause unwanted
side-effects, like RPC timeouts. Since connecting via SSH to a node
should never take too long, setting ConnectTimeout to 10s universally
seems like a good and arguably conservative default.

This fixes #1286.