### PR TITLE
GHC 8.0 - 8.4 compatibility

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -812,9 +812,6 @@ HFLAGS = \
 	-hide-all-packages \
 	`cat $(HASKELL_PACKAGE_IDS_FILE)` \
 	$(GHC_BYVERSION_FLAGS)
-if DEVELOPER_MODE
-HFLAGS += -Werror
-endif
 
 HTEST_SUFFIX = hpc
 HPROF_SUFFIX = prof

--- a/Makefile.am
+++ b/Makefile.am
@@ -1024,6 +1024,7 @@ HS_LIB_SRCS = \
 	src/Ganeti/Storage/Lvm/Types.hs \
 	src/Ganeti/Storage/Utils.hs \
 	src/Ganeti/THH.hs \
+	src/Ganeti/THH/Compat.hs \
 	src/Ganeti/THH/Field.hs \
 	src/Ganeti/THH/HsRPC.hs \
 	src/Ganeti/THH/PyRPC.hs \

--- a/Makefile.am
+++ b/Makefile.am
@@ -819,16 +819,11 @@ endif
 HTEST_SUFFIX = hpc
 HPROF_SUFFIX = prof
 
-DEP_SUFFIXES =
-if GHC_LE_76
-DEP_SUFFIXES += -dep-suffix $(HPROF_SUFFIX) -dep-suffix $(HTEST_SUFFIX)
-else
 # GHC >= 7.8 stopped putting underscores into -dep-suffix by itself
 # (https://ghc.haskell.org/trac/ghc/ticket/9749) so we have to put them.
 # It also needs -dep-suffix "" for the .o file.
-DEP_SUFFIXES += -dep-suffix $(HPROF_SUFFIX)_ -dep-suffix $(HTEST_SUFFIX)_ \
+DEP_SUFFIXES = -dep-suffix $(HPROF_SUFFIX)_ -dep-suffix $(HTEST_SUFFIX)_ \
 	-dep-suffix ""
-endif
 
 # GHC > 7.6 needs -dynamic-too when using Template Haskell since its
 # ghci is switched to loading dynamic libraries by default.
@@ -836,10 +831,7 @@ endif
 # We also don't use it in compilations that use HTEST_SUFFIX (which are
 # compiled with -fhpc) because HPC coverage doesn't interact well with
 # GHCI shared lib loading (https://ghc.haskell.org/trac/ghc/ticket/9762).
-HFLAGS_DYNAMIC =
-if !GHC_LE_76
-HFLAGS_DYNAMIC += -dynamic-too
-endif
+HFLAGS_DYNAMIC = -dynamic-too
 
 if HPROFILE
 HPROFFLAGS = -prof -fprof-auto-top -osuf $(HPROF_SUFFIX)_o \
@@ -866,11 +858,7 @@ HEXTRA_COMBINED = $(HEXTRA) $(HEXTRA_CONFIGURE)
 # in base that wasn't fixed until 4.7.0.0 in GHC 7.8 causes random file lock
 # errors in the JQueue tests with the threaded runtime.
 # See https://ghc.haskell.org/trac/ghc/ticket/7646
-if GHC_LE_76
-HEXTRA_TEST =
-else
 HEXTRA_TEST = -threaded -with-rtsopts=-N
-endif
 
 # exclude options for coverage reports
 HPCEXCL = --exclude Main \

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -80,7 +80,7 @@ library
 
   if flag(htest)
     build-depends:
-        HUnit                         >= 1.2.4.2    && < 1.3
+        HUnit                         >= 1.2.4.2    && < 1.7
       , QuickCheck                    >= 2.8        && < 2.12
       , test-framework                >= 0.6        && < 0.9
       , test-framework-hunit          >= 0.2.7      && < 0.4

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -82,7 +82,7 @@ library
   if flag(htest)
     build-depends:
         HUnit                         >= 1.2.4.2    && < 1.3
-      , QuickCheck                    >= 2.4.2      && < 2.8
+      , QuickCheck                    >= 2.8        && < 2.10
       , test-framework                >= 0.6        && < 0.9
       , test-framework-hunit          >= 0.2.7      && < 0.4
       , test-framework-quickcheck2    >= 0.2.12.1   && < 0.4

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -69,7 +69,7 @@ library
     , network                       >= 2.3.0.13   && < 2.7
     , parallel                      >= 3.2.0.2    && < 3.3
     , regex-pcre                    >= 0.94.2     && < 0.95
-    , temporary                     >= 1.1.2.3    && < 1.3
+    , temporary                     >= 1.1.2.3    && < 1.4
     , transformers-base             >= 0.4.1      && < 0.5
     , zlib                          >= 0.5.3.3    && < 0.7
 

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -89,8 +89,8 @@ library
   if flag(mond)
     build-depends:
         PSQueue                       >= 1.1        && < 1.2
-      , snap-core                     >= 0.8.1
-      , snap-server                   >= 0.8.1
+      , snap-core                     >= 1.0.0
+      , snap-server                   >= 1.0.0
 
   if flag(metad)
     build-depends:

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -49,7 +49,7 @@ library
     , pretty                        >= 1.1.1.0
     , process                       >= 1.1.0.1
     , random                        >= 1.0.1.1
-    , template-haskell              >= 2.7.0.0
+    , template-haskell              >= 2.11.0.0
     , text                          >= 0.11.1.13
     , transformers                  >= 0.3.0.0
     , unix                          >= 2.5.1.0

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -66,7 +66,6 @@ library
     , lens                          >= 3.10       && < 5.0
     , lifted-base                   >= 0.2.0.3    && < 0.3
     , monad-control                 >= 0.3.1.3    && < 1.1
-    , MonadCatchIO-transformers     >= 0.3.0.0    && < 0.4
     , network                       >= 2.3.0.13   && < 2.7
     , parallel                      >= 3.2.0.2    && < 3.3
     , regex-pcre                    >= 0.94.2     && < 0.95

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -37,7 +37,7 @@ library
   other-extensions:
       TemplateHaskell
   build-depends:
-      base                          >= 4.5.0.0
+      base                          >= 4.9.0.0
     , array                         >= 0.4.0.0
     , bytestring                    >= 0.9.2.1
     , containers                    >= 0.4.2.1

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -81,7 +81,7 @@ library
   if flag(htest)
     build-depends:
         HUnit                         >= 1.2.4.2    && < 1.3
-      , QuickCheck                    >= 2.8        && < 2.10
+      , QuickCheck                    >= 2.8        && < 2.12
       , test-framework                >= 0.6        && < 0.9
       , test-framework-hunit          >= 0.2.7      && < 0.4
       , test-framework-quickcheck2    >= 0.2.12.1   && < 0.4

--- a/configure.ac
+++ b/configure.ac
@@ -634,10 +634,6 @@ if test -z "$GHC"; then
   AC_MSG_FAILURE([ghc not found, compilation will not possible])
 fi
 
-# Note: Character classes ([...]) need to be double quoted due to autoconf
-# using m4
-AM_CONDITIONAL([GHC_LE_76], [$GHC --numeric-version | grep -q '^7\.[[0-6]]\.'])
-
 AC_MSG_CHECKING([checking for extra GHC flags])
 GHC_BYVERSION_FLAGS=
 # check for GHC supported flags that vary across versions

--- a/src/Ganeti/BasicTypes.hs
+++ b/src/Ganeti/BasicTypes.hs
@@ -87,7 +87,6 @@ import Control.Monad.Trans.Control
 import Data.Function
 import Data.List
 import Data.Maybe
-import Data.Monoid
 import Data.Set (Set)
 import qualified Data.Set as Set (empty)
 import Text.JSON (JSON)

--- a/src/Ganeti/Codec.hs
+++ b/src/Ganeti/Codec.hs
@@ -44,7 +44,6 @@ import qualified Codec.Compression.Zlib.Internal as I
 import Control.Monad.Except
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Internal as BL
-import Data.Monoid (mempty)
 
 
 -- | Compresses a lazy bytestring.
@@ -55,18 +54,8 @@ compressZlib = compressWith $
 -- | Decompresses a lazy bytestring, throwing decoding errors using
 -- 'throwError'.
 decompressZlib :: (MonadError String m) => BL.ByteString -> m BL.ByteString
-#if MIN_VERSION_zlib(0, 6, 0)
 decompressZlib = I.foldDecompressStreamWithInput
                    (liftM . BL.chunk)
                    return
                    (throwError . (++)"Zlib: " . show)
                    $ I.decompressST I.zlibFormat I.defaultDecompressParams
-#else
-decompressZlib = I.foldDecompressStream
-                     (liftM . BL.chunk)
-                     (return mempty)
-                     (const $ throwError . ("Zlib: " ++))
-                 . I.decompressWithErrors
-                     I.zlibFormat
-                     I.defaultDecompressParams
-#endif

--- a/src/Ganeti/Compat.hs
+++ b/src/Ganeti/Compat.hs
@@ -38,35 +38,19 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 
 module Ganeti.Compat
