### PR TITLE
QEMU 3.1 compatibility

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -1289,7 +1289,7 @@ class KVMHypervisor(hv_base.BaseHypervisor):
         "%s,id=scsi" % hvp[constants.HV_KVM_SCSI_CONTROLLER_TYPE]
         ])
 
-    kvm_cmd.extend(["-balloon", "virtio"])
+    kvm_cmd.extend(["-device", "virtio-balloon"])
     kvm_cmd.extend(["-daemonize"])
     if not instance.hvparams[constants.HV_ACPI]:
       kvm_cmd.extend(["-no-acpi"])

--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -1547,7 +1547,7 @@ class KVMHypervisor(hv_base.BaseHypervisor):
         kvm_cmd.extend(["-nographic"])
 
     if hvp[constants.HV_USE_LOCALTIME]:
-      kvm_cmd.extend(["-localtime"])
+      kvm_cmd.extend(["-rtc", "base=localtime"])
 
     if hvp[constants.HV_KVM_USE_CHROOT]:
       kvm_cmd.extend(["-chroot", self._InstanceChrootDir(instance.name)])

--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -621,7 +621,7 @@ class KVMHypervisor(hv_base.BaseHypervisor):
   # accept the output even on failure.
   _KVMOPTS_CMDS = {
     _KVMOPT_HELP: (["--help"], False),
-    _KVMOPT_MLIST: (["-M", "?"], False),
+    _KVMOPT_MLIST: (["-machine", "?"], False),
     _KVMOPT_DEVICELIST: (["-device", "?"], True),
   }
 
@@ -1311,7 +1311,7 @@ class KVMHypervisor(hv_base.BaseHypervisor):
       machinespec = "%s%s" % (mversion, specprop)
       kvm_cmd.extend(["-machine", machinespec])
     else:
-      kvm_cmd.extend(["-M", mversion])
+      kvm_cmd.extend(["-machine", mversion])
       if (hvp[constants.HV_KVM_FLAG] == constants.HT_KVM_ENABLED and
           self._ENABLE_KVM_RE.search(kvmhelp)):
         kvm_cmd.extend(["-enable-kvm"])

--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -1428,13 +1428,21 @@ class KVMHypervisor(hv_base.BaseHypervisor):
         # kvm/qemu gets confused otherwise about the filename to use.
         vnc_append = ""
         if hvp[constants.HV_VNC_TLS]:
-          vnc_append = "%s,tls" % vnc_append
+          vnc_append = "%s,tls-creds=vnctls0" % vnc_append
+          tls_obj = "tls-creds-anon"
+          tls_obj_options = ["id=vnctls0", "endpoint=server"]
           if hvp[constants.HV_VNC_X509_VERIFY]:
-            vnc_append = "%s,x509verify=%s" % (vnc_append,
-                                               hvp[constants.HV_VNC_X509])
+            tls_obj = "tls-creds-x509"
+            tls_obj_options.extend(["dir=%s" %
+                                    hvp[constants.HV_VNC_X509],
+                                    "verify-peer=yes"])
           elif hvp[constants.HV_VNC_X509]:
-            vnc_append = "%s,x509=%s" % (vnc_append,
-                                         hvp[constants.HV_VNC_X509])
+            tls_obj = "tls-creds-x509"
+            tls_obj_options.extend(["dir=%s" %
+                                    hvp[constants.HV_VNC_X509],
+                                    "verify-peer=no"])
+          kvm_cmd.extend(["-object",
+                          "%s,%s" % (tls_obj, ",".join(tls_obj_options))])
         if hvp[constants.HV_VNC_PASSWORD_FILE]:
           vnc_append = "%s,password" % vnc_append
 


### PR DESCRIPTION
A number of options have been dropped in QEMU 3.1 and as a result KVM does not work out of the box. Fix these by converting to the new syntax. Note that for users using VNC TLS, this means a minimum QEMU version of 2.5 (released in Dec 2015).

This fixes #1338