### PR TITLE
Use SHA256 for certificate signatures

### DIFF
--- a/lib/utils/x509.py
+++ b/lib/utils/x509.py
@@ -55,7 +55,6 @@ X509_SIGNATURE = re.compile(r"^%s:\s*(?P<salt>%s+)/(?P<sign>%s+)$" %
                             (re.escape(constants.X509_CERT_SIGNATURE_HEADER),
                              HEX_CHAR_RE, HEX_CHAR_RE),
                             re.S | re.I)
-X509_CERT_SIGN_DIGEST = "SHA1"
 
 # Certificate verification results
 (CERT_WARNING,
@@ -350,7 +349,7 @@ def GenerateSignedX509Cert(common_name, validity, serial_no,
   req = OpenSSL.crypto.X509Req()
   req.get_subject().CN = common_name
   req.set_pubkey(key_pair)
-  req.sign(key_pair, X509_CERT_SIGN_DIGEST)
+  req.sign(key_pair, constants.X509_CERT_SIGN_DIGEST)
 
   # Load the certificates used for signing.
   signing_key = OpenSSL.crypto.load_privatekey(
@@ -366,7 +365,7 @@ def GenerateSignedX509Cert(common_name, validity, serial_no,
   cert.gmtime_adj_notAfter(validity)
   cert.set_issuer(signing_cert.get_subject())
   cert.set_pubkey(req.get_pubkey())
-  cert.sign(signing_key, X509_CERT_SIGN_DIGEST)
+  cert.sign(signing_key, constants.X509_CERT_SIGN_DIGEST)
 
   # Encode the key and certificate in PEM format.
   key_pem = OpenSSL.crypto.dump_privatekey(

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -617,9 +617,9 @@ x509CertDefaultValidity = 365 * 5
 x509CertSignatureHeader :: String
 x509CertSignatureHeader = "X-Ganeti-Signature"
 
--- | Digest used to sign certificates ("openssl x509" uses SHA1 by default)
+-- | Digest used to sign certificates
 x509CertSignDigest :: String
-x509CertSignDigest = "SHA1"
+x509CertSignDigest = "SHA256"
 
 -- * Import/export daemon mode
 


### PR DESCRIPTION
SHA1 is regarded by several parties as too weak and certificates bearing
SHA1 CA signatures are rejected by OpenSSL above security level 2.
Replace SHA1 with SHA256 which should give us enough time.

While at it, drop utils.x509's private X509_CERT_SIGN_DIGEST instance in
favor of the global version from constants.

Finally, check the certificate key/signing algorithm strength in cluster verify operations to let admins know that they need to upgrade their certificates.

See also Debian bug [#907216](https://bugs.debian.org/907216).