-  ( rwhnf
-  , Control.Parallel.Strategies.parMap
-  , finiteBitSize
+  ( finiteBitSize
   , atomicModifyIORef'
   , filePath'
   , maybeFilePath'
   , toInotifyPath
   ) where
 
-import qualified Control.Parallel.Strategies
 import qualified Data.Bits
 import qualified Data.IORef
 import qualified Data.ByteString.UTF8 as UTF8
 import System.FilePath (FilePath)
 import System.Posix.ByteString.FilePath (RawFilePath)
 import qualified System.INotify
-
--- | Wrapper over the function exported from
--- "Control.Parallel.Strategies".
---
--- This wraps either the old or the new name of the function,
--- depending on the detected library version.
-rwhnf :: Control.Parallel.Strategies.Strategy a
-#if MIN_VERSION_parallel(3,0,0)
-rwhnf = Control.Parallel.Strategies.rseq
-#else
-rwhnf = Control.Parallel.Strategies.rwhnf
-#endif
-
 
 #if __GLASGOW_HASKELL__ < 707
 finiteBitSize :: (Data.Bits.Bits a) => a -> Int

--- a/src/Ganeti/Compat.hs
+++ b/src/Ganeti/Compat.hs
@@ -38,28 +38,17 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 
 module Ganeti.Compat
-  ( finiteBitSize
-  , atomicModifyIORef'
+  ( atomicModifyIORef'
   , filePath'
   , maybeFilePath'
   , toInotifyPath
   ) where
 
-import qualified Data.Bits
 import qualified Data.IORef
 import qualified Data.ByteString.UTF8 as UTF8
 import System.FilePath (FilePath)
 import System.Posix.ByteString.FilePath (RawFilePath)
 import qualified System.INotify
-
-#if __GLASGOW_HASKELL__ < 707
-finiteBitSize :: (Data.Bits.Bits a) => a -> Int
-finiteBitSize = Data.Bits.bitSize
-#else
-finiteBitSize :: (Data.Bits.FiniteBits a) => a -> Int
-finiteBitSize = Data.Bits.finiteBitSize
-#endif
-{-# INLINE finiteBitSize #-}
 
 -- FIXME: remove this when dropping support for GHC 7.4.
 atomicModifyIORef' :: Data.IORef.IORef a -> (a -> (a, b)) -> IO b

--- a/src/Ganeti/Compat.hs
+++ b/src/Ganeti/Compat.hs
@@ -38,29 +38,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 
 module Ganeti.Compat
-  ( atomicModifyIORef'
-  , filePath'
+  ( filePath'
   , maybeFilePath'
   , toInotifyPath
   ) where
 
-import qualified Data.IORef
 import qualified Data.ByteString.UTF8 as UTF8
 import System.FilePath (FilePath)
 import System.Posix.ByteString.FilePath (RawFilePath)
 import qualified System.INotify
-
--- FIXME: remove this when dropping support for GHC 7.4.
-atomicModifyIORef' :: Data.IORef.IORef a -> (a -> (a, b)) -> IO b
-#if MIN_VERSION_base(4,6,0)
-atomicModifyIORef' = Data.IORef.atomicModifyIORef'
-#else
-atomicModifyIORef' ref f = do
-    b <- Data.IORef.atomicModifyIORef ref $ \a ->
-            case f a of
-                v@(a',_) -> a' `seq` v
-    b `seq` return b
-#endif
 
 -- | Wrappers converting ByteString filepaths to Strings and vice versa
 --

--- a/src/Ganeti/Confd/Client.hs
+++ b/src/Ganeti/Confd/Client.hs
@@ -40,9 +40,11 @@ module Ganeti.Confd.Client
 import Control.Concurrent
 import Control.Exception (bracket)
 import Control.Monad
+import qualified Data.ByteString.Char8 as Char8
 import Data.List
 import Data.Maybe
 import qualified Network.Socket as S
+import Network.Socket.ByteString (sendTo, recv)
 import System.Posix.Time
 import qualified Text.JSON as J
 
@@ -133,8 +135,8 @@ queryOneServer semaphore answer crType cQuery hmac (host, port) = do
     exitIfBad "Unable to resolve the IP address" addr
   replyMsg <- bracket (S.socket af_family S.Datagram S.defaultProtocol) S.close
                 $ \s -> do
-    _ <- S.sendTo s completeMsg sockaddr
-    S.recv s C.maxUdpDataSize
+    _ <- sendTo s (Char8.pack completeMsg) sockaddr
+    Char8.unpack <$> recv s C.maxUdpDataSize
   parsedReply <-
     if C.confdMagicFourcc `isPrefixOf` replyMsg
       then return . parseReply hmac (drop 4 replyMsg) $ confdRqRsalt request

--- a/src/Ganeti/Confd/Client.hs
+++ b/src/Ganeti/Confd/Client.hs
@@ -131,7 +131,7 @@ queryOneServer semaphore answer crType cQuery hmac (host, port) = do
   addr <- resolveAddr (fromIntegral port) host
   (af_family, sockaddr) <-
     exitIfBad "Unable to resolve the IP address" addr
-  replyMsg <- bracket (S.socket af_family S.Datagram S.defaultProtocol) S.sClose
+  replyMsg <- bracket (S.socket af_family S.Datagram S.defaultProtocol) S.close
                 $ \s -> do
     _ <- S.sendTo s completeMsg sockaddr
     S.recv s C.maxUdpDataSize

--- a/src/Ganeti/Confd/Server.hs
+++ b/src/Ganeti/Confd/Server.hs
@@ -40,7 +40,6 @@ module Ganeti.Confd.Server
   , prepMain
   ) where
 
-import Control.Applicative((<$>))
 import Control.Concurrent
 import Control.Monad (forever, liftM)
 import Data.IORef

--- a/src/Ganeti/Confd/Server.hs
+++ b/src/Ganeti/Confd/Server.hs
@@ -353,7 +353,7 @@ prepMain :: PrepFn (S.Family, S.SockAddr) PrepResult
 prepMain _ (af_family, bindaddr) = do
   s <- S.socket af_family S.Datagram S.defaultProtocol
   S.setSocketOption s S.ReuseAddr 1
-  S.bindSocket s bindaddr
+  S.bind s bindaddr
   cref <- newIORef (Bad "Configuration not yet loaded")
   return (s, cref)
 

--- a/src/Ganeti/Confd/Utils.hs
+++ b/src/Ganeti/Confd/Utils.hs
@@ -47,7 +47,6 @@ module Ganeti.Confd.Utils
 
 import qualified Data.Attoparsec.Text as P
 
-import Control.Applicative ((*>))
 import qualified Data.ByteString as B
 import Data.Text (pack)
 import qualified Text.JSON as J

--- a/src/Ganeti/Config.hs
+++ b/src/Ganeti/Config.hs
@@ -82,7 +82,6 @@ module Ganeti.Config
     , instNodes
     ) where
 
-import Control.Applicative
 import Control.Arrow ((&&&))
 import Control.Monad
 import Control.Monad.State

--- a/src/Ganeti/ConfigReader.hs
+++ b/src/Ganeti/ConfigReader.hs
@@ -46,6 +46,7 @@ import System.INotify
 
 import Ganeti.BasicTypes
 import Ganeti.Objects
+import Ganeti.Compat
 import Ganeti.Confd.Utils
 import Ganeti.Config
 import Ganeti.Logging
@@ -246,7 +247,7 @@ addNotifier :: INotify -> FilePath -> (Result ConfigData -> IO ())
             -> MVar ServerState -> IO Bool
 addNotifier inotify path save_fn mstate =
   Control.Exception.catch
-        (addWatch inotify [CloseWrite] path
+        (addWatch inotify [CloseWrite] (toInotifyPath path)
             (onInotify inotify path save_fn mstate) >> return True)
         (\e -> const (return False) (e::IOError))
 

--- a/src/Ganeti/ConstantUtils.hs
+++ b/src/Ganeti/ConstantUtils.hs
@@ -38,7 +38,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 module Ganeti.ConstantUtils where
 
 import Data.Char (ord)
-import Data.Monoid (Monoid(..))
 import Data.Set (Set)
 import qualified Data.Set as Set (difference, fromList, toList, union)
 

--- a/src/Ganeti/ConstantUtils.hs
+++ b/src/Ganeti/ConstantUtils.hs
@@ -40,6 +40,7 @@ module Ganeti.ConstantUtils where
 import Data.Char (ord)
 import Data.Set (Set)
 import qualified Data.Set as Set (difference, fromList, toList, union)
+import qualified Data.Semigroup as Sem
 
 import Ganeti.PyValue
 
@@ -62,9 +63,12 @@ instance PyValue PythonNone where
 newtype FrozenSet a = FrozenSet { unFrozenSet :: Set a }
   deriving (Eq, Ord, Show)
 
+instance (Ord a) => Sem.Semigroup (FrozenSet a) where
+  (FrozenSet s) <> (FrozenSet t) = FrozenSet (mappend s t)
+
 instance (Ord a) => Monoid (FrozenSet a) where
   mempty = FrozenSet mempty
-  mappend (FrozenSet s) (FrozenSet t) = FrozenSet (mappend s t)
+  mappend = (Sem.<>)
 
 -- | Converts a Haskell 'Set' into a Python 'frozenset'
 --

--- a/src/Ganeti/Cpu/LoadParser.hs
+++ b/src/Ganeti/Cpu/LoadParser.hs
@@ -36,7 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 module Ganeti.Cpu.LoadParser (cpustatParser) where
 
-import Control.Applicative ((<*>), (<*), (*>), (<$>), (<|>))
+import Control.Applicative ((<|>))
 import qualified Data.Attoparsec.Text as A
 import qualified Data.Attoparsec.Combinator as AC
 import Data.Attoparsec.Text (Parser)

--- a/src/Ganeti/DataCollectors.hs
+++ b/src/Ganeti/DataCollectors.hs
@@ -36,7 +36,6 @@ module Ganeti.DataCollectors( collectors ) where
 
 import qualified Data.ByteString.UTF8 as UTF8
 import Data.Map (findWithDefault)
-import Data.Monoid (mempty)
 
 import qualified Ganeti.DataCollectors.CPUload as CPUload
 import qualified Ganeti.DataCollectors.Diskstats as Diskstats

--- a/src/Ganeti/DataCollectors/XenCpuLoad.hs
+++ b/src/Ganeti/DataCollectors/XenCpuLoad.hs
@@ -42,7 +42,7 @@ module Ganeti.DataCollectors.XenCpuLoad
   , dcUpdate
   ) where
 
-import Control.Applicative ((<$>), liftA2)
+import Control.Applicative (liftA2)
 import Control.Arrow ((***))
 import Control.Monad (liftM, when)
 import Control.Monad.IO.Class (liftIO)

--- a/src/Ganeti/HTools/Cluster.hs
+++ b/src/Ganeti/HTools/Cluster.hs
@@ -82,7 +82,7 @@ module Ganeti.HTools.Cluster
   , findSplitInstances
   ) where
 
-import Control.Applicative ((<$>), liftA2)
+import Control.Applicative (liftA2)
 import Control.Arrow ((&&&))
 import Control.Monad (unless)
 import qualified Data.IntSet as IntSet

--- a/src/Ganeti/HTools/Dedicated.hs
+++ b/src/Ganeti/HTools/Dedicated.hs
@@ -44,7 +44,7 @@ module Ganeti.HTools.Dedicated
   , runDedicatedAllocation
   ) where
 
-import Control.Applicative (liftA2, (<$>))
+import Control.Applicative (liftA2)
 import Control.Arrow ((&&&))
 import Control.Monad (unless, liftM, foldM, mplus)
 import qualified Data.Foldable as F

--- a/src/Ganeti/HTools/Graph.hs
+++ b/src/Ganeti/HTools/Graph.hs
@@ -232,6 +232,6 @@ colorDsatur g =
 
 -- | ColorVertMap from VertColorMap.
 colorVertMap :: VertColorMap -> ColorVertMap
-colorVertMap = IntMap.foldWithKey
+colorVertMap = IntMap.foldrWithKey
                  (flip (IntMap.insertWith ((:) . head)) . replicate 1)
                  IntMap.empty

--- a/src/Ganeti/HTools/Node.hs
+++ b/src/Ganeti/HTools/Node.hs
@@ -102,7 +102,6 @@ module Ganeti.HTools.Node
   ) where
 
 import Control.Monad (liftM, liftM2)
-import Control.Applicative ((<$>), (<*>))
 import qualified Data.Foldable as Foldable
 import Data.Function (on)
 import qualified Data.Graph as Graph

--- a/src/Ganeti/Hypervisor/Xen/XmParser.hs
+++ b/src/Ganeti/Hypervisor/Xen/XmParser.hs
@@ -71,7 +71,7 @@ lispConfigParser =
           doubleP = LCDouble <$> A.rational <* A.skipSpace <* A.endOfInput
           innerDoubleP = LCDouble <$> A.rational
           stringP = LCString . unpack <$> A.takeWhile1 (not . (\c -> isSpace c
-            || c `elem` "()"))
+            || c `elem` ("()" :: String)))
           wspace = AC.many1 A.space
           rparen = A.skipSpace *> A.char ')'
           finalP =   listConfigP <* rparen
@@ -163,5 +163,5 @@ uptimeLineParser :: Parser UptimeInfo
 uptimeLineParser = do
   name <- A.takeTill isSpace <* A.skipSpace
   idNum <- A.decimal <* A.skipSpace
-  uptime <- A.takeTill (`elem` "\n\r") <* A.skipSpace
+  uptime <- A.takeTill (`elem` ("\n\r" :: String)) <* A.skipSpace
   return . UptimeInfo (unpack name) idNum $ unpack uptime

--- a/src/Ganeti/JQScheduler.hs
+++ b/src/Ganeti/JQScheduler.hs
@@ -55,7 +55,7 @@ import Control.Exception
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.Function (on)
-import Data.IORef (IORef, atomicModifyIORef, newIORef, readIORef)
+import Data.IORef (IORef, atomicModifyIORef, atomicModifyIORef', newIORef, readIORef)
 import Data.List
 import Data.Maybe
 import qualified Data.Map as Map

--- a/src/Ganeti/JQScheduler.hs
+++ b/src/Ganeti/JQScheduler.hs
@@ -48,14 +48,13 @@ module Ganeti.JQScheduler
   , configChangeNeedsRescheduling
   ) where
 
-import Control.Applicative (liftA2, (<$>))
+import Control.Applicative (liftA2)
 import Control.Arrow
 import Control.Concurrent
 import Control.Exception
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.Function (on)
-import Data.Functor ((<$))
 import Data.IORef (IORef, atomicModifyIORef, newIORef, readIORef)
 import Data.List
 import Data.Maybe

--- a/src/Ganeti/JQScheduler.hs
+++ b/src/Ganeti/JQScheduler.hs
@@ -279,7 +279,7 @@ jobWatcher state jWS e = do
   let inotify = jINotify jWS
   when (e == Ignored  && isJust inotify) $ do
     qdir <- queueDir
-    let fpath = liveJobFile qdir jid
+    let fpath = toInotifyPath $ liveJobFile qdir jid
     _ <- addWatch (fromJust inotify) [Modify, Delete] fpath
            (jobWatcher state jWS)
     return ()
@@ -297,7 +297,7 @@ attachWatcher state jWS = when (isNothing $ jINotify jWS) $ do
      let fpath = liveJobFile qdir . qjId $ jJob jWS
          jWS' = jWS { jINotify=Just inotify }
      logDebug $ "Attaching queue watcher for " ++ fpath
-     _ <- addWatch inotify [Modify, Delete] fpath $ jobWatcher state jWS'
+     _ <- addWatch inotify [Modify, Delete] (toInotifyPath fpath) $ jobWatcher state jWS'
      modifyJobs state . onRunningJobs $ updateJobStatus jWS'
    else logDebug $ "Not attaching watcher for job "
                    ++ (show . fromJobId . qjId $ jJob jWS)

--- a/src/Ganeti/JQueue.hs
+++ b/src/Ganeti/JQueue.hs
@@ -82,7 +82,7 @@ module Ganeti.JQueue
     , QueuedJob(..)
     ) where
 
-import Control.Applicative (liftA2, (<|>), (<$>))
+import Control.Applicative (liftA2, (<|>))
 import Control.Arrow (first, second)
 import Control.Concurrent (forkIO, threadDelay)
 import Control.Exception
@@ -91,7 +91,6 @@ import Control.Monad
 import Control.Monad.IO.Class
 import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Maybe
-import Data.Functor ((<$))
 import Data.List
 import Data.Maybe
 import Data.Ord (comparing)

--- a/src/Ganeti/JSON.hs
+++ b/src/Ganeti/JSON.hs
@@ -95,6 +95,7 @@ import qualified Data.Traversable as F
 import Data.Maybe (fromMaybe, catMaybes)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import qualified Data.Semigroup as Sem
 import System.Time (ClockTime(..))
 import Text.Printf (printf)
 
@@ -396,9 +397,12 @@ instance (HasStringRepr a, Ord a, J.JSON b) =>
 
 newtype UsedKeys = UsedKeys (Maybe (Set.Set T.Text))
 
