### PR TITLE
Fix openvswitch port setup when no untagged VLANs are used

### DIFF
--- a/tools/net-common.in
+++ b/tools/net-common.in
@@ -89,6 +89,7 @@ function setup_ovs {
     # Set up trunk port
     # From gnt-instance man page vlan should be :VLAN_ID[:VLAN_ID2..]
     TRUNKS=${VLAN#.*:}  # remove any access info
+    TRUNKS=${TRUNKS#:}  # remove leading ':', if still present
     [ -n "$TRUNKS" ] && ovs-vsctl set port $INTERFACE trunks=${TRUNKS//:/,}
 
   fi


### PR DESCRIPTION
OpenVSwitch port setup fails when a port is only configured to carry
tagged VLANs, due to the VLAN's configuration string being malformed.
This patch fixes these cases.

Signed-off-by: George Diamantopoulos <gdiamantopoulos@modulus.gr>