### PR TITLE
ovf_unittest: use a temporary output directory

### DIFF
--- a/test/py/ganeti.ovf_unittest.py
+++ b/test/py/ganeti.ovf_unittest.py
@@ -54,7 +54,7 @@ from ganeti import pathutils
 
 import testutils
 
-OUTPUT_DIR = "newdir"
+OUTPUT_DIR = tempfile.mkdtemp()
 
 GANETI_DISKS = {
   "disk_count": "1",


### PR DESCRIPTION
Since this is a temporary working directory for the duration of the
test, use a directory under /tmp. There are a number of reasons why this
is desirable, e.g. to be able to run the unittests with a read-only
source tree, as in the case of Debian autopkgtests.