### PR TITLE
Initiate the 3.0 development cycle

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,8 +1,8 @@
 # Configure script for Ganeti
-m4_define([gnt_version_major], [2])
-m4_define([gnt_version_minor], [16])
+m4_define([gnt_version_major], [3])
+m4_define([gnt_version_minor], [0])
 m4_define([gnt_version_revision], [0])
-m4_define([gnt_version_suffix], [])
+m4_define([gnt_version_suffix], [~alpha1])
 m4_define([gnt_version_full],
           m4_format([%d.%d.%d%s],
                     gnt_version_major, gnt_version_minor,


### PR DESCRIPTION
Mark master as 2.18.0~alpha1.

Note that while `2.17.0~beta1` was released, we decided to skip 2.17.0
altogether. Bumping to 2.18 will help avoid confusion and will also
allow `cfgupgrade` to revert any config changes for people using
`2.17.0~beta1`.