### PR TITLE
Preliminary support for persistent hugepages under KVM (#473)

### DIFF
--- a/lib/backend.py
+++ b/lib/backend.py
@@ -703,6 +703,7 @@ def _GetHvInfo(name, hvparams, get_hv_fn=hypervisor.GetHypervisor):
     - vg_free is the free size of the volume group in MiB
     - memory_dom0 is the memory allocated for domain0 in MiB
     - memory_free is the currently available (free) ram in MiB
+    - hugepages_free is the currently available (unreserved) hugepages capacity in MiB
     - memory_total is the total number of ram in MiB
     - hv_version: the hypervisor version, if available
 

--- a/lib/client/gnt_node.py
+++ b/lib/client/gnt_node.py
@@ -58,7 +58,7 @@ from ganeti.confd import client as confd_client
 _LIST_DEF_FIELDS = [
   "name", "dtotal", "dfree",
   "mtotal", "mnode", "mfree",
-  "pinst_cnt", "sinst_cnt",
+  "hpfree", "pinst_cnt", "sinst_cnt",
   ]
 
 

--- a/lib/cmdlib/instance_migration.py
+++ b/lib/cmdlib/instance_migration.py
@@ -38,6 +38,7 @@ from ganeti import errors
 from ganeti import locking
 from ganeti import hypervisor
 from ganeti.masterd import iallocator
+from ganeti import objects
 from ganeti import utils
 from ganeti.cmdlib.base import LogicalUnit, Tasklet
 from ganeti.cmdlib.common import ExpandInstanceUuidAndName, \
@@ -413,11 +414,12 @@ class TLMigrateInstance(Tasklet):
     if (not self.cleanup and
          (not self.failover or
            self.instance.admin_state == constants.ADMINST_UP)):
+      hvfull = objects.FillDict(cluster.hvparams.get(self.instance.hypervisor, {}), cluster.FillHV(self.instance))
       self.tgt_free_mem = CheckNodeFreeMemory(
           self.lu, target_node_uuid,
           "migrating instance %s" % self.instance.name,
           i_be[constants.BE_MINMEM], self.instance.hypervisor,
-          self.cfg.GetClusterInfo().hvparams[self.instance.hypervisor])
+          hvfull)
     else:
       self.lu.LogInfo("Not checking memory on the secondary node as"
                       " instance will not be started")

--- a/lib/cmdlib/instance_operation.py
+++ b/lib/cmdlib/instance_operation.py
@@ -129,6 +129,8 @@ class LUInstanceStartup(LogicalUnit):
       hv_type.CheckParameterSyntax(filled_hvp)
       CheckHVParams(self, self.cfg.GetInstanceNodes(self.instance.uuid),
                     self.instance.hypervisor, filled_hvp)
+    else:
+      filled_hvp = cluster.FillHV(self.instance)
 
     CheckInstanceState(self, self.instance, INSTANCE_ONLINE)
 
@@ -164,11 +166,12 @@ class LUInstanceStartup(LogicalUnit):
                                remote_info.payload):
           self.requires_cleanup = True
       else: # not running already
+        hvfull = objects.FillDict(cluster.hvparams.get(self.instance.hypervisor, {}), filled_hvp)
         CheckNodeFreeMemory(
             self, self.instance.primary_node,
             "starting instance %s" % self.instance.name,
             bep[constants.BE_MINMEM], self.instance.hypervisor,
-            self.cfg.GetClusterInfo().hvparams[self.instance.hypervisor])
+            hvfull)
 
   def Exec(self, feedback_fn):
     """Start the instance.

--- a/lib/cmdlib/instance_set_params.py
+++ b/lib/cmdlib/instance_set_params.py
@@ -1117,11 +1117,12 @@ class LUInstanceSetParams(LogicalUnit):
 
       delta = self.op.runtime_mem - current_memory
       if delta > 0:
+        hvfull = objects.FillDict(cluster_hvparams, self.instance.hvparams)
         CheckNodeFreeMemory(
             self, self.instance.primary_node,
             "ballooning memory for instance %s" % self.instance.name, delta,
             self.instance.hypervisor,
-            self.cfg.GetClusterInfo().hvparams[self.instance.hypervisor])
+            hvfull)
 
   def CheckPrereq(self):
     """Check prerequisites.