+instance Sem.Semigroup UsedKeys where
+  (UsedKeys xs) <> (UsedKeys ys) = UsedKeys $ liftA2 Set.union xs ys
+
 instance Monoid UsedKeys where
   mempty = UsedKeys (Just Set.empty)
-  mappend (UsedKeys xs) (UsedKeys ys) = UsedKeys $ liftA2 Set.union xs ys
+  mappend = (Sem.<>)
 
 mkUsedKeys :: Set.Set T.Text -> UsedKeys
 mkUsedKeys = UsedKeys . Just

--- a/src/Ganeti/Kvmd.hs
+++ b/src/Ganeti/Kvmd.hs
@@ -61,7 +61,6 @@ module Ganeti.Kvmd where
 
 import Prelude hiding (rem)
 
-import Control.Applicative ((<$>))
 import Control.Exception (try)
 import Control.Concurrent
 import Control.Monad (unless, when)

--- a/src/Ganeti/Kvmd.hs
+++ b/src/Ganeti/Kvmd.hs
@@ -75,6 +75,7 @@ import System.INotify
 
 import qualified AutoConf
 import qualified Ganeti.BasicTypes as BasicTypes
+import Ganeti.Compat
 import qualified Ganeti.Constants as Constants
 import qualified Ganeti.Daemon as Daemon (getFQDN)
 import qualified Ganeti.Logging as Logging
@@ -221,7 +222,7 @@ ensureMonitor monitors monitorFile =
 handleGenericEvent :: Lock -> String -> String -> Event -> IO ()
 handleGenericEvent lock curDir tarDir ev@Created {}
   | isDirectory ev && curDir /= tarDir &&
