### PR TITLE
daemon-util: also match processes by name when using s-s-d

### DIFF
--- a/daemons/daemon-util.in
+++ b/daemons/daemon-util.in
@@ -262,7 +262,7 @@ check() {
     fi
   elif type -p start-stop-daemon >/dev/null; then
     start-stop-daemon --stop --signal 0 --quiet \
-      --pidfile $pidfile
+      --pidfile $pidfile --name "$name"
   else
     _ignore_error status \
       -p $pidfile \
@@ -337,7 +337,7 @@ stop() {
     systemctl stop "${name}.service"
   elif type -p start-stop-daemon >/dev/null; then
     start-stop-daemon --stop --quiet --oknodo --retry 30 \
-      --pidfile $pidfile
+      --pidfile $pidfile --name "$name"
   else
     _ignore_error killproc -p $pidfile $name
   fi
@@ -423,7 +423,7 @@ rotate_logs() {
 
   if type -p start-stop-daemon >/dev/null; then
     start-stop-daemon --stop --signal HUP --quiet \
-      --oknodo --pidfile $pidfile
+      --oknodo --pidfile $pidfile --name "$name"
   else
     _ignore_error killproc \
       -p $pidfile \


### PR DESCRIPTION
As of dpkg 1.19.4, start-stop-daemon will refuse to match a running process by pidfile only, when the pidfile is not owned by root. It does so on security grounds, as a user-controlled pidfile could be used to
kill any process on the system.

When running with user separation enabled, most Ganeti daemons write their PID files as regular users, which means that process control with s-s-d is currently broken. Fix this by also matching processes by name,in addition to the PID file.

Fixes #1322.