--- a/lib/cmdlib/instance_utils.py
+++ b/lib/cmdlib/instance_utils.py
@@ -580,9 +580,9 @@ def CheckNodeFreeMemory(lu, node_uuid, reason, requested, hvname, hvparams):
                                errors.ECODE_ENVIRON)
   if hvparams.get("mem_path", None):
     if requested > free_hugepages_mem:
-      raise errors.OpPrereqError("Not enough memory on node %s for %s:"
+      raise errors.OpPrereqError("Not enough hugepages capacity on node %s for %s:"
                             " needed %s MiB, available %s MiB" %
-                            (node_name, reason, requested, free_mem),
+                            (node_name, reason, requested, free_hugepages_mem),
                             errors.ECODE_NORES)
     else:
       free_mem = free_hugepages_mem

--- a/lib/hypervisor/hv_base.py
+++ b/lib/hypervisor/hv_base.py
@@ -695,6 +695,8 @@ class BaseHypervisor(object):
 
     result = {}
     sum_free = 0
+    sum_hugepages_free = 0
+    hugepages_size = 0
     try:
       for line in data:
         splitfields = line.split(":", 1)
@@ -706,12 +708,19 @@ class BaseHypervisor(object):
             result["memory_total"] = int(val.split()[0]) / 1024
           elif key in ("MemFree", "Buffers", "Cached"):
             sum_free += int(val.split()[0]) / 1024
+          elif key == "HugePages_Free":
+            sum_hugepages_free += int(val.split()[0])
+          elif key == "HugePages_Rsvd":
+            sum_hugepages_free -= int(val.split()[0])
+          elif key == "Hugepagesize":
+            hugepages_size = int(val.split()[0]) / 1024
           elif key == "Active":
             result["memory_dom0"] = int(val.split()[0]) / 1024
     except (ValueError, TypeError), err:
       raise errors.HypervisorError("Failed to compute memory usage: %s" %
                                    (err,))
     result["memory_free"] = sum_free
+    result["hugepages_free"] = sum_hugepages_free * hugepages_size
 
     cpu_total = 0
     try:

--- a/lib/query.py
+++ b/lib/query.py
@@ -1184,6 +1184,8 @@ _NODE_LIVE_FIELDS = {
               "Total spindles in volume group (exclusive storage only)"),
   "mfree": ("MFree", QFT_UNIT, "memory_free",
             "Memory available for instance allocations"),
+  "hpfree": ("HPFree", QFT_UNIT, "hugepages_free",
+            "Unreserved hugepage capacity available for instance allocations"),
   "mnode": ("MNode", QFT_UNIT, "memory_dom0",
             "Amount of memory used by node (dom0 for Xen)"),
   "mtotal": ("MTotal", QFT_UNIT, "memory_total",

--- a/lib/rapi/rlib2.py
+++ b/lib/rapi/rlib2.py
@@ -95,7 +95,7 @@ I_FIELDS = ["name", "admin_state", "os",
 
 N_FIELDS = ["name", "offline", "master_candidate", "drained",
             "dtotal", "dfree", "sptotal", "spfree",
-            "mtotal", "mnode", "mfree",
+            "mtotal", "mnode", "mfree", "hpfree",
             "pinst_cnt", "sinst_cnt",
             "ctotal", "cnos", "cnodes", "csockets",
             "pip", "sip", "role",

--- a/qa/qa_rapi.py
+++ b/qa/qa_rapi.py
@@ -298,7 +298,7 @@ INSTANCE_FIELDS = ("name", "os", "pnode", "snodes",
                    "oper_state", "oper_ram", "oper_vcpus", "status", "tags")
 
 NODE_FIELDS = ("name", "dtotal", "dfree", "sptotal", "spfree",
-               "mtotal", "mnode", "mfree",
+               "mtotal", "mnode", "mfree", "hpfree",
                "pinst_cnt", "sinst_cnt", "tags")
 
 GROUP_FIELDS = compat.UniqueFrozenset([

--- a/src/Ganeti/Query/Node.hs
+++ b/src/Ganeti/Query/Node.hs
@@ -82,6 +82,8 @@ nodeLiveFieldsDefs =
      "Total spindles in volume group (exclusive storage only)")
   , ("mfree", "MFree", QFTUnit, "memory_free",
      "Memory available for instance allocations")
+  , ("hpfree", "HPFree", QFTUnit, "hugepages_free",
+     "Unreserved hugepage capacity available for instance allocations")
   , ("mnode", "MNode", QFTUnit, "memory_dom0",
      "Amount of memory used by node (dom0 for Xen)")
   , ("mtotal", "MTotal", QFTUnit, "memory_total",
@@ -141,6 +143,8 @@ nodeLiveFieldExtract "sptotal" res =
       (rpcResNodeInfoStorageInfo res) StorageLvmPv)
 nodeLiveFieldExtract "mfree" res =
   jsonHead (rpcResNodeInfoHvInfo res) hvInfoMemoryFree
+nodeLiveFieldExtract "hpfree" res =
+  jsonHead (rpcResNodeInfoHvInfo res) hvInfoHugepagesFree
 nodeLiveFieldExtract "mnode" res =
   jsonHead (rpcResNodeInfoHvInfo res) hvInfoMemoryDom0
 nodeLiveFieldExtract "mtotal" res =
@@ -277,7 +281,7 @@ storageFields = ["dtotal", "dfree", "spfree", "sptotal"]
 
 -- | Hypervisor-related query fields
 hypervisorFields :: [String]
-hypervisorFields = ["mnode", "mfree", "mtotal",
+hypervisorFields = ["mnode", "mfree", "hpfree", "mtotal",
                     "cnodes", "csockets", "cnos", "ctotal"]
 
 -- | Check if it is required to include domain-specific entities (for example

--- a/src/Ganeti/Rpc.hs
+++ b/src/Ganeti/Rpc.hs
@@ -546,6 +546,7 @@ $(buildObject "HvInfo" "hvInfo"
   [ optionalField $ simpleField C.hvNodeinfoKeyVersion [t| [Int] |]
   , simpleField "memory_total" [t| Int |]
   , simpleField "memory_free" [t| Int |]
+  , simpleField "hugepages_free" [t| Int |]
   , simpleField "memory_dom0" [t| Int |]
   , optionalField $ simpleField "memory_hv" [t| Int |]
   , simpleField "cpu_total" [t| Int |]


### PR DESCRIPTION
This pull request is an early, I-don't-really-know-what-I'm-doing attempt at allowing KVM instances to use persistent hugepages as memory backend.

My intention for these patches was to check the mem_path hypervisor parameter for each instance, and allow their creation or startup if there are enough unreserved hugepages available to accomodate them. Previously, such actions would fail because only free memory would be taken into account for resource accounting when creating instances. But if persistent hugepages are enabled (via kernel boot command parameter or sysfs, for example), their capacity, even if they are unused, is not included in free memory reporting by the kernel.

With this patch, free memory and free hugepages are calculated separately, and resource accounting is performed accordingly (based on the mem_path parameter being set or not).

Free hugepages are now also reported with 'gnt-node list'.

This pull request is mostly meant as a request for comments from the community and developers involed in this project. Some (successful) preliminary testing has been done, but by no means should this work be considered as stable or suitable for use of any kind at this point.