-    (curDir </> filePath ev) `isPrefixPath` tarDir = putMVar lock ()
+    (curDir </> filePath' ev) `isPrefixPath` tarDir = putMVar lock ()
 handleGenericEvent lock _ _ event
   | event == DeletedSelf || event == Unmounted = putMVar lock ()
 handleGenericEvent _ _ _ _ = return ()
@@ -232,23 +233,23 @@ handleGenericEvent _ _ _ _ = return ()
 -- ensures that there is a monitor running for the new Qmp socket.
 handleTargetEvent :: Lock -> Monitors -> String -> Event -> IO ()
 handleTargetEvent _ monitors tarDir ev@Created {}
-  | not (isDirectory ev) && isMonitorPath (filePath ev) =
-    ensureMonitor monitors $ tarDir </> filePath ev
+  | not (isDirectory ev) && isMonitorPath (filePath' ev) =
+    ensureMonitor monitors $ tarDir </> filePath' ev
 handleTargetEvent lock monitors tarDir ev@Opened {}
   | not (isDirectory ev) =
-    case maybeFilePath ev of
+    case maybeFilePath' ev of
       Just p | isMonitorPath p ->
-        ensureMonitor monitors $ tarDir </> filePath ev
+        ensureMonitor monitors $ tarDir </> filePath' ev
       _ ->
         handleGenericEvent lock tarDir tarDir ev
 handleTargetEvent _ _ tarDir ev@Created {}
-  | not (isDirectory ev) && takeExtension (filePath ev) == shutdownExtension =
+  | not (isDirectory ev) && takeExtension (filePath' ev) == shutdownExtension =
     Logging.logInfo $ "User shutdown file opened " ++
-      show (tarDir </> filePath ev)
+      show (tarDir </> filePath' ev)
 handleTargetEvent _ _ tarDir ev@Deleted {}
-  | not (isDirectory ev) && takeExtension (filePath ev) == shutdownExtension =
+  | not (isDirectory ev) && takeExtension (filePath' ev) == shutdownExtension =
     Logging.logInfo $ "User shutdown file deleted " ++
-      show (tarDir </> filePath ev)
+      show (tarDir </> filePath' ev)
 handleTargetEvent lock _ tarDir ev =
   handleGenericEvent lock tarDir tarDir ev
 
@@ -265,7 +266,7 @@ handleDir lock monitors curDir tarDir event =
 recapDir :: Lock -> Monitors -> FilePath -> IO ()
 recapDir lock monitors dir =
   do files <- getDirectoryContents dir
-     let files' = filter isMonitorPath files
+     let files' = map toInotifyPath $ filter isMonitorPath files
      mapM_ sendEvent files'
   where sendEvent file =
           handleTargetEvent lock monitors dir Created { isDirectory = False
@@ -289,7 +290,7 @@ watchDir lock tarDir inotify = watchDir' tarDir
                  let events = watchDirEvents dir
                  Logging.logInfo $ "Watch directory " ++ show dir
                  monitors <- newMVar Set.empty
-                 wd <- addWatch inotify events dir
+                 wd <- addWatch inotify events (toInotifyPath dir)
                        (handleDir lock monitors dir tarDir)
                  when (dir == tarDir) $ recapDir lock monitors dir
                  () <- takeMVar lock

--- a/src/Ganeti/Lens.hs
+++ b/src/Ganeti/Lens.hs
@@ -44,7 +44,7 @@ module Ganeti.Lens
   , atSet
   ) where
 
-import Control.Applicative ((<$>), WrappedMonad(..))
+import Control.Applicative (WrappedMonad(..))
 import Control.Lens
 import Control.Monad
 import Data.Functor.Compose (Compose(..))

--- a/src/Ganeti/Locking/Allocation.hs
+++ b/src/Ganeti/Locking/Allocation.hs
@@ -50,7 +50,7 @@ module Ganeti.Locking.Allocation
   , freeLocks
   ) where
 
-import Control.Applicative (liftA2, (<$>), (<*>), pure)
+import Control.Applicative (liftA2)
 import Control.Arrow (second, (***))
 import Control.Monad
 import Data.Foldable (for_, find)

--- a/src/Ganeti/Locking/Locks.hs
+++ b/src/Ganeti/Locking/Locks.hs
@@ -44,7 +44,6 @@ module Ganeti.Locking.Locks
   , lockLevel
   ) where
 
-import Control.Applicative ((<$>), (<*>), pure)
 import Control.Monad ((>=>), liftM)
 import Data.List (stripPrefix)
 import System.Posix.Types (ProcessID)

--- a/src/Ganeti/Logging.hs
+++ b/src/Ganeti/Logging.hs
@@ -60,7 +60,6 @@ module Ganeti.Logging
   , isDebugMode
   ) where
 
-import Control.Applicative ((<$>))
 import Control.Monad
 import Control.Monad.Error (Error(..), MonadError(..), catchError)
 import Control.Monad.Reader
@@ -68,7 +67,6 @@ import qualified Control.Monad.RWS.Strict as RWSS
 import qualified Control.Monad.State.Strict as SS
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.Maybe
-import Data.Monoid
 import System.Log.Logger
 import System.Log.Handler.Simple
 import System.Log.Handler.Syslog

--- a/src/Ganeti/Metad/ConfigCore.hs
+++ b/src/Ganeti/Metad/ConfigCore.hs
@@ -35,7 +35,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 module Ganeti.Metad.ConfigCore where
 
-import Control.Applicative
 import Control.Concurrent.MVar.Lifted
 import Control.Monad.Base
 import Control.Monad.IO.Class

--- a/src/Ganeti/Metad/ConfigCore.hs
+++ b/src/Ganeti/Metad/ConfigCore.hs
@@ -70,7 +70,7 @@ instance MonadBaseControl IO MetadMonadInt where
 #if MIN_VERSION_monad_control(1,0,0)
 -- Needs Undecidable instances
   type StM MetadMonadInt b = StM MetadMonadIntType b
-  liftBaseWith f = MetadMonadInt . liftBaseWith
+  liftBaseWith f = MetadMonadInt $ liftBaseWith
                    $ \r -> f (r . getMetadMonadInt)
   restoreM = MetadMonadInt . restoreM
 #else

--- a/src/Ganeti/Metad/ConfigCore.hs
+++ b/src/Ganeti/Metad/ConfigCore.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TupleSections, TemplateHaskell, CPP, UndecidableInstances,
-    MultiParamTypeClasses, TypeFamilies, GeneralizedNewtypeDeriving #-}
+    MultiParamTypeClasses, TypeFamilies, GeneralizedNewtypeDeriving,
+    ImpredicativeTypes #-}
 {-| Functions of the metadata daemon exported for RPC
 
 -}

--- a/src/Ganeti/Metad/WebServer.hs
+++ b/src/Ganeti/Metad/WebServer.hs
@@ -39,7 +39,7 @@ import Control.Applicative
 import Control.Concurrent (MVar, readMVar)
 import Control.Monad.Error.Class (MonadError, catchError, throwError)
 import Control.Monad.IO.Class (liftIO)
-import qualified Control.Monad.CatchIO as CatchIO (catch)
+import Control.Exception.Lifted (catch)
 import qualified Data.CaseInsensitive as CI
 import Data.List (intercalate)
 import Data.Map (Map)
@@ -105,7 +105,7 @@ serveOsPackage inst params key =
      maybeResult (JSON.readJSON instParams >>=
                   Config.getPublicOsParams >>=
                   getOsPackage) $ \package ->
-       serveFile package `CatchIO.catch` \err ->
+       serveFile package `catch` \err ->
          throwError $ "Could not serve OS package: " ++ show (err :: IOError)
   where getOsPackage osParams =
           case lookup key (JSON.fromJSObject osParams) of
@@ -130,7 +130,7 @@ serveOsScript inst params script =
           throwError $ "Could not find OS script " ++ show (os </> script)
         serveScript os (d:ds) =
           serveFile (d </> os </> script)
-          `CatchIO.catch`
+          `catch`
           \err -> do let _ = err :: IOError
                      serveScript os ds
 

--- a/src/Ganeti/Metad/WebServer.hs
+++ b/src/Ganeti/Metad/WebServer.hs
@@ -37,9 +37,11 @@ module Ganeti.Metad.WebServer (start) where
 
 import Control.Applicative
 import Control.Concurrent (MVar, readMVar)
-import Control.Monad.Error.Class (MonadError, catchError, throwError)
+import Control.Monad.Base (MonadBase)
 import Control.Monad.IO.Class (liftIO)
-import Control.Exception.Lifted (catch)
+import Control.Exception.Lifted (catch, throwIO)
+import Control.Exception.Base (Exception)
+import Data.Typeable (Typeable)
 import qualified Data.CaseInsensitive as CI
 import Data.List (intercalate)
 import Data.Map (Map)
@@ -63,13 +65,19 @@ import Ganeti.Metad.Types (InstanceParams)
 
 type MetaM = Snap ()
 
+data MetaMExc = MetaMExc String deriving (Show, Typeable)
+instance Exception MetaMExc
+
+throwError :: MonadBase IO m => String -> m a
+throwError = throwIO . MetaMExc
+
 split :: String -> [String]
 split str =
   case span (/= '/') str of
     (x, []) -> [x]
     (x, _:xs) -> x:split xs
 
-lookupInstanceParams :: MonadError String m => String -> Map String b -> m b
+lookupInstanceParams :: MonadBase IO m => String -> Map String b -> m b
 lookupInstanceParams inst params =
   case Map.lookup inst params of
     Nothing -> throwError $ "Could not get instance params for " ++ show inst
@@ -87,7 +95,7 @@ error405 ms = modifyResponse $
   addHeader (CI.mk "Allow") (ByteString.pack . intercalate ", " $ map show ms)
   . setResponseStatus 405 "Method not allowed"
 
-maybeResult :: MonadError String m => Result t -> (t -> m a) -> m a
+maybeResult :: MonadBase IO m => Result t -> (t -> m a) -> m a
 maybeResult (Error err) _ = throwError err
 maybeResult (Ok x) f = f x
 
@@ -144,10 +152,11 @@ handleMetadata params GET  "ganeti" "latest" "os/os-install-package" =
        Logging.logInfo $ "OS install package for " ++ show remoteAddr
        readMVar params
      serveOsPackage remoteAddr instanceParams "os-install-package"
-       `catchError`
+       `catch`
        \err -> do
+         let MetaMExc e = err
          liftIO .
-           Logging.logWarning $ "Could not serve OS install package: " ++ err
+           Logging.logWarning $ "Could not serve OS install package: " ++ e
          error404
 handleMetadata params GET  "ganeti" "latest" "os/package" =
   do remoteAddr <- ByteString.unpack . rqRemoteAddr <$> getRequest
@@ -160,18 +169,20 @@ handleMetadata params GET  "ganeti" "latest" "os/parameters.json" =
      instanceParams <- liftIO $ do
        Logging.logInfo $ "OS parameters for " ++ show remoteAddr
        readMVar params
-     serveOsParams remoteAddr instanceParams `catchError`
+     serveOsParams remoteAddr instanceParams `catch`
        \err -> do
-         liftIO . Logging.logWarning $ "Could not serve OS parameters: " ++ err
+         let MetaMExc e = err
+         liftIO . Logging.logWarning $ "Could not serve OS parameters: " ++ e
          error404
 handleMetadata params GET  "ganeti" "latest" script | isScript script =
   do remoteAddr <- ByteString.unpack . rqRemoteAddr <$> getRequest
      instanceParams <- liftIO $ do
        Logging.logInfo $ "OS package for " ++ show remoteAddr
        readMVar params
-     serveOsScript remoteAddr instanceParams (last $ split script) `catchError`
+     serveOsScript remoteAddr instanceParams (last $ split script) `catch`
        \err -> do
-         liftIO . Logging.logWarning $ "Could not serve OS scripts: " ++ err
+         let MetaMExc e = err
+         liftIO . Logging.logWarning $ "Could not serve OS scripts: " ++ e
          error404
   where isScript =
           (`elem` [ "os/scripts/create"

--- a/src/Ganeti/Monitoring/Server.hs
+++ b/src/Ganeti/Monitoring/Server.hs
@@ -50,7 +50,6 @@ import Data.ByteString.Char8 (pack, unpack)
 import qualified Data.ByteString.UTF8 as UTF8
 import Data.Maybe (fromMaybe)
 import Data.List (find)
-import Data.Monoid (mempty)
 import qualified Data.Map as Map
 import qualified Data.PSQueue as Queue
 import Network.BSD (getServicePortNumber)

--- a/src/Ganeti/Objects.hs
+++ b/src/Ganeti/Objects.hs
@@ -105,14 +105,12 @@ module Ganeti.Objects
   , module Ganeti.Objects.Instance
   ) where
 
-import Control.Applicative
 import Control.Arrow (first)
 import Control.Monad.State
 import qualified Data.ByteString.UTF8 as UTF8
 import Data.List (foldl', intercalate)
 import Data.Maybe
 import qualified Data.Map as Map
-import Data.Monoid
 import Data.Ord (comparing)
 import Data.Ratio (numerator, denominator)
 import Data.Tuple (swap)

--- a/src/Ganeti/Objects.hs
+++ b/src/Ganeti/Objects.hs
@@ -113,6 +113,7 @@ import Data.Maybe
 import qualified Data.Map as Map
 import Data.Ord (comparing)
 import Data.Ratio (numerator, denominator)
+import qualified Data.Semigroup as Sem
 import Data.Tuple (swap)
 import Data.Word
 import Text.JSON (showJSON, readJSON, JSON, JSValue(..), fromJSString,
@@ -284,12 +285,15 @@ $(buildObject "DataCollectorConfig" "dataCollector" [
   ])
 
 -- | Central default values of the data collector config.
+instance Sem.Semigroup DataCollectorConfig where
+  _ <> a = a
+
 instance Monoid DataCollectorConfig where
   mempty = DataCollectorConfig
     { dataCollectorActive = True
     , dataCollectorInterval = 10^(6::Integer) * fromIntegral C.mondTimeInterval
     }
-  mappend _ a = a
+  mappend = (Sem.<>)
 
 -- * IPolicy definitions
 

--- a/src/Ganeti/Objects/Disk.hs
+++ b/src/Ganeti/Objects/Disk.hs
@@ -36,7 +36,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module Ganeti.Objects.Disk where
 
-import Control.Applicative ((<*>), (<$>))
 import qualified Data.ByteString.UTF8 as UTF8
 import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
 import Data.List (isPrefixOf, isInfixOf)

--- a/src/Ganeti/Objects/Instance.hs
+++ b/src/Ganeti/Objects/Instance.hs
@@ -40,7 +40,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 module Ganeti.Objects.Instance where
 
 import qualified Data.ByteString.UTF8 as UTF8
-import Data.Monoid
 
 import Ganeti.JSON (emptyContainer)
 import Ganeti.Objects.Nic

--- a/src/Ganeti/OpCodes.hs
+++ b/src/Ganeti/OpCodes.hs
@@ -58,7 +58,6 @@ module Ganeti.OpCodes
   , setOpPriority
   ) where
 
-import Control.Applicative
 import Data.List (intercalate)
 import Data.Map (Map)
 import qualified Text.JSON

--- a/src/Ganeti/OpParams.hs
+++ b/src/Ganeti/OpParams.hs
@@ -905,12 +905,12 @@ pPowerDelay =
 pRequiredNodes :: Field
 pRequiredNodes =
   withDoc "Required list of node names" .
-  renameField "ReqNodes " $ simpleField "nodes" [t| [NonEmptyString] |]
+  renameField "ReqNodes" $ simpleField "nodes" [t| [NonEmptyString] |]
 
 pRequiredNodeUuids :: Field
 pRequiredNodeUuids =
   withDoc "Required list of node UUIDs" .
-  renameField "ReqNodeUuids " . optionalField $
+  renameField "ReqNodeUuids" . optionalField $
   simpleField "node_uuids" [t| [NonEmptyString] |]
 
 pRestrictedCommand :: Field
@@ -1521,7 +1521,7 @@ pOsNameChange =
 pDiskIndex :: Field
 pDiskIndex =
   withDoc "Disk index for e.g. grow disk" .
-  renameField "DiskIndex " $ simpleField "disk" [t| DiskIndex |]
+  renameField "DiskIndex" $ simpleField "disk" [t| DiskIndex |]
 
 pDiskChgAmount :: Field
 pDiskChgAmount =
@@ -1742,7 +1742,7 @@ pIAllocatorOs =
 pIAllocatorInstances :: Field
 pIAllocatorInstances =
   withDoc "IAllocator instances field" .
-  renameField "IAllocatorInstances " .
+  renameField "IAllocatorInstances" .
   optionalField $
   simpleField "instances" [t| [NonEmptyString] |]
 

--- a/src/Ganeti/Parsers.hs
+++ b/src/Ganeti/Parsers.hs
@@ -37,7 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 module Ganeti.Parsers where
 
-import Control.Applicative ((*>))
 import qualified Data.Attoparsec.Text as A
 import Data.Attoparsec.Text (Parser)
 import Data.Text (unpack)

--- a/src/Ganeti/Query/Exec.hs
+++ b/src/Ganeti/Query/Exec.hs
@@ -65,7 +65,6 @@ import Control.Concurrent.Lifted (threadDelay)
 import Control.Exception (finally)
 import Control.Monad
 import Control.Monad.Error
-import Data.Functor
 import qualified Data.Map as M
 import Data.Maybe (listToMaybe, mapMaybe)
 import System.Directory (getDirectoryContents)

--- a/src/Ganeti/Query/Filter.hs
+++ b/src/Ganeti/Query/Filter.hs
@@ -136,7 +136,7 @@ trueFilter v = Bad . ParameterError $
 -- | A type synonim for a rank-2 comparator function. This is used so
 -- that we can pass the usual '<=', '>', '==' functions to 'binOpFilter'
 -- and for them to be used in multiple contexts.
-type Comparator = (Eq a, Ord a) => a -> a -> Bool
+type Comparator = forall a . (Eq a, Ord a) => a -> a -> Bool
 
 -- | Equality checker.
 --

--- a/src/Ganeti/Query/Filter.hs
+++ b/src/Ganeti/Query/Filter.hs
@@ -66,13 +66,11 @@ module Ganeti.Query.Filter
   , FilterOp(..)
   ) where
 
-import Control.Applicative
 import Control.Monad (liftM, mzero)
 import Control.Monad.Trans.Maybe (MaybeT, runMaybeT)
 import Control.Monad.Trans.Class (lift)
 import qualified Data.Map as Map
 import Data.Maybe
-import Data.Traversable (traverse)
 import Text.JSON (JSValue(..), fromJSString)
 import Text.JSON.Pretty (pp_value)
 import qualified Text.Regex.PCRE as PCRE

--- a/src/Ganeti/Query/Filter.hs
+++ b/src/Ganeti/Query/Filter.hs
@@ -183,10 +183,10 @@ containsFilter :: FilterValue -> JSValue -> ErrorResult Bool
 -- note: the next two implementations are the same, but we have to
 -- repeat them due to the encapsulation done by FilterValue
 containsFilter (QuotedString val) lst = do
-  lst' <- fromJVal lst
+  lst' <- fromJVal lst :: ErrorResult [String]
   return $! val `elem` lst'
 containsFilter (NumericValue val) lst = do
-  lst' <- fromJVal lst
+  lst' <- fromJVal lst :: ErrorResult [Integer]
   return $! val `elem` lst'
 
 

--- a/src/Ganeti/Query/Language.hs
+++ b/src/Ganeti/Query/Language.hs
@@ -94,7 +94,8 @@ $(makeJSONInstance ''ResultStatus)
 
 -- | No-op 'NFData' instance for 'ResultStatus', since it's a single
 -- constructor data-type.
-instance NFData ResultStatus
+instance NFData ResultStatus where
+  rnf x = seq x ()
 
 -- | Check that ResultStatus is success or fail with descriptive
 -- message.

--- a/src/Ganeti/Query/Language.hs
+++ b/src/Ganeti/Query/Language.hs
@@ -65,10 +65,8 @@ module Ganeti.Query.Language
     , checkRS
     ) where
 
-import Control.Applicative
 import Control.DeepSeq
 import Data.Foldable
-import Data.Traversable (Traversable)
 import Data.Ratio (numerator, denominator)
 import Text.JSON.Pretty (pp_value)
 import Text.JSON.Types

--- a/src/Ganeti/Query/Node.hs
+++ b/src/Ganeti/Query/Node.hs
@@ -38,7 +38,6 @@ module Ganeti.Query.Node
   , collectLiveData
   ) where
 
-import Control.Applicative
 import Data.List
 import Data.Maybe
 import qualified Text.JSON as J

--- a/src/Ganeti/Query/Server.hs
+++ b/src/Ganeti/Query/Server.hs
@@ -51,6 +51,7 @@ import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Maybe
 import qualified Data.ByteString.UTF8 as UTF8
 import qualified Data.Set as Set (toList)
+import Data.Bits (finiteBitSize)
 import Data.IORef
 import Data.List (intersperse)
 import Data.Maybe (fromMaybe)
@@ -70,7 +71,6 @@ import Ganeti.Daemon.Utils (handleMasterVerificationOptions)
 import Ganeti.Objects
 import Ganeti.Objects.Lens (configFiltersL)
 import qualified Ganeti.Config as Config
-import qualified Ganeti.Compat as Compat
 import Ganeti.ConfigReader
 import Ganeti.BasicTypes
 import Ganeti.JQueue
@@ -192,7 +192,7 @@ handleCall _ _ cdata QueryClusterInfo =
       def_hv = case hypervisors of
                  x:_ -> showJSON x
                  [] -> JSNull
-      bits = show (Compat.finiteBitSize (0::Int)) ++ "bits"
+      bits = show (finiteBitSize (0::Int)) ++ "bits"
       arch_tuple = [bits, arch]
       obj = [ ("software_version", showJSON C.releaseVersion)
             , ("protocol_version", showJSON C.protocolVersion)

--- a/src/Ganeti/Query/Server.hs
+++ b/src/Ganeti/Query/Server.hs
@@ -40,7 +40,6 @@ module Ganeti.Query.Server
   , prepMain
   ) where
 
-import Control.Applicative
 import Control.Concurrent
 import Control.Exception
 import Control.Lens ((.~))

--- a/src/Ganeti/Ssconf.hs
+++ b/src/Ganeti/Ssconf.hs
@@ -55,7 +55,6 @@ module Ganeti.Ssconf
   ) where
 
 import Control.Arrow ((&&&))
-import Control.Applicative ((<$>))
 import Control.Exception
 import Control.Monad (forM, liftM)
 import qualified Data.Map as M

--- a/src/Ganeti/Storage/Diskstats/Parser.hs
+++ b/src/Ganeti/Storage/Diskstats/Parser.hs
@@ -36,7 +36,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 module Ganeti.Storage.Diskstats.Parser (diskstatsParser) where
 
-import Control.Applicative ((<*>), (<*), (<$>))
 import qualified Data.Attoparsec.Text as A
 import qualified Data.Attoparsec.Combinator as AC
 import Data.Attoparsec.Text (Parser)

--- a/src/Ganeti/Storage/Drbd/Parser.hs
+++ b/src/Ganeti/Storage/Drbd/Parser.hs
@@ -36,7 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 module Ganeti.Storage.Drbd.Parser (drbdStatusParser, commaIntParser) where
 
-import Control.Applicative ((<*>), (*>), (<*), (<$>), (<|>), pure)
+import Control.Applicative ((<|>))
 import qualified Data.Attoparsec.Text as A
 import qualified Data.Attoparsec.Combinator as AC
 import Data.Attoparsec.Text (Parser)

--- a/src/Ganeti/Storage/Lvm/LVParser.hs
+++ b/src/Ganeti/Storage/Lvm/LVParser.hs
@@ -37,7 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 module Ganeti.Storage.Lvm.LVParser (lvParser, lvCommand, lvParams) where
 
-import Control.Applicative ((<*>), (*>), (<*), (<$>))
 import qualified Data.Attoparsec.Text as A
 import qualified Data.Attoparsec.Combinator as AC
 import Data.Attoparsec.Text (Parser)

--- a/src/Ganeti/THH.hs
+++ b/src/Ganeti/THH.hs
@@ -93,7 +93,6 @@ import Data.Function (on)
 import Data.List
 import Data.Maybe
 import qualified Data.Map as M
-import Data.Monoid
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Language.Haskell.TH

--- a/src/Ganeti/THH.hs
+++ b/src/Ganeti/THH.hs
@@ -1203,8 +1203,13 @@ genDictObject :: (Name -> Field -> Q Exp)  -- ^ a saving function
               -> Q [Dec]
 genDictObject save_fn load_fn sname fields = do
   let name = mkName sname
+      -- newName fails in ghc 7.10 when used on keywords
+      newName' "data" = newName "data_ghcBug10599"
+      newName' "instance" = newName "instance_ghcBug10599"
+      newName' "type" = newName "type_ghcBug10599"
+      newName' s = newName s
   -- toDict
-  fnames <- mapM (newName . fieldVariable) fields
+  fnames <- mapM (newName' . fieldVariable) fields
   let pat = conP name (map varP fnames)
       tdexp = [| concat $(listE $ zipWith save_fn fnames fields) |]
   tdclause <- clause [pat] (normalB tdexp) []

--- a/src/Ganeti/THH.hs
+++ b/src/Ganeti/THH.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ParallelListComp, TemplateHaskell #-}
+{-# LANGUAGE ParallelListComp, TemplateHaskell, RankNTypes #-}
 
 {-| TemplateHaskell helper for Ganeti Haskell code.
 
@@ -488,7 +488,7 @@ genToRaw traw fname tname constructors = do
 genFromRaw :: Name -> Name -> Name -> [(String, Either String Name)] -> Q [Dec]
 genFromRaw traw fname tname constructors = do
   -- signature of form (Monad m) => String -> m $name
-  sigt <- [t| (Monad m) => $(conT traw) -> m $(conT tname) |]
+  sigt <- [t| forall m. (Monad m) => $(conT traw) -> m $(conT tname) |]
   -- clauses for a guarded pattern
   let varp = mkName "s"
       varpe = varE varp

--- a/src/Ganeti/THH/Compat.hs
+++ b/src/Ganeti/THH/Compat.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE CPP, TemplateHaskell #-}
+
+{-| Shim library for supporting various Template Haskell versions
+
+-}
+
+{-
+
+Copyright (C) 2018 Ganeti Project Contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-}
+
+module Ganeti.THH.Compat
+  ( derivesFromNames
+  ) where
+
+import Language.Haskell.TH
+
+-- | Convert Names to DerivClauses
+--
+-- template-haskell 2.12 (GHC 8.2) has changed the DataD class of
+-- constructors to expect [DerivClause] instead of [Names]. Handle this in a
+-- backwards-compatible way.
+#if MIN_VERSION_template_haskell(2,12,0)
+derivesFromNames :: [Name] -> [DerivClause]
+derivesFromNames names = [DerivClause Nothing $ map ConT names]
+#else
+derivesFromNames :: [Name] -> Cxt
+derivesFromNames names = map ConT names
+#endif

--- a/src/Ganeti/THH/HsRPC.hs
+++ b/src/Ganeti/THH/HsRPC.hs
@@ -72,7 +72,7 @@ instance MonadBaseControl IO RpcClientMonad where
 #if MIN_VERSION_monad_control(1,0,0)
 -- Needs Undecidable instances
   type StM RpcClientMonad b = StM (ReaderT Client ResultG) b
-  liftBaseWith f = RpcClientMonad . liftBaseWith
+  liftBaseWith f = RpcClientMonad $ liftBaseWith
                    $ \r -> f (r . runRpcClientMonad)
   restoreM = RpcClientMonad . restoreM
 #else

--- a/src/Ganeti/THH/HsRPC.hs
+++ b/src/Ganeti/THH/HsRPC.hs
@@ -43,7 +43,6 @@ module Ganeti.THH.HsRPC
   , mkRpcCalls
   ) where
 
-import Control.Applicative
 import Control.Monad
 import Control.Monad.Base
 import Control.Monad.Error

--- a/src/Ganeti/THH/PyRPC.hs
+++ b/src/Ganeti/THH/PyRPC.hs
@@ -42,7 +42,6 @@ module Ganeti.THH.PyRPC
 
 import Control.Monad
 import Data.Char (toLower, toUpper)
-import Data.Functor
 import Data.Maybe (fromMaybe)
 import Language.Haskell.TH
 import Language.Haskell.TH.Syntax (liftString)

--- a/src/Ganeti/THH/PyRPC.hs
+++ b/src/Ganeti/THH/PyRPC.hs
@@ -40,6 +40,7 @@ module Ganeti.THH.PyRPC
   , genPyUDSRpcStubStr
   ) where
 
+import Prelude hiding ((<>))
 import Control.Monad
 import Data.Char (toLower, toUpper)
 import Data.Maybe (fromMaybe)

--- a/src/Ganeti/THH/PyType.hs
+++ b/src/Ganeti/THH/PyType.hs
@@ -39,7 +39,6 @@ module Ganeti.THH.PyType
   , pyOptionalType
   ) where
 
-import Control.Applicative
 import Control.Monad
 import Data.List (intercalate)
 import Language.Haskell.TH

--- a/src/Ganeti/THH/RPC.hs
+++ b/src/Ganeti/THH/RPC.hs
@@ -42,7 +42,6 @@ module Ganeti.THH.RPC
   , mkRpcM
   ) where
 
