### PR TITLE
Make Sphinx compatible to version 1.7/1.8

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -526,13 +526,13 @@ else
   # Sphinx exits with code 1 when it prints its usage
   sphinxver=`{ $SPHINX --version 2>&1 || :; } | head -n 3`
 
-  if ! echo "$sphinxver" | grep -q -w -e '^Sphinx' -e '^Usage:'; then
+  if ! echo "$sphinxver" | grep -q -w -i -e '^Sphinx' -e '^Usage:'; then
     AC_MSG_ERROR([Unable to determine Sphinx version])
 
   # Note: Character classes ([...]) need to be double quoted due to autoconf
   # using m4
   elif ! echo "$sphinxver" | grep -q -E \
-       '^Sphinx([[[:space:]]]+|\(sphinx-build[[1-9]]?\)|v)*[[1-9]]\>'; then
+       '^(Sphinx|sphinx-build[[1-9]]?)([[[:space:]]]+|\(sphinx-build[[1-9]]?\)|v)*[[1-9]]\>'; then
     AC_MSG_ERROR([Sphinx 1.0 or higher is required])
   fi
 fi

--- a/lib/build/sphinx_ext.py
+++ b/lib/build/sphinx_ext.py
@@ -42,13 +42,12 @@ import docutils.statemachine
 import docutils.nodes
 import docutils.utils
 import docutils.parsers.rst
+from docutils.parsers.rst import Directive
 
 import sphinx.errors
 import sphinx.util.compat
 import sphinx.roles
 import sphinx.addnodes
-
-s_compat = sphinx.util.compat
 
 orig_manpage_role = None
 
@@ -213,7 +212,7 @@ def _BuildOpcodeResult(op_id):
   return "``%s``" % result_fn
 
 
-class OpcodeParams(s_compat.Directive):
+class OpcodeParams(Directive):
   """Custom directive for opcode parameters.
 
   See also <http://docutils.sourceforge.net/docs/howto/rst-directives.html>.
@@ -246,7 +245,7 @@ class OpcodeParams(s_compat.Directive):
     return []
 
 
-class OpcodeResult(s_compat.Directive):
+class OpcodeResult(Directive):
   """Custom directive for opcode result.
 
   See also <http://docutils.sourceforge.net/docs/howto/rst-directives.html>.
@@ -296,7 +295,7 @@ def PythonEvalRole(role, rawtext, text, lineno, inliner,
   return ([node], [])
 
 
-class PythonAssert(s_compat.Directive):
+class PythonAssert(Directive):
   """Custom directive for writing assertions.
 
   The content must be a valid Python expression. If its result does not
@@ -561,7 +560,7 @@ def _BuildRapiAccessTable(res):
               _DescribeHandlerAccess(handler, method)))
 
 
-class RapiAccessTable(s_compat.Directive):
+class RapiAccessTable(Directive):
   """Custom directive to generate table of all RAPI resources.
 
   See also <http://docutils.sourceforge.net/docs/howto/rst-directives.html>.
@@ -584,7 +583,7 @@ class RapiAccessTable(s_compat.Directive):
     return []
 
 
-class RapiResourceDetails(s_compat.Directive):
+class RapiResourceDetails(Directive):
   """Custom directive for RAPI resource details.
 
   See also <http://docutils.sourceforge.net/docs/howto/rst-directives.html>.


### PR DESCRIPTION
Sphinx 1.7 changed to output format of `sphinx-build --version`. `configure.ac` uses a regex to check that the sphinx major version is at least one. The first commit changes this regex to match both formats.
Alternatively, we could drop the regex completely, because realistically nobody will try to build the docs with sphinx < 1.0, which was release in 2010.

Also, `sphinx.util.compat.Directive` was deprecated and removed, it should be replaced by `docutils.parsers.rst.Directive`.

With these two commits, I can build (`make`) ganeti and the docs with sphinx 1.8.4