### PR TITLE
Fix Haskell daemon '-b' help text

### DIFF
--- a/src/Ganeti/Daemon.hs
+++ b/src/Ganeti/Daemon.hs
@@ -110,7 +110,7 @@ data DaemonOptions = DaemonOptions
   , optPort         :: Maybe Word16   -- ^ Override for the network port
   , optDebug        :: Bool           -- ^ Enable debug messages
   , optNoUserChecks :: Bool           -- ^ Ignore user checks
-  , optBindAddress  :: Maybe String   -- ^ Override for the bind address
+  , optBindAddress  :: Maybe String   -- ^ Listen on a custom address
   , optSyslogUsage  :: Maybe SyslogUsage -- ^ Override for Syslog usage
   , optForceNode    :: Bool           -- ^ Ignore node checks
   , optNoVoting     :: Bool           -- ^ skip voting for master
@@ -190,7 +190,8 @@ oBindAddress =
   (Option "b" ["bind"]
    (ReqArg (\addr opts -> Ok opts { optBindAddress = Just addr })
     "ADDR")
-   "Bind address (default depends on cluster configuration)",
+   "Bind address (default is 'any' on either IPv4 or IPv6, depending \
+   \on cluster configuration)",
    OptComplInetAddr)
 
 oSyslogUsage :: OptType


### PR DESCRIPTION
This refers to, and fixes #974.

Looking at the source code, the previous "default depends on cluster
configuration" refers to the address _family_, not the address itself
(which is always 'any' as in INADDR_ANY or INADDR6_ANY). Let's correct
the help text and also the docstring for that parameter (which also
implied an override of a specific address).

Signed-off-by: Iustin Pop <iustin@k1024.org>