-import Control.Applicative
 import Control.Arrow ((&&&))
 import Control.Monad
 import Control.Monad.Error.Class

--- a/src/Ganeti/THH/Types.hs
+++ b/src/Ganeti/THH/Types.hs
@@ -68,7 +68,7 @@ typeOfFun :: Name -> Q Type
 typeOfFun name = reify name >>= args
   where
     args :: Info -> Q Type
-    args (VarI _ tp _ _) = return tp
+    args (VarI _ tp _) = return tp
     args _               = fail $ "Not a function: " ++ show name
 
 -- | Splits a function type into the types of its arguments and the result.

--- a/src/Ganeti/Types.hs
+++ b/src/Ganeti/Types.hs
@@ -190,7 +190,6 @@ module Ganeti.Types
   , TagsObject(..)
   ) where
 
-import Control.Applicative
 import Control.Monad (liftM)
 import qualified Text.JSON as JSON
 import Text.JSON (JSON, readJSON, showJSON)

--- a/src/Ganeti/UDSServer.hs
+++ b/src/Ganeti/UDSServer.hs
@@ -192,12 +192,12 @@ closeClientSocket = hClose
 openServerSocket :: FilePath -> IO S.Socket
 openServerSocket path = do
   sock <- S.socket S.AF_UNIX S.Stream S.defaultProtocol
-  S.bindSocket sock (S.SockAddrUnix path)
+  S.bind sock (S.SockAddrUnix path)
   return sock
 
 closeServerSocket :: S.Socket -> FilePath -> IO ()
 closeServerSocket sock path = do
-  S.sClose sock
+  S.close sock
   removeFile path
 
 acceptSocket :: S.Socket -> IO Handle

--- a/src/Ganeti/UDSServer.hs
+++ b/src/Ganeti/UDSServer.hs
@@ -70,7 +70,6 @@ module Ganeti.UDSServer
   , listener
   ) where
 
-import Control.Applicative
 import Control.Concurrent.Lifted (fork, yield)
 import Control.Monad.Base
 import Control.Monad.Trans.Control

--- a/src/Ganeti/Utils.hs
+++ b/src/Ganeti/Utils.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts, ScopedTypeVariables, CPP #-}
 
 {-| Utility functions. -}
 
@@ -110,7 +110,11 @@ import Data.Char (toUpper, isAlphaNum, isDigit, isSpace)
 import qualified Data.Either as E
 import Data.Function (on)
 import Data.IORef
+#if MIN_VERSION_base(4,8,0)
+import Data.List hiding (isSubsequenceOf)
+#else
 import Data.List
+#endif
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as S

--- a/src/Ganeti/Utils.hs
+++ b/src/Ganeti/Utils.hs
@@ -109,11 +109,7 @@ import Data.Char (toUpper, isAlphaNum, isDigit, isSpace)
 import qualified Data.Either as E
 import Data.Function (on)
 import Data.IORef
-#if MIN_VERSION_base(4,8,0)
-import Data.List hiding (isSubsequenceOf)
-#else
 import Data.List
-#endif
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as S
@@ -815,13 +811,6 @@ ordNub =
         then go s xs
         else x : go (S.insert x s) xs
   in go S.empty
-
--- | `isSubsequenceOf a b`: Checks if a is a subsequence of b.
-isSubsequenceOf :: (Eq a) => [a] -> [a] -> Bool
-isSubsequenceOf []    _                    = True
-isSubsequenceOf _     []                   = False
-isSubsequenceOf a@(x:a') (y:b) | x == y    = isSubsequenceOf a' b
-                               | otherwise = isSubsequenceOf a b
 
 {-# ANN frequency "HLint: ignore Use alternative" #-}
 -- | Returns a list of tuples of elements and the number of times they occur

--- a/src/Ganeti/Utils.hs
+++ b/src/Ganeti/Utils.hs
@@ -99,7 +99,6 @@ module Ganeti.Utils
   , frequency
   ) where
 
-import Control.Applicative
 import Control.Concurrent
 import Control.Exception (try, bracket)
 import Control.Monad

--- a/src/Ganeti/Utils.hs
+++ b/src/Ganeti/Utils.hs
@@ -124,6 +124,7 @@ import Debug.Trace
 import Network.Socket
 
 import Ganeti.BasicTypes
+import Ganeti.Compat
 import qualified Ganeti.ConstantUtils as ConstantUtils
 import Ganeti.Logging
 import Ganeti.Runtime
@@ -720,11 +721,11 @@ watchFileBy fpath timeout check read_fn = do
                        logDebug $ "Notified of change in " ++ fpath
                                     ++ "; event: " ++ show e
                        when (e == Ignored)
-                         (addWatch inotify [Modify, Delete] fpath do_watch
+                         (addWatch inotify [Modify, Delete] (toInotifyPath fpath) do_watch
                             >> return ())
                        fstat' <- getFStatSafe fpath
                        writeIORef ref fstat'
-    _ <- addWatch inotify [Modify, Delete] fpath do_watch
+    _ <- addWatch inotify [Modify, Delete] (toInotifyPath fpath) do_watch
     newval <- read_fn
     if check newval
       then do

--- a/src/Ganeti/Utils/Monad.hs
+++ b/src/Ganeti/Utils/Monad.hs
@@ -44,7 +44,7 @@ module Ganeti.Utils.Monad
   ) where
 
 import Control.Monad
-import Control.Monad.Error
+import Control.Monad.Except
 import Control.Monad.Trans.Maybe
 
 -- | Retries the given action up to @n@ times.

--- a/src/Ganeti/Utils/MultiMap.hs
+++ b/src/Ganeti/Utils/MultiMap.hs
@@ -60,7 +60,6 @@ import Control.Monad
 import qualified Data.Foldable as F
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe, isJust)
-import Data.Monoid
 import qualified Data.Set as S
 import qualified Text.JSON as J
 

--- a/src/Ganeti/Utils/MultiMap.hs
+++ b/src/Ganeti/Utils/MultiMap.hs
@@ -59,6 +59,7 @@ import Prelude hiding (lookup, null, elem)
 import Control.Monad
 import qualified Data.Foldable as F
 import qualified Data.Map as M
+import qualified Data.Semigroup as Sem
 import Data.Maybe (fromMaybe, isJust)
 import qualified Data.Set as S
 import qualified Text.JSON as J
@@ -71,9 +72,12 @@ import Ganeti.Lens
 newtype MultiMap k v = MultiMap { getMultiMap :: M.Map k (S.Set v) }
   deriving (Eq, Ord, Show)
 
+instance (Ord v, Ord k) => Sem.Semigroup (MultiMap k v) where
+  (MultiMap x) <> (MultiMap y) = MultiMap $ M.unionWith S.union x y
+
 instance (Ord v, Ord k) => Monoid (MultiMap k v) where
   mempty = MultiMap M.empty
-  mappend (MultiMap x) (MultiMap y) = MultiMap $ M.unionWith S.union x y
+  mappend = (Sem.<>)
 
 instance F.Foldable (MultiMap k) where
   foldMap f = F.foldMap (F.foldMap f) . getMultiMap

--- a/src/Ganeti/Utils/Random.hs
+++ b/src/Ganeti/Utils/Random.hs
@@ -38,7 +38,6 @@ module Ganeti.Utils.Random
   , delayRandom
   ) where
 
-import Control.Applicative
 import Control.Concurrent (threadDelay)
 import Control.Monad
 import Control.Monad.State

--- a/src/Ganeti/Utils/Validate.hs
+++ b/src/Ganeti/Utils/Validate.hs
@@ -51,7 +51,6 @@ module Ganeti.Utils.Validate
   , validate'
   ) where
 
-import Control.Applicative
 import Control.Arrow
 import Control.Monad
 import Control.Monad.Except

