### PR TITLE
Fix ganeti-kvm-poweroff with systemd

### DIFF
--- a/doc/examples/ganeti-kvm-poweroff.initd.in
+++ b/doc/examples/ganeti-kvm-poweroff.initd.in
@@ -5,7 +5,7 @@
 # Provides:          ganeti-kvm-poweroff
 # Required-Start:
 # Required-Stop:     drbd qemu-kvm $local_fs
-# Default-Start:
+# Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
 # Short-Description: Poweroff Ganeti KVM instances
 # Description: Sends system_powerdown command to Ganeti instances, otherwise


### PR DESCRIPTION
The ganeti-kvm-poweroff script is lacking Default-Start runlevels. While
this is okay with sysvinit, it doesn't work with systemd because the
latter keeps state of whether a service was started before stopping it.

Fix this by populating Default-Start on the LSB header. Note that start
is noop already, so this is harmless.

Thanks to @pboguslawski.

Fixes #1288.