--- a/src/Ganeti/Utils/Validate.hs
+++ b/src/Ganeti/Utils/Validate.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE FlexibleInstances, FlexibleContexts, GeneralizedNewtypeDeriving #-}
 
 {-| A validation monad and corresponding utilities
 
@@ -54,7 +54,7 @@ module Ganeti.Utils.Validate
 import Control.Applicative
 import Control.Arrow
 import Control.Monad
-import Control.Monad.Error
+import Control.Monad.Except
 import Control.Monad.Writer
 import qualified Data.Foldable as F
 import Data.Functor.Identity
@@ -100,19 +100,19 @@ execValidate = runIdentity . execValidateT
 
 -- | A helper function for throwing an exception if a list of errors
 -- is non-empty.
-throwIfErrors :: (MonadError e m, Error e) => (a, [String]) -> m a
+throwIfErrors :: (MonadError String m) => (a, [String]) -> m a
 throwIfErrors (x, []) = return x
-throwIfErrors (_, es) = throwError (strMsg $ "Validation errors: "
-                                             ++ intercalate "; " es)
+throwIfErrors (_, es) = throwError $ "Validation errors: "
+                                      ++ intercalate "; " es
 
 -- | Runs a validation action and if there are errors, combine them
 -- into an exception.
-evalValidate :: (MonadError e m, Error e) => ValidationMonad a -> m a
+evalValidate :: (MonadError String m) => ValidationMonad a -> m a
 evalValidate = throwIfErrors . runValidate
 
 -- | Runs a validation action and if there are errors, combine them
 -- into an exception.
-evalValidateT :: (MonadError e m, Error e) => ValidationMonadT m a -> m a
+evalValidateT :: (MonadError String m) => ValidationMonadT m a -> m a
 evalValidateT k = runValidateT k >>= throwIfErrors
 
 -- | A typeclass for objects that can be validated.

--- a/src/Ganeti/WConfd/ConfigModifications.hs
+++ b/src/Ganeti/WConfd/ConfigModifications.hs
@@ -39,7 +39,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module Ganeti.WConfd.ConfigModifications where
 
-import Control.Applicative ((<$>))
 import Control.Lens (_2)
 import Control.Lens.Getter ((^.))
 import Control.Lens.Setter ((.~), (%~))
@@ -50,7 +49,7 @@ import Control.Monad.Error (throwError, MonadError)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.State (StateT, get, put, modify,
                                   runStateT, execStateT)
-import Data.Foldable (fold, foldMap)
+import Data.Foldable (fold)
 import Data.List (elemIndex)
 import Data.Maybe (isJust, maybeToList, fromMaybe, fromJust)
 import Language.Haskell.TH (Name)

--- a/src/Ganeti/WConfd/ConfigState.hs
+++ b/src/Ganeti/WConfd/ConfigState.hs
@@ -43,7 +43,6 @@ module Ganeti.WConfd.ConfigState
   , needsFullDist
   ) where
 
-import Control.Applicative
 import Data.Function (on)
 import System.Time (ClockTime(..))
 

--- a/src/Ganeti/WConfd/ConfigWriter.hs
+++ b/src/Ganeti/WConfd/ConfigWriter.hs
@@ -43,7 +43,6 @@ module Ganeti.WConfd.ConfigWriter
   , distSSConfAsyncTask
   ) where
 
-import Control.Applicative
 import Control.Monad.Base
 import Control.Monad.Error
 import qualified Control.Monad.State.Strict as S

--- a/src/Ganeti/WConfd/Monad.hs
+++ b/src/Ganeti/WConfd/Monad.hs
@@ -81,6 +81,7 @@ import Control.Monad.Trans.Control
 import Data.Functor.Identity
 import Data.IORef.Lifted
 import Data.Monoid (Any(..))
+import qualified Data.Semigroup as Sem
 import qualified Data.Set as S
 import Data.Tuple (swap)
 import System.Posix.Process (getProcessID)
@@ -108,11 +109,14 @@ import Ganeti.WConfd.TempRes
 -- | Data type describing where the configuration has to be distributed to.
 data DistributionTarget = Everywhere | ToGroups (S.Set String) deriving Show
 
+instance Sem.Semigroup DistributionTarget where
+  Everywhere <> _ = Everywhere
+  _ <> Everywhere = Everywhere
+  (ToGroups a) <> (ToGroups b) = ToGroups (a `S.union` b)
+
 instance Monoid DistributionTarget where
   mempty = ToGroups S.empty
-  mappend Everywhere _ = Everywhere
-  mappend _ Everywhere = Everywhere
-  mappend (ToGroups a) (ToGroups b) = ToGroups (a `S.union` b)
+  mappend = (Sem.<>)
 
 -- * Pure data types used in the monad
 

--- a/src/Ganeti/WConfd/Monad.hs
+++ b/src/Ganeti/WConfd/Monad.hs
@@ -69,7 +69,6 @@ module Ganeti.WConfd.Monad
   , DistributionTarget(..)
   ) where
 
-import Control.Applicative
 import Control.Arrow ((&&&), second)
 import Control.Concurrent (forkIO, myThreadId)
 import Control.Exception.Lifted (bracket)
@@ -81,7 +80,7 @@ import Control.Monad.State
 import Control.Monad.Trans.Control
 import Data.Functor.Identity
 import Data.IORef.Lifted
-import Data.Monoid (Any(..), Monoid(..))
+import Data.Monoid (Any(..))
 import qualified Data.Set as S
 import Data.Tuple (swap)
 import System.Posix.Process (getProcessID)

--- a/src/Ganeti/WConfd/Monad.hs
+++ b/src/Ganeti/WConfd/Monad.hs
@@ -196,7 +196,7 @@ instance MonadBaseControl IO WConfdMonadInt where
 #if MIN_VERSION_monad_control(1,0,0)
 -- Needs Undecidable instances
   type StM WConfdMonadInt b = StM WConfdMonadIntType b
-  liftBaseWith f = WConfdMonadInt . liftBaseWith
+  liftBaseWith f = WConfdMonadInt $ liftBaseWith
                    $ \r -> f (r . getWConfdMonadInt)
   restoreM = WConfdMonadInt . restoreM
 #else

--- a/src/Ganeti/WConfd/TempRes.hs
+++ b/src/Ganeti/WConfd/TempRes.hs
@@ -73,7 +73,6 @@ module Ganeti.WConfd.TempRes
   , reserved
   ) where
 
-import Control.Applicative
 import Control.Lens.At
 import Control.Monad.Error
 import Control.Monad.State

--- a/src/Ganeti/WConfd/TempRes.hs
+++ b/src/Ganeti/WConfd/TempRes.hs
@@ -84,6 +84,7 @@ import Data.Maybe
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Monoid
+import qualified Data.Semigroup as Sem
 import qualified Data.Set as S
 import System.Random
 import qualified Text.JSON as J
@@ -159,9 +160,12 @@ instance J.JSON IPv4Reservation where
 newtype TempRes j a = TempRes { getTempRes :: MM.MultiMap j a }
   deriving (Eq, Ord, Show)
 
+instance (Ord j, Ord a) => Sem.Semigroup (TempRes j a) where
+  (TempRes x) <> (TempRes y) = TempRes $ x <> y
+
 instance (Ord j, Ord a) => Monoid (TempRes j a) where
   mempty = TempRes mempty
-  mappend (TempRes x) (TempRes y) = TempRes $ x <> y
+  mappend = (Sem.<>)
 
 instance (J.JSON j, Ord j, J.JSON a, Ord a) => J.JSON (TempRes j a) where
   showJSON = J.showJSON . getTempRes

--- a/test/hs/Test/Ganeti/BasicTypes.hs
+++ b/test/hs/Test/Ganeti/BasicTypes.hs
@@ -40,7 +40,6 @@ module Test.Ganeti.BasicTypes (testBasicTypes) where
 import Test.QuickCheck hiding (Result)
 import Test.QuickCheck.Function
 
-import Control.Applicative
 import Control.Monad
 
 import Test.Ganeti.TestHelper

--- a/test/hs/Test/Ganeti/Confd/Types.hs
+++ b/test/hs/Test/Ganeti/Confd/Types.hs
@@ -42,7 +42,6 @@ module Test.Ganeti.Confd.Types
   , ConfdReqQ(..)
   ) where
 
-import Control.Applicative
 import Test.QuickCheck
 import Test.HUnit
 import qualified Text.JSON as J

--- a/test/hs/Test/Ganeti/HTools/Graph.hs
+++ b/test/hs/Test/Ganeti/HTools/Graph.hs
@@ -149,7 +149,7 @@ prop_colorAllNodes :: (Graph.Graph -> VertColorMap)
                    -> TestableGraph
                    -> Property
 prop_colorAllNodes alg (TestableGraph g) = numvertices ==? numcolored
-    where numcolored = IntMap.fold ((+) . length) 0 vcMap
+    where numcolored = IntMap.foldr ((+) . length) 0 vcMap
           vcMap = colorVertMap $ alg g
           numvertices = length (Graph.vertices g)
 

--- a/test/hs/Test/Ganeti/HTools/Instance.hs
+++ b/test/hs/Test/Ganeti/HTools/Instance.hs
@@ -45,7 +45,6 @@ module Test.Ganeti.HTools.Instance
   ) where
 
 import Control.Arrow ((&&&))
-import Control.Applicative ((<$>))
 import Control.Monad (liftM)
 import Test.QuickCheck hiding (Result)
 

--- a/test/hs/Test/Ganeti/HTools/Types.hs
+++ b/test/hs/Test/Ganeti/HTools/Types.hs
@@ -48,7 +48,6 @@ module Test.Ganeti.HTools.Types
 import Test.QuickCheck hiding (Result)
 import Test.HUnit
 
-import Control.Applicative
 import Control.Monad (replicateM)
 
 import Test.Ganeti.TestHelper

--- a/test/hs/Test/Ganeti/JQScheduler.hs
+++ b/test/hs/Test/Ganeti/JQScheduler.hs
@@ -37,7 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module Test.Ganeti.JQScheduler (testJQScheduler) where
 
-import Control.Applicative
 import Control.Lens ((&), (.~), _2)
 import qualified Data.ByteString.UTF8 as UTF8
 import Data.List (inits)
@@ -45,7 +44,6 @@ import Data.Maybe
 import qualified Data.Map as Map
 import Data.Set (Set, difference)
 import qualified Data.Set as Set
-import Data.Traversable (traverse)
 import Text.JSON (JSValue(..))
 import Test.HUnit
 import Test.QuickCheck

--- a/test/hs/Test/Ganeti/JQueue.hs
+++ b/test/hs/Test/Ganeti/JQueue.hs
@@ -171,11 +171,12 @@ prop_ListJobIDs = monadicIO $ do
     full_dir <- extractJobIDs $ getJobIDs [tempdir]
     invalid_dir <- getJobIDs [tempdir </> "no-such-dir"]
     return (empty_dir, sortJobIDs full_dir, invalid_dir)
-  stop $ conjoin [ counterexample "empty directory" $ e ==? []
-                 , counterexample "directory with valid names" $
-                   f ==? sortJobIDs jobs
-                 , counterexample "invalid directory" $ isBad g
-                 ]
+  _ <- stop $ conjoin [ counterexample "empty directory" $ e ==? []
+                      , counterexample "directory with valid names" $
+                        f ==? sortJobIDs jobs
+                      , counterexample "invalid directory" $ isBad g
+                      ]
+  return ()
 
 -- | Tests loading jobs from disk.
 prop_LoadJobs :: Property
@@ -207,12 +208,13 @@ prop_LoadJobs = monadicIO $ do
     writeFile live_path "invalid job"
     broken <- load True
     return (missing, current, archived, missing_current, broken)
-  stop $ conjoin [ missing ==? noSuchJob
-                 , current ==? Ganeti.BasicTypes.Ok (job, False)
-                 , archived ==? Ganeti.BasicTypes.Ok (job, True)
-                 , missing_current ==? noSuchJob
-                 , counterexample "broken job" (isBad broken)
-                 ]
+  _ <- stop $ conjoin [ missing ==? noSuchJob
+                      , current ==? Ganeti.BasicTypes.Ok (job, False)
+                      , archived ==? Ganeti.BasicTypes.Ok (job, True)
+                      , missing_current ==? noSuchJob
+                      , counterexample "broken job" (isBad broken)
+                      ]
+  return ()
 
 -- | Tests computing job directories. Creates random directories,
 -- files and stale symlinks in a directory, and checks that we return
@@ -237,10 +239,11 @@ prop_DetermineDirs = monadicIO $ do
     invalid_root <- determineJobDirectories (tempdir </> "no-such-subdir") True
     return (tempdir, non_arch, with_arch, invalid_root)
   let arch_dir = tempdir </> jobQueueArchiveSubDir
-  stop $ conjoin [ non_arch ==? [tempdir]
-                 , sort with_arch ==? sort (tempdir:map (arch_dir </>) valid)
-                 , invalid_root ==? [tempdir </> "no-such-subdir"]
-                 ]
+  _ <- stop $ conjoin [ non_arch ==? [tempdir]
+                      , sort with_arch ==? sort (tempdir:map (arch_dir </>) valid)
+                      , invalid_root ==? [tempdir </> "no-such-subdir"]
+                      ]
+  return ()
 
 -- | Tests the JSON serialisation for 'InputOpCode'.
 prop_InputOpCode :: MetaOpCode -> Int -> Property

--- a/test/hs/Test/Ganeti/JQueue/Objects.hs
+++ b/test/hs/Test/Ganeti/JQueue/Objects.hs
@@ -39,7 +39,6 @@ module Test.Ganeti.JQueue.Objects
   , genJobId
   ) where
 
-import Control.Applicative
 import Test.QuickCheck as QuickCheck
 import Text.JSON
 

--- a/test/hs/Test/Ganeti/Locking/Allocation.hs
+++ b/test/hs/Test/Ganeti/Locking/Allocation.hs
@@ -42,7 +42,6 @@ module Test.Ganeti.Locking.Allocation
   , requestSucceeded
   ) where
 
-import Control.Applicative
 import qualified Data.Foldable as F
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)

--- a/test/hs/Test/Ganeti/Locking/Locks.hs
+++ b/test/hs/Test/Ganeti/Locking/Locks.hs
@@ -37,7 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module Test.Ganeti.Locking.Locks (testLocking_Locks) where
 
-import Control.Applicative ((<$>), (<*>), liftA2)
+import Control.Applicative (liftA2)
 import Control.Monad (liftM)
 import System.Posix.Types (CPid)
 

--- a/test/hs/Test/Ganeti/Locking/Waiting.hs
+++ b/test/hs/Test/Ganeti/Locking/Waiting.hs
@@ -37,7 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module Test.Ganeti.Locking.Waiting (testLocking_Waiting) where
 
-import Control.Applicative ((<$>), (<*>), liftA2)
+import Control.Applicative (liftA2)
 import Control.Monad (liftM)
 import qualified Data.Map as M
 import qualified Data.Set as S

--- a/test/hs/Test/Ganeti/Luxi.hs
+++ b/test/hs/Test/Ganeti/Luxi.hs
@@ -42,7 +42,6 @@ import Test.QuickCheck
 import Test.QuickCheck.Monadic (monadicIO, run, stop)
 
 import Data.List
-import Control.Applicative
 import Control.Concurrent (forkIO)
 import Control.Exception (bracket)
 import qualified Text.JSON as J

--- a/test/hs/Test/Ganeti/Luxi.hs
+++ b/test/hs/Test/Ganeti/Luxi.hs
@@ -148,7 +148,8 @@ prop_ClientServer dnschars = monadicIO $ do
       (Luxi.getLuxiClient fpath)
       Luxi.closeClient
       (`luxiClientPong` msgs)
-  stop $ replies ==? msgs
+  _ <- stop $ replies ==? msgs
+  return ()
 
 -- | Check that Python and Haskell define the same Luxi requests list.
 case_AllDefined :: Assertion

--- a/test/hs/Test/Ganeti/Objects.hs
+++ b/test/hs/Test/Ganeti/Objects.hs
@@ -340,9 +340,6 @@ instance Arbitrary ClusterOsParams where
 instance Arbitrary ClusterBeParams where
   arbitrary = (GenericContainer . Map.fromList) <$> arbitrary
 
-instance Arbitrary TagSet where
-  arbitrary = Set.fromList <$> genTags
-
 instance Arbitrary IAllocatorParams where
   arbitrary = return $ GenericContainer Map.empty
 

--- a/test/hs/Test/Ganeti/Objects.hs
+++ b/test/hs/Test/Ganeti/Objects.hs
@@ -52,7 +52,6 @@ module Test.Ganeti.Objects
 import Test.QuickCheck
 import qualified Test.HUnit as HUnit
 
-import Control.Applicative
 import Control.Monad
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.UTF8 as UTF8

--- a/test/hs/Test/Ganeti/OpCodes.hs
+++ b/test/hs/Test/Ganeti/OpCodes.hs
@@ -43,7 +43,6 @@ module Test.Ganeti.OpCodes
 import Test.HUnit as HUnit
 import Test.QuickCheck as QuickCheck
 
-import Control.Applicative
 import Control.Monad
 import Data.Char
 import Data.List

--- a/test/hs/Test/Ganeti/Query/Filter.hs
+++ b/test/hs/Test/Ganeti/Query/Filter.hs
@@ -64,8 +64,9 @@ checkQueryResults :: ConfigData -> Query -> String
                   -> [[ResultEntry]] -> Property
 checkQueryResults cfg qr descr expected = monadicIO $ do
   result <- run (query cfg False qr) >>= resultProp
-  stop $ counterexample ("Inconsistent results in " ++ descr)
-         (qresData result ==? expected)
+  _ <- stop $ counterexample ("Inconsistent results in " ++ descr)
+              (qresData result ==? expected)
+  return ()
 
 -- | Makes a node name query, given a filter.
 makeNodeQuery :: Filter FilterField -> Query

--- a/test/hs/Test/Ganeti/Query/Language.hs
+++ b/test/hs/Test/Ganeti/Query/Language.hs
@@ -44,7 +44,6 @@ module Test.Ganeti.Query.Language
 import Test.HUnit (Assertion, assertEqual)
 import Test.QuickCheck
 
-import Control.Applicative
 import Control.Arrow (second)
 import Text.JSON
 

--- a/test/hs/Test/Ganeti/Query/Query.hs
+++ b/test/hs/Test/Ganeti/Query/Query.hs
@@ -87,15 +87,16 @@ prop_queryNode_noUnknown =
                               [field] EmptyFilter)) >>= resultProp
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields (ItemTypeOpCode QRNode) [field])
-  stop $ conjoin
-         [ counterexample ("Got unknown fields via query (" ++
-                           show fdefs ++ ")") (hasUnknownFields fdefs)
-         , counterexample ("Got unknown result status via query (" ++
-                           show fdata ++ ")")
-           (all (all ((/= RSUnknown) . rentryStatus)) fdata)
-         , counterexample ("Got unknown fields via query fields (" ++
-                           show fdefs'++ ")") (hasUnknownFields fdefs')
-         ]
+  _ <- stop $ conjoin
+              [ counterexample ("Got unknown fields via query (" ++
+                                show fdefs ++ ")") (hasUnknownFields fdefs)
+              , counterexample ("Got unknown result status via query (" ++
+                                show fdata ++ ")")
+                (all (all ((/= RSUnknown) . rentryStatus)) fdata)
+              , counterexample ("Got unknown fields via query fields (" ++
+                                show fdefs'++ ")") (hasUnknownFields fdefs')
+              ]
+  return ()
 
 -- | Tests that an unknown field is returned as such.
 prop_queryNode_Unknown :: Property
@@ -108,18 +109,19 @@ prop_queryNode_Unknown =
                               [field] EmptyFilter)) >>= resultProp
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields (ItemTypeOpCode QRNode) [field])
-  stop $ conjoin
-         [ counterexample ("Got known fields via query (" ++ show fdefs ++ ")")
-           (not $ hasUnknownFields fdefs)
-         , counterexample ("Got /= ResultUnknown result status via query (" ++
-                           show fdata ++ ")")
-           (all (all ((== RSUnknown) . rentryStatus)) fdata)
-         , counterexample ("Got a Just in a result value (" ++
-                           show fdata ++ ")")
-           (all (all (isNothing . rentryValue)) fdata)
-         , counterexample ("Got known fields via query fields (" ++ show fdefs'
-                           ++ ")") (not $ hasUnknownFields fdefs')
-         ]
+  _ <- stop $ conjoin
+              [ counterexample ("Got known fields via query (" ++ show fdefs ++ ")")
+                (not $ hasUnknownFields fdefs)
+              , counterexample ("Got /= ResultUnknown result status via query (" ++
+                                show fdata ++ ")")
+                (all (all ((== RSUnknown) . rentryStatus)) fdata)
+              , counterexample ("Got a Just in a result value (" ++
+                                show fdata ++ ")")
+                (all (all (isNothing . rentryValue)) fdata)
+              , counterexample ("Got known fields via query fields (" ++ show fdefs'
+                                ++ ")") (not $ hasUnknownFields fdefs')
+              ]
+  return ()
 
 -- | Checks that a result type is conforming to a field definition.
 checkResultType :: FieldDefinition -> ResultEntry -> Property
@@ -154,16 +156,17 @@ prop_queryNode_types =
   QueryResult fdefs fdata <-
     run (query cfg False (Query (ItemTypeOpCode QRNode)
                           [field] EmptyFilter)) >>= resultProp
-  stop $ conjoin
-         [ counterexample ("Inconsistent result entries (" ++ show fdata ++ ")")
-           (conjoin $ map (conjoin . zipWith checkResultType fdefs) fdata)
-         , counterexample "Wrong field definitions length"
-           (length fdefs ==? 1)
-         , counterexample "Wrong field result rows length"
-           (all ((== 1) . length) fdata)
-         , counterexample "Wrong number of result rows"
-           (length fdata ==? numnodes)
-         ]
+  _ <- stop $ conjoin
+              [ counterexample ("Inconsistent result entries (" ++ show fdata ++ ")")
+                (conjoin $ map (conjoin . zipWith checkResultType fdefs) fdata)
+              , counterexample "Wrong field definitions length"
+                (length fdefs ==? 1)
+              , counterexample "Wrong field result rows length"
+                (all ((== 1) . length) fdata)
+              , counterexample "Wrong number of result rows"
+                (length fdata ==? numnodes)
+              ]
+  return ()
 
 -- | Test that queryFields with empty fields list returns all node fields.
 case_queryNode_allfields :: Assertion
@@ -200,10 +203,11 @@ prop_queryNode_filter =
     QueryResult _ fdata <-
       run (query cluster False (Query (ItemTypeOpCode QRNode)
                                 ["name"] flt)) >>= resultProp
-    stop $ conjoin
-      [ counterexample "Invalid node names" $
-        map (map rentryValue) fdata ==? map (\f -> [Just (showJSON f)]) fqdns
-      ]
+    _ <- stop $ conjoin
+           [ counterexample "Invalid node names" $
+             map (map rentryValue) fdata ==? map (\f -> [Just (showJSON f)]) fqdns
+           ]
+    return ()
 
 -- ** Group queries
 
@@ -217,15 +221,16 @@ prop_queryGroup_noUnknown =
            resultProp
     QueryFieldsResult fdefs' <-
       resultProp $ queryFields (QueryFields (ItemTypeOpCode QRGroup) [field])
-    stop $ conjoin
-     [ counterexample ("Got unknown fields via query (" ++ show fdefs ++ ")")
-          (hasUnknownFields fdefs)
-     , counterexample ("Got unknown result status via query (" ++
-                       show fdata ++ ")")
-       (all (all ((/= RSUnknown) . rentryStatus)) fdata)
-     , counterexample ("Got unknown fields via query fields (" ++ show fdefs'
-                       ++ ")") (hasUnknownFields fdefs')
-     ]
+    _ <- stop $ conjoin
+      [ counterexample ("Got unknown fields via query (" ++ show fdefs ++ ")")
+           (hasUnknownFields fdefs)
+      , counterexample ("Got unknown result status via query (" ++
+                        show fdata ++ ")")
+        (all (all ((/= RSUnknown) . rentryStatus)) fdata)
+      , counterexample ("Got unknown fields via query fields (" ++ show fdefs'
+                        ++ ")") (hasUnknownFields fdefs')
+      ]
+    return ()
 
 prop_queryGroup_Unknown :: Property
 prop_queryGroup_Unknown =
@@ -237,7 +242,7 @@ prop_queryGroup_Unknown =
                               [field] EmptyFilter)) >>= resultProp
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields (ItemTypeOpCode QRGroup) [field])
-  stop $ conjoin
+  _ <- stop $ conjoin
          [ counterexample ("Got known fields via query (" ++ show fdefs ++ ")")
            (not $ hasUnknownFields fdefs)
          , counterexample ("Got /= ResultUnknown result status via query (" ++
@@ -249,6 +254,7 @@ prop_queryGroup_Unknown =
          , counterexample ("Got known fields via query fields (" ++ show fdefs'
                            ++ ")") (not $ hasUnknownFields fdefs')
          ]
+  return ()
 
 prop_queryGroup_types :: Property
 prop_queryGroup_types =
@@ -258,13 +264,14 @@ prop_queryGroup_types =
   QueryResult fdefs fdata <-
     run (query cfg False (Query (ItemTypeOpCode QRGroup)
                           [field] EmptyFilter)) >>= resultProp
-  stop $ conjoin
+  _ <- stop $ conjoin
          [ counterexample ("Inconsistent result entries (" ++ show fdata ++ ")")
            (conjoin $ map (conjoin . zipWith checkResultType fdefs) fdata)
          , counterexample "Wrong field definitions length" (length fdefs ==? 1)
          , counterexample "Wrong field result rows length"
            (all ((== 1) . length) fdata)
          ]
+  return ()
 
 case_queryGroup_allfields :: Assertion
 case_queryGroup_allfields = do
@@ -288,10 +295,11 @@ prop_queryGroup_nodeCount =
     QueryResult _ fdata <-
       run (query cluster False (Query (ItemTypeOpCode QRGroup)
                                 ["node_cnt"] EmptyFilter)) >>= resultProp
-    stop $ conjoin
-      [ counterexample "Invalid node count" $
-        map (map rentryValue) fdata ==? [[Just (showJSON nodes)]]
-      ]
+    _ <- stop $ conjoin
+           [ counterexample "Invalid node count" $
+             map (map rentryValue) fdata ==? [[Just (showJSON nodes)]]
+           ]
+    return ()
 
 -- ** Job queries
 
@@ -311,15 +319,16 @@ prop_queryJob_noUnknown =
     run (query undefined False (Query qtype [field] flt)) >>= resultProp
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields qtype [field])
-  stop $ conjoin
-         [ counterexample ("Got unknown fields via query (" ++
-                           show fdefs ++ ")") (hasUnknownFields fdefs)
-         , counterexample ("Got unknown result status via query (" ++
-                           show fdata ++ ")")
-           (all (all ((/= RSUnknown) . rentryStatus)) fdata)
-         , counterexample ("Got unknown fields via query fields (" ++
-                           show fdefs'++ ")") (hasUnknownFields fdefs')
-         ]
+  _ <- stop $ conjoin
+              [ counterexample ("Got unknown fields via query (" ++
+                                show fdefs ++ ")") (hasUnknownFields fdefs)
+              , counterexample ("Got unknown result status via query (" ++
+                                show fdata ++ ")")
+                (all (all ((/= RSUnknown) . rentryStatus)) fdata)
+              , counterexample ("Got unknown fields via query fields (" ++
+                                show fdefs'++ ")") (hasUnknownFields fdefs')
+              ]
+  return ()
 
 -- | Tests that an unknown field is returned as such.
 prop_queryJob_Unknown :: Property
@@ -334,7 +343,7 @@ prop_queryJob_Unknown =
     run (query undefined False (Query qtype [field] flt)) >>= resultProp
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields qtype [field])
-  stop $ conjoin
+  _ <- stop $ conjoin
          [ counterexample ("Got known fields via query (" ++ show fdefs ++ ")")
            (not $ hasUnknownFields fdefs)
          , counterexample ("Got /= ResultUnknown result status via query (" ++
@@ -346,6 +355,7 @@ prop_queryJob_Unknown =
          , counterexample ("Got known fields via query fields (" ++ show fdefs'
                            ++ ")") (not $ hasUnknownFields fdefs')
          ]
+  return ()
 
 -- ** Misc other tests
 

--- a/test/hs/Test/Ganeti/Rpc.hs
+++ b/test/hs/Test/Ganeti/Rpc.hs
@@ -114,7 +114,8 @@ runOfflineTest :: (Rpc.Rpc a b, Eq b, Show b) => a -> Property
 runOfflineTest call =
   forAll (arbitrary `suchThat` Objects.nodeOffline) $ \node -> monadicIO $ do
       res <- run $ Rpc.executeRpcCall [node] call
-      stop $ res ==? [(node, Left Rpc.OfflineNodeError)]
+      _ <- stop $ res ==? [(node, Left Rpc.OfflineNodeError)]
+      return ()
 
 prop_noffl_request_allinstinfo :: Rpc.RpcCallAllInstancesInfo -> Property
 prop_noffl_request_allinstinfo = runOfflineTest

--- a/test/hs/Test/Ganeti/Rpc.hs
+++ b/test/hs/Test/Ganeti/Rpc.hs
@@ -40,7 +40,6 @@ module Test.Ganeti.Rpc (testRpc) where
 import Test.QuickCheck
 import Test.QuickCheck.Monadic (monadicIO, run, stop)
 
-import Control.Applicative
 import qualified Data.Map as Map
 
 import Test.Ganeti.TestHelper

--- a/test/hs/Test/Ganeti/SlotMap.hs
+++ b/test/hs/Test/Ganeti/SlotMap.hs
@@ -44,14 +44,12 @@ module Test.Ganeti.SlotMap
 
 import Prelude hiding (all)
 
-import Control.Applicative
 import Control.Monad
 import Data.Foldable (all)
 import qualified Data.Map as Map
 import Data.Map (Map, member, keys, keysSet)
 import Data.Set (Set, size, union)
 import qualified Data.Set as Set
-import Data.Traversable (traverse)
 import Test.HUnit
 import Test.QuickCheck
 

--- a/test/hs/Test/Ganeti/Storage/Diskstats/Parser.hs
+++ b/test/hs/Test/Ganeti/Storage/Diskstats/Parser.hs
@@ -41,7 +41,6 @@ import Test.HUnit
 import Test.Ganeti.TestHelper
 import Test.Ganeti.TestCommon
 
-import Control.Applicative ((<*>), (<$>))
 import qualified Data.Attoparsec.Text as A
 import Data.Text (pack)
 import Text.Printf

--- a/test/hs/Test/Ganeti/Storage/Lvm/LVParser.hs
+++ b/test/hs/Test/Ganeti/Storage/Lvm/LVParser.hs
@@ -41,7 +41,6 @@ import Test.HUnit
 import Test.Ganeti.TestHelper
 import Test.Ganeti.TestCommon
 
-import Control.Applicative ((<$>), (<*>))
 import Data.List (intercalate)
 
 import Ganeti.Storage.Lvm.LVParser

--- a/test/hs/Test/Ganeti/TestCommon.hs
+++ b/test/hs/Test/Ganeti/TestCommon.hs
@@ -108,9 +108,6 @@ import System.IO.Error (isDoesNotExistError)
 import System.Process (readProcessWithExitCode)
 import qualified Test.HUnit as HUnit
 import Test.QuickCheck
-#if !MIN_VERSION_QuickCheck(2,7,0)
-import qualified Test.QuickCheck as QC
-#endif
 import Test.QuickCheck.Monadic
 import qualified Text.JSON as J
 import Numeric
@@ -119,13 +116,6 @@ import qualified Ganeti.BasicTypes as BasicTypes
 import Ganeti.JSON (ArrayObject(..))
 import Ganeti.Types
 import Ganeti.Utils.Monad (unfoldrM)
-
--- * Arbitrary orphan instances
-
-instance (Ord k, Arbitrary k, Arbitrary a) => Arbitrary (M.Map k a) where
-  arbitrary = M.fromList <$> arbitrary
-  shrink m = M.fromList <$> shrink (M.toList m)
-
 
 -- * Constants
 
@@ -584,8 +574,3 @@ listOfUniqueBy gen keyFun forbidden = do
         x <- gen `suchThat` ((`Set.notMember` usedKeys) . keyFun)
         return $ Just (x, (i + 1, Set.insert (keyFun x) usedKeys))
 
-
-#if !MIN_VERSION_QuickCheck(2,7,0)
-counterexample :: Testable prop => String -> prop -> Property
-counterexample = QC.printTestCase
-#endif

--- a/test/hs/Test/Ganeti/TestCommon.hs
+++ b/test/hs/Test/Ganeti/TestCommon.hs
@@ -92,7 +92,6 @@ module Test.Ganeti.TestCommon
   , counterexample
   ) where
 
-import Control.Applicative
 import Control.Exception (catchJust)
 import Control.Monad
 import Data.Attoparsec.Text (Parser, parseOnly)

--- a/test/hs/Test/Ganeti/TestHelper.hs
+++ b/test/hs/Test/Ganeti/TestHelper.hs
@@ -126,7 +126,7 @@ mkRegularArbitrary name cons = do
             [x] -> return $ mkConsArbitrary (conInfo x)
             xs -> appE (varE 'oneof) $
                   listE (map (return . mkConsArbitrary . conInfo) xs)
-  return [InstanceD [] (AppT (ConT ''Arbitrary) (ConT name))
+  return [InstanceD Nothing [] (AppT (ConT ''Arbitrary) (ConT name))
           [ValD (VarP 'arbitrary) (NormalB expr) []]]
 
 -- | Builds a default Arbitrary instance for a type. This requires
@@ -139,9 +139,9 @@ genArbitrary :: Name -> Q [Dec]
 genArbitrary name = do
   r <- reify name
   case r of
-    TyConI (DataD _ _ _ cons _) ->
+    TyConI (DataD _ _ _ _ cons _) ->
       mkRegularArbitrary name cons
-    TyConI (NewtypeD _ _ _ con _) ->
+    TyConI (NewtypeD _ _ _ _ con _) ->
       mkRegularArbitrary name [con]
     TyConI (TySynD _ _ (ConT tn)) -> genArbitrary tn
     _ -> fail $ "Invalid type in call to genArbitrary for " ++ show name

--- a/test/hs/Test/Ganeti/TestHelper.hs
+++ b/test/hs/Test/Ganeti/TestHelper.hs
@@ -39,7 +39,6 @@ module Test.Ganeti.TestHelper
   , genArbitrary
   ) where
 
-import Control.Applicative
 import Data.List (stripPrefix, isPrefixOf)
 import Data.Maybe (fromMaybe)
 import Test.Framework

--- a/test/hs/Test/Ganeti/Types.hs
+++ b/test/hs/Test/Ganeti/Types.hs
@@ -47,7 +47,6 @@ module Test.Ganeti.Types
   , genReasonTrail
   ) where
 
-import Control.Applicative
 import System.Time (ClockTime(..))
 
 import Test.QuickCheck as QuickCheck hiding (Result)

--- a/test/hs/Test/Ganeti/Utils.hs
+++ b/test/hs/Test/Ganeti/Utils.hs
@@ -43,7 +43,11 @@ import Test.HUnit
 import Control.Applicative ((<$>), (<*>))
 import Data.Char (isSpace)
 import qualified Data.Either as Either
+#if MIN_VERSION_base(4,8,0)
+import Data.List hiding (isSubsequenceOf)
+#else
 import Data.List
+#endif
 import Data.Maybe (listToMaybe)
 import qualified Data.Set as S
 import System.Time

--- a/test/hs/Test/Ganeti/Utils.hs
+++ b/test/hs/Test/Ganeti/Utils.hs
@@ -42,11 +42,7 @@ import Test.HUnit
 
 import Data.Char (isSpace)
 import qualified Data.Either as Either
-#if MIN_VERSION_base(4,8,0)
-import Data.List hiding (isSubsequenceOf)
-#else
 import Data.List
-#endif
 import Data.Maybe (listToMaybe)
 import qualified Data.Set as S
 import System.Time
@@ -374,19 +370,6 @@ prop_splitRecombineEithers es =
         (splitleft, splitright, trail) = splitEithers es
         emptylist = []::[Int]
 
--- | Tests 'isSubsequenceOf'.
-prop_isSubsequenceOf :: Property
-prop_isSubsequenceOf = do
-  -- isSubsequenceOf only has access to Eq so restricting to a small
-  -- set of numbers and short lists still covers everything it can do.
-  let num = choose (0, 5)
-  forAll (choose (0, 4)) $ \n1 ->
-    forAll (choose (0, 4)) $ \n2 ->
-      forAll (vectorOf n1 num) $ \(a :: [Int]) ->
-        forAll (vectorOf n2 num) $ \b ->
-          let subs = S.fromList $ subsequences b
-          in a `isSubsequenceOf` b == a `S.member` subs
-
 testSuite "Utils"
             [ 'prop_commaJoinSplit
             , 'prop_commaSplitJoin
@@ -415,5 +398,4 @@ testSuite "Utils"
             , 'prop_chompPrefix_empty_string
             , 'prop_chompPrefix_nothing
             , 'prop_splitRecombineEithers
-            , 'prop_isSubsequenceOf
             ]

--- a/test/hs/Test/Ganeti/Utils.hs
+++ b/test/hs/Test/Ganeti/Utils.hs
@@ -40,7 +40,6 @@ module Test.Ganeti.Utils (testUtils) where
 import Test.QuickCheck hiding (Result)
 import Test.HUnit
 
-import Control.Applicative ((<$>), (<*>))
 import Data.Char (isSpace)
 import qualified Data.Either as Either
 #if MIN_VERSION_base(4,8,0)

--- a/test/hs/Test/Ganeti/Utils/MultiMap.hs
+++ b/test/hs/Test/Ganeti/Utils/MultiMap.hs
@@ -39,7 +39,6 @@ module Test.Ganeti.Utils.MultiMap
   ( testUtils_MultiMap
   ) where
 
-import Control.Applicative
 import qualified Data.Set as S
 import qualified Data.Map as M
 

--- a/test/hs/Test/Ganeti/WConfd/TempRes.hs
+++ b/test/hs/Test/Ganeti/WConfd/TempRes.hs
@@ -37,8 +37,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module Test.Ganeti.WConfd.TempRes (testWConfd_TempRes) where
 
-import Control.Applicative
-
 import Test.QuickCheck
 
 import Test.Ganeti.Objects ()


### PR DESCRIPTION
This PR aims at achieving single-source compatibility with GHC 8.0 - 8.4 (LTS 7 through LTS 12). It contains some of @bsrk's work for GHC 7.10 compat from `attic/master` and a refined form of the patches we had been carrying in the Debian package since Stretch. On top of that, I'm also dropping support for ancient versions of libraries we no longer need to care about.

After merging this, the minimum supported GHC version will be 8.0/base-4.9.0.

This PR addresses #1312 #1222 #1287 and #1313. I'll need to reference the issues from the respective commits as well.