### PR TITLE
GHC 8 compatibility for stable-2.16

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -812,9 +812,6 @@ HFLAGS = \
 	-hide-all-packages \
 	`cat $(HASKELL_PACKAGE_IDS_FILE)` \
 	$(GHC_BYVERSION_FLAGS)
-if DEVELOPER_MODE
-HFLAGS += -Werror
-endif
 
 HTEST_SUFFIX = hpc
 HPROF_SUFFIX = prof

--- a/Makefile.am
+++ b/Makefile.am
@@ -1024,6 +1024,7 @@ HS_LIB_SRCS = \
 	src/Ganeti/Storage/Lvm/Types.hs \
 	src/Ganeti/Storage/Utils.hs \
 	src/Ganeti/THH.hs \
+	src/Ganeti/THH/Compat.hs \
 	src/Ganeti/THH/Field.hs \
 	src/Ganeti/THH/HsRPC.hs \
 	src/Ganeti/THH/PyRPC.hs \

--- a/NEWS
+++ b/NEWS
@@ -43,6 +43,19 @@ to these changes. This was done in a backwards-compatible way, however
 there is one special case: Users using VNC with X.509 support enabled,
 will need to be running at least QEMU 2.5. See #1342 for details.
 
+Newer GHC support
++++++++++++++++++
+
+Ganeti 2.16.0 could only be built using GHC versions prior to 7.10,
+as GHC 7.10 and later versions introduced breaking API changes that made
+the build fail.
+
+This release introduces support for building with newer GHC versions:
+Ganeti is now known to build with GHC 8.0, 8.2 and 8.4. Furthermore,
+Ganeti can now be built with snap-server 1.0 as well as hinotify 0.3.10
+and later. Previously supported versions of GHC and of these libraries
+remain supported.
+
 Misc changes
 ~~~~~~~~~~~~
 

--- a/cabal/CabalDependenciesMacros.hs
+++ b/cabal/CabalDependenciesMacros.hs
@@ -8,6 +8,19 @@ import Distribution.Simple.Configure (maybeGetPersistBuildConfig)
 import Distribution.Simple.LocalBuildInfo (externalPackageDeps)
 import Distribution.PackageDescription (packageDescription)
 
+-- MIN_VERSION_* macros are automatically defined by GHC only since 7.11, see
+-- https://ghc.haskell.org/trac/ghc/ticket/10970
+--
+-- For the rest of the source this is fine, because the MIN_VERSION_* macros
+-- are defined by cabal next, but at this stage cabal can not run (yet). So, we
+-- rely on the __GLASGOW_HASKELL__ macro which is always present to define the
+-- MIN_VERSION_* macros which always return false.
+#if __GLASGOW_HASKELL__ < 711
+#ifndef MIN_VERSION_Cabal
+#define MIN_VERSION_Cabal(x,y,z) 0
+#endif
+#endif
+
 -- Common Cabal 2.x dependencies
 #if MIN_VERSION_Cabal(2,0,0)
 import qualified Distribution.Types.LocalBuildInfo as LocalBuildInfo

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -69,7 +69,7 @@ library
     , network                       >= 2.3.0.13   && < 2.7
     , parallel                      >= 3.2.0.2    && < 3.3
     , regex-pcre                    >= 0.94.2     && < 0.95
-    , temporary                     >= 1.1.2.3    && < 1.3
+    , temporary                     >= 1.1.2.3    && < 1.4
     , transformers-base             >= 0.4.1      && < 0.5
     , zlib                          >= 0.5.3.3    && < 0.7
 

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -49,7 +49,7 @@ library
     , pretty                        >= 1.1.1.0
     , process                       >= 1.1.0.1
     , random                        >= 1.0.1.1
-    , template-haskell              >= 2.11.0.0
+    , template-haskell              >= 2.7.0.0
     , text                          >= 0.11.1.13
     , transformers                  >= 0.3.0.0
     , unix                          >= 2.5.1.0

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -49,7 +49,7 @@ library
     , pretty                        >= 1.1.1.0
     , process                       >= 1.1.0.1
     , random                        >= 1.0.1.1
-    , template-haskell              >= 2.7.0.0
+    , template-haskell              >= 2.11.0.0
     , text                          >= 0.11.1.13
     , transformers                  >= 0.3.0.0
     , unix                          >= 2.5.1.0

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -80,7 +80,7 @@ library
 
   if flag(htest)
     build-depends:
-        HUnit                         >= 1.2.4.2    && < 1.3
+        HUnit                         >= 1.2.4.2    && < 1.7
       , QuickCheck                    >= 2.4.2      && < 2.12
       , test-framework                >= 0.6        && < 0.9
       , test-framework-hunit          >= 0.2.7      && < 0.4

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -66,7 +66,6 @@ library
     , lens                          >= 3.10       && < 5.0
     , lifted-base                   >= 0.2.0.3    && < 0.3
     , monad-control                 >= 0.3.1.3    && < 1.1
-    , MonadCatchIO-transformers     >= 0.3.0.0    && < 0.4
     , network                       >= 2.3.0.13   && < 2.7
     , parallel                      >= 3.2.0.2    && < 3.3
     , regex-pcre                    >= 0.94.2     && < 0.95

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -29,6 +29,10 @@ flag htest
   description: enable tests
   default:     True
 
+flag mcio_xformers
+  description: use MonadCatchIO-transformers (deprecated)
+  default:     True
+
 
 library
   exposed-modules:
@@ -96,6 +100,11 @@ library
     build-depends:
         snap-core                     >= 0.8.1
       , snap-server                   >= 0.8.1
+
+
+  if flag(mcio_xformers)
+    build-depends:
+        MonadCatchIO-transformers
 
   hs-source-dirs:
     src, test/hs

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -65,7 +65,7 @@ library
     , case-insensitive              >= 0.4.0.1    && < 1.3
     , Crypto                        >= 4.2.4      && < 4.3
     , curl                          >= 1.3.7      && < 1.4
-    , hinotify                      >= 0.3.2      && < 0.4
+    , hinotify                      >= 0.3.2      && < 0.5
     , hslogger                      >= 1.1.4      && < 1.3
     , json                          >= 0.5        && < 1.0
     , lens                          >= 3.10       && < 5.0

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -81,7 +81,7 @@ library
   if flag(htest)
     build-depends:
         HUnit                         >= 1.2.4.2    && < 1.3
-      , QuickCheck                    >= 2.4.2      && < 2.8
+      , QuickCheck                    >= 2.4.2      && < 2.12
       , test-framework                >= 0.6        && < 0.9
       , test-framework-hunit          >= 0.2.7      && < 0.4
       , test-framework-quickcheck2    >= 0.2.12.1   && < 0.4

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -53,6 +53,7 @@ library
     , pretty                        >= 1.1.1.0
     , process                       >= 1.1.0.1
     , random                        >= 1.0.1.1
+    , semigroups                    >= 0.15.0
     , template-haskell              >= 2.7.0.0
     , text                          >= 0.11.1.13
     , transformers                  >= 0.3.0.0

--- a/src/Ganeti/BasicTypes.hs
+++ b/src/Ganeti/BasicTypes.hs
@@ -233,7 +233,7 @@ instance (Error a, MonadBaseControl IO m)
   {-# INLINE liftBaseWith #-}
   {-# INLINE restoreM #-}
 
-instance (Monad m, Error a, Monoid a)
+instance (Monad m, Applicative m, Error a, Monoid a)
          => Alternative (ResultT a m) where
   empty = ResultT $ return mzero
   -- Ensure that 'y' isn't run if 'x' contains a value. This makes it a bit
@@ -241,7 +241,7 @@ instance (Monad m, Error a, Monoid a)
   x <|> y = elimResultT combine return x
     where combine x' = ResultT $ liftM (mplus (Bad x')) (runResultT y)
 
-instance (Monad m, Error a, Monoid a)
+instance (Monad m, Applicative m, Error a, Monoid a)
          => MonadPlus (ResultT a m) where
   mzero = empty
   mplus = (<|>)

--- a/src/Ganeti/ConfigReader.hs
+++ b/src/Ganeti/ConfigReader.hs
@@ -46,6 +46,7 @@ import System.INotify
 
 import Ganeti.BasicTypes
 import Ganeti.Objects
+import Ganeti.Compat
 import Ganeti.Confd.Utils
 import Ganeti.Config
 import Ganeti.Logging
@@ -246,7 +247,7 @@ addNotifier :: INotify -> FilePath -> (Result ConfigData -> IO ())
             -> MVar ServerState -> IO Bool
 addNotifier inotify path save_fn mstate =
   Control.Exception.catch
-        (addWatch inotify [CloseWrite] path
+        (addWatch inotify [CloseWrite] (toInotifyPath path)
             (onInotify inotify path save_fn mstate) >> return True)
         (\e -> const (return False) (e::IOError))
 

--- a/src/Ganeti/ConstantUtils.hs
+++ b/src/Ganeti/ConstantUtils.hs
@@ -41,6 +41,7 @@ import Data.Char (ord)
 import Data.Monoid (Monoid(..))
 import Data.Set (Set)
 import qualified Data.Set as Set (difference, fromList, toList, union)
+import qualified Data.Semigroup as Sem
 
 import Ganeti.PyValue
 
@@ -63,9 +64,12 @@ instance PyValue PythonNone where
 newtype FrozenSet a = FrozenSet { unFrozenSet :: Set a }
   deriving (Eq, Ord, Show)
 
+instance (Ord a) => Sem.Semigroup (FrozenSet a) where
+  (FrozenSet s) <> (FrozenSet t) = FrozenSet (mappend s t)
+
 instance (Ord a) => Monoid (FrozenSet a) where
   mempty = FrozenSet mempty
-  mappend (FrozenSet s) (FrozenSet t) = FrozenSet (mappend s t)
+  mappend = (Sem.<>)
 
 -- | Converts a Haskell 'Set' into a Python 'frozenset'
 --

--- a/src/Ganeti/Hypervisor/Xen/XmParser.hs
+++ b/src/Ganeti/Hypervisor/Xen/XmParser.hs
@@ -71,7 +71,7 @@ lispConfigParser =
           doubleP = LCDouble <$> A.rational <* A.skipSpace <* A.endOfInput
           innerDoubleP = LCDouble <$> A.rational
           stringP = LCString . unpack <$> A.takeWhile1 (not . (\c -> isSpace c
-            || c `elem` "()"))
+            || c `elem` ("()" :: String)))
           wspace = AC.many1 A.space
           rparen = A.skipSpace *> A.char ')'
           finalP =   listConfigP <* rparen
@@ -163,5 +163,5 @@ uptimeLineParser :: Parser UptimeInfo
 uptimeLineParser = do
   name <- A.takeTill isSpace <* A.skipSpace
   idNum <- A.decimal <* A.skipSpace
-  uptime <- A.takeTill (`elem` "\n\r") <* A.skipSpace
+  uptime <- A.takeTill (`elem` ("\n\r" :: String)) <* A.skipSpace
   return . UptimeInfo (unpack name) idNum $ unpack uptime

--- a/src/Ganeti/JQScheduler.hs
+++ b/src/Ganeti/JQScheduler.hs
@@ -280,7 +280,7 @@ jobWatcher state jWS e = do
   let inotify = jINotify jWS
   when (e == Ignored  && isJust inotify) $ do
     qdir <- queueDir
-    let fpath = liveJobFile qdir jid
+    let fpath = toInotifyPath $ liveJobFile qdir jid
     _ <- addWatch (fromJust inotify) [Modify, Delete] fpath
            (jobWatcher state jWS)
     return ()
@@ -298,7 +298,7 @@ attachWatcher state jWS = when (isNothing $ jINotify jWS) $ do
      let fpath = liveJobFile qdir . qjId $ jJob jWS
          jWS' = jWS { jINotify=Just inotify }
      logDebug $ "Attaching queue watcher for " ++ fpath
-     _ <- addWatch inotify [Modify, Delete] fpath $ jobWatcher state jWS'
+     _ <- addWatch inotify [Modify, Delete] (toInotifyPath fpath) $ jobWatcher state jWS'
      modifyJobs state . onRunningJobs $ updateJobStatus jWS'
    else logDebug $ "Not attaching watcher for job "
                    ++ (show . fromJobId . qjId $ jJob jWS)

--- a/src/Ganeti/JSON.hs
+++ b/src/Ganeti/JSON.hs
@@ -95,6 +95,7 @@ import qualified Data.Traversable as F
 import Data.Maybe (fromMaybe, catMaybes)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import qualified Data.Semigroup as Sem
 import System.Time (ClockTime(..))
 import Text.Printf (printf)
 
@@ -396,9 +397,12 @@ instance (HasStringRepr a, Ord a, J.JSON b) =>
 
 newtype UsedKeys = UsedKeys (Maybe (Set.Set T.Text))
 
+instance Sem.Semigroup UsedKeys where
+  (UsedKeys xs) <> (UsedKeys ys) = UsedKeys $ liftA2 Set.union xs ys
+
 instance Monoid UsedKeys where
   mempty = UsedKeys (Just Set.empty)
-  mappend (UsedKeys xs) (UsedKeys ys) = UsedKeys $ liftA2 Set.union xs ys
+  mappend = (Sem.<>)
 
 mkUsedKeys :: Set.Set T.Text -> UsedKeys
 mkUsedKeys = UsedKeys . Just

--- a/src/Ganeti/Metad/ConfigCore.hs
+++ b/src/Ganeti/Metad/ConfigCore.hs
@@ -71,7 +71,7 @@ instance MonadBaseControl IO MetadMonadInt where
 #if MIN_VERSION_monad_control(1,0,0)
 -- Needs Undecidable instances
   type StM MetadMonadInt b = StM MetadMonadIntType b
-  liftBaseWith f = MetadMonadInt . liftBaseWith
+  liftBaseWith f = MetadMonadInt $ liftBaseWith
                    $ \r -> f (r . getMetadMonadInt)
   restoreM = MetadMonadInt . restoreM
 #else

--- a/src/Ganeti/Metad/ConfigCore.hs
+++ b/src/Ganeti/Metad/ConfigCore.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TupleSections, TemplateHaskell, CPP, UndecidableInstances,
-    MultiParamTypeClasses, TypeFamilies, GeneralizedNewtypeDeriving #-}
+    MultiParamTypeClasses, TypeFamilies, GeneralizedNewtypeDeriving,
+    ImpredicativeTypes #-}
 {-| Functions of the metadata daemon exported for RPC
 
 -}

--- a/src/Ganeti/Metad/WebServer.hs
+++ b/src/Ganeti/Metad/WebServer.hs
@@ -39,7 +39,7 @@ import Control.Applicative
 import Control.Concurrent (MVar, readMVar)
 import Control.Monad.Error.Class (MonadError, catchError, throwError)
 import Control.Monad.IO.Class (liftIO)
-import qualified Control.Monad.CatchIO as CatchIO (catch)
+import Control.Exception.Lifted (catch)
 import qualified Data.CaseInsensitive as CI
 import Data.List (intercalate)
 import Data.Map (Map)
@@ -105,7 +105,7 @@ serveOsPackage inst params key =
      maybeResult (JSON.readJSON instParams >>=
                   Config.getPublicOsParams >>=
                   getOsPackage) $ \package ->
-       serveFile package `CatchIO.catch` \err ->
+       serveFile package `catch` \err ->
          throwError $ "Could not serve OS package: " ++ show (err :: IOError)
   where getOsPackage osParams =
           case lookup key (JSON.fromJSObject osParams) of
@@ -130,7 +130,7 @@ serveOsScript inst params script =
           throwError $ "Could not find OS script " ++ show (os </> script)
         serveScript os (d:ds) =
           serveFile (d </> os </> script)
-          `CatchIO.catch`
+          `catch`
           \err -> do let _ = err :: IOError
                      serveScript os ds
 

--- a/src/Ganeti/Metad/WebServer.hs
+++ b/src/Ganeti/Metad/WebServer.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, OverloadedStrings #-}
+{-# LANGUAGE CPP, FlexibleContexts, OverloadedStrings, ConstraintKinds, DeriveDataTypeable #-}
 {-| Web server for the metadata daemon.
 
 -}
@@ -37,9 +37,18 @@ module Ganeti.Metad.WebServer (start) where
 
 import Control.Applicative
 import Control.Concurrent (MVar, readMVar)
+#if MIN_VERSION_snap_server(1,0,0)
 import Control.Monad.Base (MonadBase)
+#else
+import Control.Monad.Error.Class (MonadError, catchError, throwError)
+#endif
 import Control.Monad.IO.Class (liftIO)
-import Control.Exception.Lifted (catch, throwIO)
+#ifdef VERSION_MonadCatchIO_transformers
+import Control.Monad.CatchIO (catch)
+#else
+import Control.Exception.Lifted (catch)
+#endif
+import Control.Exception.Lifted (throwIO)
 import Control.Exception.Base (Exception)
 import Data.Typeable (Typeable)
 import qualified Data.CaseInsensitive as CI
@@ -68,8 +77,16 @@ type MetaM = Snap ()
 data MetaMExc = MetaMExc String deriving (Show, Typeable)
 instance Exception MetaMExc
 
+#if MIN_VERSION_snap_server(1,0,0)
+catchError = catch
+
 throwError :: MonadBase IO m => String -> m a
 throwError = throwIO . MetaMExc
+
+type MetaMBase = MonadBase IO
+#else
+type MetaMBase = MonadError String
+#endif
 
 split :: String -> [String]
 split str =
@@ -77,7 +94,7 @@ split str =
     (x, []) -> [x]
     (x, _:xs) -> x:split xs
 
-lookupInstanceParams :: MonadBase IO m => String -> Map String b -> m b
+lookupInstanceParams :: MetaMBase m => String -> Map String b -> m b
 lookupInstanceParams inst params =
   case Map.lookup inst params of
     Nothing -> throwError $ "Could not get instance params for " ++ show inst
@@ -95,7 +112,7 @@ error405 ms = modifyResponse $
   addHeader (CI.mk "Allow") (ByteString.pack . intercalate ", " $ map show ms)
   . setResponseStatus 405 "Method not allowed"
 
-maybeResult :: MonadBase IO m => Result t -> (t -> m a) -> m a
+maybeResult :: MetaMBase m => Result t -> (t -> m a) -> m a
 maybeResult (Error err) _ = throwError err
 maybeResult (Ok x) f = f x
 
@@ -152,9 +169,13 @@ handleMetadata params GET  "ganeti" "latest" "os/os-install-package" =
        Logging.logInfo $ "OS install package for " ++ show remoteAddr
        readMVar params
      serveOsPackage remoteAddr instanceParams "os-install-package"
-       `catch`
+       `catchError`
        \err -> do
+#if MIN_VERSION_snap_server(1,0,0)
          let MetaMExc e = err
+#else
+         let e = err
+#endif
          liftIO .
            Logging.logWarning $ "Could not serve OS install package: " ++ e
          error404
@@ -169,9 +190,13 @@ handleMetadata params GET  "ganeti" "latest" "os/parameters.json" =
      instanceParams <- liftIO $ do
        Logging.logInfo $ "OS parameters for " ++ show remoteAddr
        readMVar params
-     serveOsParams remoteAddr instanceParams `catch`
+     serveOsParams remoteAddr instanceParams `catchError`
        \err -> do
+#if MIN_VERSION_snap_server(1,0,0)
          let MetaMExc e = err
+#else
+         let e = err
+#endif
          liftIO . Logging.logWarning $ "Could not serve OS parameters: " ++ e
          error404
 handleMetadata params GET  "ganeti" "latest" script | isScript script =
@@ -179,9 +204,13 @@ handleMetadata params GET  "ganeti" "latest" script | isScript script =
      instanceParams <- liftIO $ do
        Logging.logInfo $ "OS package for " ++ show remoteAddr
        readMVar params
-     serveOsScript remoteAddr instanceParams (last $ split script) `catch`
+     serveOsScript remoteAddr instanceParams (last $ split script) `catchError`
        \err -> do
+#if MIN_VERSION_snap_server(1,0,0)
          let MetaMExc e = err
+#else
+         let e = err
+#endif
          liftIO . Logging.logWarning $ "Could not serve OS scripts: " ++ e
          error404
   where isScript =

--- a/src/Ganeti/Metad/WebServer.hs
+++ b/src/Ganeti/Metad/WebServer.hs
@@ -37,9 +37,11 @@ module Ganeti.Metad.WebServer (start) where
 
 import Control.Applicative
 import Control.Concurrent (MVar, readMVar)
-import Control.Monad.Error.Class (MonadError, catchError, throwError)
+import Control.Monad.Base (MonadBase)
 import Control.Monad.IO.Class (liftIO)
-import Control.Exception.Lifted (catch)
+import Control.Exception.Lifted (catch, throwIO)
+import Control.Exception.Base (Exception)
+import Data.Typeable (Typeable)
 import qualified Data.CaseInsensitive as CI
 import Data.List (intercalate)
 import Data.Map (Map)
@@ -63,13 +65,19 @@ import Ganeti.Metad.Types (InstanceParams)
 
 type MetaM = Snap ()
 
+data MetaMExc = MetaMExc String deriving (Show, Typeable)
+instance Exception MetaMExc
+
+throwError :: MonadBase IO m => String -> m a
+throwError = throwIO . MetaMExc
+
 split :: String -> [String]
 split str =
   case span (/= '/') str of
     (x, []) -> [x]
     (x, _:xs) -> x:split xs
 
-lookupInstanceParams :: MonadError String m => String -> Map String b -> m b
+lookupInstanceParams :: MonadBase IO m => String -> Map String b -> m b
 lookupInstanceParams inst params =
   case Map.lookup inst params of
     Nothing -> throwError $ "Could not get instance params for " ++ show inst
@@ -87,7 +95,7 @@ error405 ms = modifyResponse $
   addHeader (CI.mk "Allow") (ByteString.pack . intercalate ", " $ map show ms)
   . setResponseStatus 405 "Method not allowed"
 
-maybeResult :: MonadError String m => Result t -> (t -> m a) -> m a
+maybeResult :: MonadBase IO m => Result t -> (t -> m a) -> m a
 maybeResult (Error err) _ = throwError err
 maybeResult (Ok x) f = f x
 
@@ -144,10 +152,11 @@ handleMetadata params GET  "ganeti" "latest" "os/os-install-package" =
        Logging.logInfo $ "OS install package for " ++ show remoteAddr
        readMVar params
      serveOsPackage remoteAddr instanceParams "os-install-package"
-       `catchError`
+       `catch`
        \err -> do
+         let MetaMExc e = err
          liftIO .
-           Logging.logWarning $ "Could not serve OS install package: " ++ err
+           Logging.logWarning $ "Could not serve OS install package: " ++ e
          error404
 handleMetadata params GET  "ganeti" "latest" "os/package" =
   do remoteAddr <- ByteString.unpack . rqRemoteAddr <$> getRequest
@@ -160,18 +169,20 @@ handleMetadata params GET  "ganeti" "latest" "os/parameters.json" =
      instanceParams <- liftIO $ do
        Logging.logInfo $ "OS parameters for " ++ show remoteAddr
        readMVar params
-     serveOsParams remoteAddr instanceParams `catchError`
+     serveOsParams remoteAddr instanceParams `catch`
        \err -> do
-         liftIO . Logging.logWarning $ "Could not serve OS parameters: " ++ err
+         let MetaMExc e = err
+         liftIO . Logging.logWarning $ "Could not serve OS parameters: " ++ e
          error404
 handleMetadata params GET  "ganeti" "latest" script | isScript script =
   do remoteAddr <- ByteString.unpack . rqRemoteAddr <$> getRequest
      instanceParams <- liftIO $ do
        Logging.logInfo $ "OS package for " ++ show remoteAddr
        readMVar params
-     serveOsScript remoteAddr instanceParams (last $ split script) `catchError`
+     serveOsScript remoteAddr instanceParams (last $ split script) `catch`
        \err -> do
-         liftIO . Logging.logWarning $ "Could not serve OS scripts: " ++ err
+         let MetaMExc e = err
+         liftIO . Logging.logWarning $ "Could not serve OS scripts: " ++ e
          error404
   where isScript =
           (`elem` [ "os/scripts/create"

--- a/src/Ganeti/Objects.hs
+++ b/src/Ganeti/Objects.hs
@@ -115,6 +115,7 @@ import qualified Data.Map as Map
 import Data.Monoid
 import Data.Ord (comparing)
 import Data.Ratio (numerator, denominator)
+import qualified Data.Semigroup as Sem
 import Data.Tuple (swap)
 import Data.Word
 import Text.JSON (showJSON, readJSON, JSON, JSValue(..), fromJSString,
@@ -286,12 +287,15 @@ $(buildObject "DataCollectorConfig" "dataCollector" [
   ])
 
 -- | Central default values of the data collector config.
+instance Sem.Semigroup DataCollectorConfig where
+  _ <> a = a
+
 instance Monoid DataCollectorConfig where
   mempty = DataCollectorConfig
     { dataCollectorActive = True
     , dataCollectorInterval = 10^(6::Integer) * fromIntegral C.mondTimeInterval
     }
-  mappend _ a = a
+  mappend = (Sem.<>)
 
 -- * IPolicy definitions
 

--- a/src/Ganeti/OpParams.hs
+++ b/src/Ganeti/OpParams.hs
@@ -905,12 +905,12 @@ pPowerDelay =
 pRequiredNodes :: Field
 pRequiredNodes =
   withDoc "Required list of node names" .
-  renameField "ReqNodes " $ simpleField "nodes" [t| [NonEmptyString] |]
+  renameField "ReqNodes" $ simpleField "nodes" [t| [NonEmptyString] |]
 
 pRequiredNodeUuids :: Field
 pRequiredNodeUuids =
   withDoc "Required list of node UUIDs" .
-  renameField "ReqNodeUuids " . optionalField $
+  renameField "ReqNodeUuids" . optionalField $
   simpleField "node_uuids" [t| [NonEmptyString] |]
 
 pRestrictedCommand :: Field
@@ -1521,7 +1521,7 @@ pOsNameChange =
 pDiskIndex :: Field
 pDiskIndex =
   withDoc "Disk index for e.g. grow disk" .
-  renameField "DiskIndex " $ simpleField "disk" [t| DiskIndex |]
+  renameField "DiskIndex" $ simpleField "disk" [t| DiskIndex |]
 
 pDiskChgAmount :: Field
 pDiskChgAmount =
@@ -1742,7 +1742,7 @@ pIAllocatorOs =
 pIAllocatorInstances :: Field
 pIAllocatorInstances =
   withDoc "IAllocator instances field" .
-  renameField "IAllocatorInstances " .
+  renameField "IAllocatorInstances" .
   optionalField $
   simpleField "instances" [t| [NonEmptyString] |]
 

--- a/src/Ganeti/Query/Filter.hs
+++ b/src/Ganeti/Query/Filter.hs
@@ -136,7 +136,7 @@ trueFilter v = Bad . ParameterError $
 -- | A type synonim for a rank-2 comparator function. This is used so
 -- that we can pass the usual '<=', '>', '==' functions to 'binOpFilter'
 -- and for them to be used in multiple contexts.
-type Comparator = (Eq a, Ord a) => a -> a -> Bool
+type Comparator = forall a . (Eq a, Ord a) => a -> a -> Bool
 
 -- | Equality checker.
 --

--- a/src/Ganeti/Query/Filter.hs
+++ b/src/Ganeti/Query/Filter.hs
@@ -183,10 +183,10 @@ containsFilter :: FilterValue -> JSValue -> ErrorResult Bool
 -- note: the next two implementations are the same, but we have to
 -- repeat them due to the encapsulation done by FilterValue
 containsFilter (QuotedString val) lst = do
-  lst' <- fromJVal lst
+  lst' <- fromJVal lst :: ErrorResult [String]
   return $! val `elem` lst'
 containsFilter (NumericValue val) lst = do
-  lst' <- fromJVal lst
+  lst' <- fromJVal lst :: ErrorResult [Integer]
   return $! val `elem` lst'
 
 

--- a/src/Ganeti/Query/Language.hs
+++ b/src/Ganeti/Query/Language.hs
@@ -94,7 +94,8 @@ $(makeJSONInstance ''ResultStatus)
 
 -- | No-op 'NFData' instance for 'ResultStatus', since it's a single
 -- constructor data-type.
-instance NFData ResultStatus
+instance NFData ResultStatus where
+  rnf x = seq x ()
 
 -- | Check that ResultStatus is success or fail with descriptive
 -- message.

--- a/src/Ganeti/THH.hs
+++ b/src/Ganeti/THH.hs
@@ -108,7 +108,10 @@ import Ganeti.JSON (readJSONWithDesc, fromObj, DictObject(..), ArrayObject(..),
 import Ganeti.PartialParams
 import Ganeti.PyValue
 import Ganeti.THH.PyType
+import Ganeti.THH.Compat
 
+myNotStrict :: Bang
+myNotStrict = Bang NoSourceUnpackedness NoSourceStrictness
 
 -- * Exported types
 
@@ -423,7 +426,7 @@ appConsApp cname =
 buildConsField :: Q Type -> StrictTypeQ
 buildConsField ftype = do
   ftype' <- ftype
-  return (NotStrict, ftype')
+  return (myNotStrict, ftype')
 
 -- | Builds a constructor based on a simple definition (not field-based).
 buildSimpleCons :: Name -> SimpleObject -> Q Dec
@@ -431,7 +434,7 @@ buildSimpleCons tname cons = do
   decl_d <- mapM (\(cname, fields) -> do
                     fields' <- mapM (buildConsField . snd) fields
                     return $ NormalC (mkName cname) fields') cons
-  return $ DataD [] tname [] decl_d [''Show, ''Eq]
+  return $ DataD [] tname [] Nothing decl_d $ derivesFromNames [''Show, ''Eq]
 
 -- | Generate the save function for a given type.
 genSaveSimpleObj :: Name                            -- ^ Object type
@@ -452,9 +455,9 @@ genSaveSimpleObj tname sname opdefs fn = do
 -- The type will have a fixed list of instances.
 strADTDecl :: Name -> [String] -> Dec
 strADTDecl name constructors =
-  DataD [] name []
+  DataD [] name [] Nothing
           (map (flip NormalC [] . mkName) constructors)
-          [''Show, ''Eq, ''Enum, ''Bounded, ''Ord]
+          $ derivesFromNames [''Show, ''Eq, ''Enum, ''Bounded, ''Ord]
 
 -- | Generates a toRaw function.
 --
@@ -598,7 +601,7 @@ makeJSONInstance name = do
   let base = nameBase name
   showJ <- genShowJSON base
   readJ <- genReadJSON base
-  return [InstanceD [] (AppT (ConT ''JSON.JSON) (ConT name)) [readJ,showJ]]
+  return [InstanceD Nothing [] (AppT (ConT ''JSON.JSON) (ConT name)) [readJ,showJ]]
 
 -- * Template code for opcodes
 
@@ -623,7 +626,7 @@ reifyConsNames :: Name -> Q [String]
 reifyConsNames name = do
   reify_result <- reify name
   case reify_result of
-    TyConI (DataD _ _ _ cons _) -> mapM (liftM nameBase . constructorName) cons
+    TyConI (DataD _ _ _ Nothing cons _) -> mapM (liftM nameBase . constructorName) cons
     o -> fail $ "Unhandled name passed to reifyConsNames, expected\
                 \ type constructor but got '" ++ show o ++ "'"
 
@@ -772,7 +775,7 @@ genOpCodeDictObject :: Name                -- ^ Type name to use
 genOpCodeDictObject tname savefn loadfn cons = do
   tdclauses <- genSaveOpCode cons savefn
   fdclauses <- genLoadOpCode cons loadfn
-  return [ InstanceD [] (AppT (ConT ''DictObject) (ConT tname))
+  return [ InstanceD Nothing [] (AppT (ConT ''DictObject) (ConT tname))
            [ FunD 'toDict tdclauses
            , FunD 'fromDictWKeys fdclauses
            ]]
@@ -793,7 +796,7 @@ genOpCode name cons = do
                     fields' <- mapM (fieldTypeInfo "op") fields
                     return $ RecC (mkName cname) fields')
             cons
-  let declD = DataD [] tname [] decl_d [''Show, ''Eq]
+  let declD = DataD [] tname [] Nothing decl_d $ derivesFromNames [''Show, ''Eq]
   let (allfsig, allffn) = genAllOpFields "allOpFields" cons
   -- DictObject
   let luxiCons = map opcodeConsToLuxiCons cons
@@ -917,10 +920,10 @@ genLuxiOp name cons = do
   decl_d <- mapM (\(cname, fields) -> do
                     -- we only need the type of the field, without Q
                     fields' <- mapM actualFieldType fields
-                    let fields'' = zip (repeat NotStrict) fields'
+                    let fields'' = zip (repeat myNotStrict) fields'
                     return $ NormalC (mkName cname) fields'')
             cons
-  let declD = DataD [] (mkName name) [] decl_d [''Show, ''Eq]
+  let declD = DataD [] (mkName name) [] Nothing decl_d $ derivesFromNames [''Show, ''Eq]
   -- generate DictObject instance
   dictObjInst <- genOpCodeDictObject tname saveLuxiConstructor
                                      loadOpConstructor cons
@@ -955,7 +958,7 @@ fieldTypeInfo :: String -> Field -> Q (Name, Strict, Type)
 fieldTypeInfo field_pfx fd = do
   t <- actualFieldType fd
   let n = mkName . (field_pfx ++) . fieldRecordName $ fd
-  return (n, NotStrict, t)
+  return (n, myNotStrict, t)
 
 -- | Build an object declaration.
 buildObject :: String -> String -> [Field] -> Q [Dec]
@@ -967,7 +970,7 @@ buildObject sname field_pfx fields = do
   let name = mkName sname
   fields_d <- mapM (fieldTypeInfo field_pfx) fields
   let decl_d = RecC name fields_d
-  let declD = DataD [] name [] [decl_d] [''Show, ''Eq]
+  let declD = DataD [] name [] Nothing [decl_d] $ derivesFromNames [''Show, ''Eq]
   ser_decls <- buildObjectSerialisation sname fields
   return $ declD:ser_decls
 
@@ -1082,10 +1085,10 @@ buildObjectWithForthcoming sname field_pfx fields = do
                       (map makeOptional fields)
   let name = mkName sname
       real_d = NormalC (mkName real_nm)
-                 [(NotStrict, ConT (mkName real_data_nm))]
+                 [(myNotStrict, ConT (mkName real_data_nm))]
       forth_d = NormalC (mkName forth_nm)
-                  [(NotStrict, ConT (mkName forth_data_nm))]
-      declD = DataD [] name [] [real_d, forth_d] [''Show, ''Eq]
+                  [(myNotStrict, ConT (mkName forth_data_nm))]
+  let declD = DataD [] name [] Nothing [real_d, forth_d] $ derivesFromNames [''Show, ''Eq]
 
   read_body <- [| branchOnField "forthcoming"
                   (liftM $(conE $ mkName forth_nm) . JSON.readJSON)
@@ -1101,7 +1104,7 @@ buildObjectWithForthcoming sname field_pfx fields = do
                  , Clause [ConP (mkName forth_nm) [VarP x]]
                     (NormalB show_forth_body) []
                  ]
-      instJSONdecl = InstanceD [] (AppT (ConT ''JSON.JSON) (ConT name))
+      instJSONdecl = InstanceD Nothing [] (AppT (ConT ''JSON.JSON) (ConT name))
                      [rdjson, shjson]
   accessors <- liftM concat . flip mapM fields
                  $ buildAccessor (mkName forth_nm) forth_pfx
@@ -1126,7 +1129,7 @@ buildObjectWithForthcoming sname field_pfx fields = do
                             ]
       fromdict = FunD 'fromDictWKeys [ Clause [VarP xs]
                                        (NormalB fromDictWKeysbody) [] ]
-      instDict = InstanceD [] (AppT (ConT ''DictObject) (ConT name))
+      instDict = InstanceD Nothing [] (AppT (ConT ''DictObject) (ConT name))
                  [todict, fromdict]
   instArray <- genArrayObjectInstance name
                  (simpleField "forthcoming" [t| Bool |] : fields)
@@ -1153,7 +1156,7 @@ buildObjectSerialisation sname fields = do
   (loadsig, loadfn) <- genLoadObject sname
   shjson <- objectShowJSON sname
   rdjson <- objectReadJSON sname
-  let instdecl = InstanceD [] (AppT (ConT ''JSON.JSON) (ConT name))
+  let instdecl = InstanceD Nothing [] (AppT (ConT ''JSON.JSON) (ConT name))
                  [rdjson, shjson]
   return $ dictdecls ++ savedecls ++ [loadsig, loadfn, instdecl]
 
@@ -1219,7 +1222,7 @@ genDictObject save_fn load_fn sname fields = do
   -- the ArrayObject instance generated from DictObject
   arrdec <- genArrayObjectInstance name fields
   -- the final instance
-  return $ [InstanceD [] (AppT (ConT ''DictObject) (ConT name))
+  return $ [InstanceD Nothing [] (AppT (ConT ''DictObject) (ConT name))
              [ FunD 'toDict [tdclause]
              , FunD 'fromDictWKeys [fdclause]
              ]]
@@ -1353,7 +1356,7 @@ paramFieldNames field_pfx fd =
 paramFieldTypeInfo :: String -> Field -> VarStrictTypeQ
 paramFieldTypeInfo field_pfx fd = do
   t <- actualFieldType fd
-  return (snd $ paramFieldNames field_pfx fd, NotStrict, AppT (ConT ''Maybe) t)
+  return (snd $ paramFieldNames field_pfx fd, myNotStrict, AppT (ConT ''Maybe) t)
 
 -- | Build a parameter declaration.
 --
@@ -1372,8 +1375,8 @@ buildParam sname field_pfx fields = do
   fields_p <- mapM (paramFieldTypeInfo field_pfx) fields
   let decl_f = RecC name_f fields_f
       decl_p = RecC name_p fields_p
-  let declF = DataD [] name_f [] [decl_f] [''Show, ''Eq]
-      declP = DataD [] name_p [] [decl_p] [''Show, ''Eq]
+  let declF = DataD [] name_f [] Nothing [decl_f] $ derivesFromNames [''Show, ''Eq]
+  let declP = DataD [] name_p [] Nothing [decl_p] $ derivesFromNames [''Show, ''Eq]
   ser_decls_f <- buildObjectSerialisation sname_f fields
   ser_decls_p <- buildPParamSerialisation sname_p fields
   fill_decls <- fillParam sname field_pfx fields
@@ -1397,7 +1400,7 @@ buildPParamSerialisation sname fields = do
   (loadsig, loadfn) <- genLoadObject sname
   shjson <- objectShowJSON sname
   rdjson <- objectReadJSON sname
-  let instdecl = InstanceD [] (AppT (ConT ''JSON.JSON) (ConT name))
+  let instdecl = InstanceD Nothing [] (AppT (ConT ''JSON.JSON) (ConT name))
                  [rdjson, shjson]
   return $ dictdecls ++ savedecls ++ [loadsig, loadfn, instdecl]
 
@@ -1467,12 +1470,12 @@ fillParam sname field_pfx fields = do
       mappendClause = Clause [pConP, pConP2] (NormalB mappendExp) []
   let monoidType = AppT (ConT ''Monoid) (ConT name_p)
   -- the instances combined
-  return [ InstanceD [] instType
+  return [ InstanceD Nothing [] instType
                      [ FunD 'fillParams [fclause]
                      , FunD 'toPartial [tpclause]
                      , FunD 'toFilled [tfclause]
                      ]
-         , InstanceD [] monoidType
+         , InstanceD Nothing [] monoidType
                      [ FunD 'mempty [memptyClause]
                      , FunD 'mappend [mappendClause]
                      ]]

--- a/src/Ganeti/THH.hs
+++ b/src/Ganeti/THH.hs
@@ -94,6 +94,7 @@ import Data.List
 import Data.Maybe
 import qualified Data.Map as M
 import Data.Monoid
+import qualified Data.Semigroup as Sem
 import qualified Data.Set as S
 import qualified Data.Text as T
 import Language.Haskell.TH
@@ -1468,16 +1469,21 @@ fillParam sname field_pfx fields = do
   let altExp = zipWith (\l r -> AppE (AppE (VarE '(<|>)) (VarE r)) (VarE l))
       mappendExp = appCons name_p $ altExp pbinds pbinds2
       mappendClause = Clause [pConP, pConP2] (NormalB mappendExp) []
+      mappendAlias = Clause [] (NormalB $ VarE '(Sem.<>)) []
   let monoidType = AppT (ConT ''Monoid) (ConT name_p)
+  let semigroupType = AppT (ConT ''Sem.Semigroup) (ConT name_p)
   -- the instances combined
   return [ InstanceD Nothing [] instType
                      [ FunD 'fillParams [fclause]
                      , FunD 'toPartial [tpclause]
                      , FunD 'toFilled [tfclause]
                      ]
+         , InstanceD Nothing [] semigroupType
+                     [ FunD '(Sem.<>) [mappendClause]
+                     ]
          , InstanceD Nothing [] monoidType
                      [ FunD 'mempty [memptyClause]
-                     , FunD 'mappend [mappendClause]
+                     , FunD 'mappend [mappendAlias]
                      ]]
 
 -- * Template code for exceptions

--- a/src/Ganeti/THH.hs
+++ b/src/Ganeti/THH.hs
@@ -1203,8 +1203,13 @@ genDictObject :: (Name -> Field -> Q Exp)  -- ^ a saving function
               -> Q [Dec]
 genDictObject save_fn load_fn sname fields = do
   let name = mkName sname
+      -- newName fails in ghc 7.10 when used on keywords
+      newName' "data" = newName "data_ghcBug10599"
+      newName' "instance" = newName "instance_ghcBug10599"
+      newName' "type" = newName "type_ghcBug10599"
+      newName' s = newName s
   -- toDict
-  fnames <- mapM (newName . fieldVariable) fields
+  fnames <- mapM (newName' . fieldVariable) fields
   let pat = conP name (map varP fnames)
       tdexp = [| concat $(listE $ zipWith save_fn fnames fields) |]
   tdclause <- clause [pat] (normalB tdexp) []

--- a/src/Ganeti/THH.hs
+++ b/src/Ganeti/THH.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ParallelListComp, TemplateHaskell #-}
+{-# LANGUAGE ParallelListComp, TemplateHaskell, RankNTypes #-}
 
 {-| TemplateHaskell helper for Ganeti Haskell code.
 
@@ -488,7 +488,7 @@ genToRaw traw fname tname constructors = do
 genFromRaw :: Name -> Name -> Name -> [(String, Either String Name)] -> Q [Dec]
 genFromRaw traw fname tname constructors = do
   -- signature of form (Monad m) => String -> m $name
-  sigt <- [t| (Monad m) => $(conT traw) -> m $(conT tname) |]
+  sigt <- [t| forall m. (Monad m) => $(conT traw) -> m $(conT tname) |]
   -- clauses for a guarded pattern
   let varp = mkName "s"
       varpe = varE varp

--- a/src/Ganeti/THH/Compat.hs
+++ b/src/Ganeti/THH/Compat.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE CPP, TemplateHaskell #-}
+
+{-| Shim library for supporting various Template Haskell versions
+
+-}
+
+{-
+
+Copyright (C) 2018 Ganeti Project Contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-}
+
+module Ganeti.THH.Compat
+  ( derivesFromNames
+  ) where
+
+import Language.Haskell.TH
+
+-- | Convert Names to DerivClauses
+--
+-- template-haskell 2.12 (GHC 8.2) has changed the DataD class of
+-- constructors to expect [DerivClause] instead of [Names]. Handle this in a
+-- backwards-compatible way.
+#if MIN_VERSION_template_haskell(2,12,0)
+derivesFromNames :: [Name] -> [DerivClause]
+derivesFromNames names = [DerivClause Nothing $ map ConT names]
+#else
+derivesFromNames :: [Name] -> Cxt
+derivesFromNames names = map ConT names
+#endif

--- a/src/Ganeti/THH/HsRPC.hs
+++ b/src/Ganeti/THH/HsRPC.hs
@@ -73,7 +73,7 @@ instance MonadBaseControl IO RpcClientMonad where
 #if MIN_VERSION_monad_control(1,0,0)
 -- Needs Undecidable instances
   type StM RpcClientMonad b = StM (ReaderT Client ResultG) b
-  liftBaseWith f = RpcClientMonad . liftBaseWith
+  liftBaseWith f = RpcClientMonad $ liftBaseWith
                    $ \r -> f (r . runRpcClientMonad)
   restoreM = RpcClientMonad . restoreM
 #else

--- a/src/Ganeti/THH/PyRPC.hs
+++ b/src/Ganeti/THH/PyRPC.hs
@@ -40,6 +40,7 @@ module Ganeti.THH.PyRPC
   , genPyUDSRpcStubStr
   ) where
 
+import Prelude hiding ((<>))
 import Control.Monad
 import Data.Char (toLower, toUpper)
 import Data.Functor

--- a/src/Ganeti/THH/Types.hs
+++ b/src/Ganeti/THH/Types.hs
@@ -68,7 +68,7 @@ typeOfFun :: Name -> Q Type
 typeOfFun name = reify name >>= args
   where
     args :: Info -> Q Type
-    args (VarI _ tp _ _) = return tp
+    args (VarI _ tp _) = return tp
     args _               = fail $ "Not a function: " ++ show name
 
 -- | Splits a function type into the types of its arguments and the result.

--- a/src/Ganeti/THH/Types.hs
+++ b/src/Ganeti/THH/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell, DeriveFunctor #-}
+{-# LANGUAGE TemplateHaskell, DeriveFunctor, CPP #-}
 
 {-| Utility Template Haskell functions for working with types.
 
@@ -68,7 +68,11 @@ typeOfFun :: Name -> Q Type
 typeOfFun name = reify name >>= args
   where
     args :: Info -> Q Type
+#if MIN_VERSION_template_haskell(2,11,0)
     args (VarI _ tp _) = return tp
+#else
+    args (VarI _ tp _ _) = return tp
+#endif
     args _               = fail $ "Not a function: " ++ show name
 
 -- | Splits a function type into the types of its arguments and the result.

--- a/src/Ganeti/Utils.hs
+++ b/src/Ganeti/Utils.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts, ScopedTypeVariables, CPP #-}
 
 {-| Utility functions. -}
 
@@ -110,7 +110,11 @@ import Data.Char (toUpper, isAlphaNum, isDigit, isSpace)
 import qualified Data.Either as E
 import Data.Function (on)
 import Data.IORef
+#if MIN_VERSION_base(4,8,0)
+import Data.List hiding (isSubsequenceOf)
+#else
 import Data.List
+#endif
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as S

--- a/src/Ganeti/Utils.hs
+++ b/src/Ganeti/Utils.hs
@@ -129,6 +129,7 @@ import Debug.Trace
 import Network.Socket
 
 import Ganeti.BasicTypes
+import Ganeti.Compat
 import qualified Ganeti.ConstantUtils as ConstantUtils
 import Ganeti.Logging
 import Ganeti.Runtime
@@ -725,11 +726,11 @@ watchFileBy fpath timeout check read_fn = do
                        logDebug $ "Notified of change in " ++ fpath
                                     ++ "; event: " ++ show e
                        when (e == Ignored)
-                         (addWatch inotify [Modify, Delete] fpath do_watch
+                         (addWatch inotify [Modify, Delete] (toInotifyPath fpath) do_watch
                             >> return ())
                        fstat' <- getFStatSafe fpath
                        writeIORef ref fstat'
-    _ <- addWatch inotify [Modify, Delete] fpath do_watch
+    _ <- addWatch inotify [Modify, Delete] (toInotifyPath fpath) do_watch
     newval <- read_fn
     if check newval
       then do

--- a/src/Ganeti/Utils/MultiMap.hs
+++ b/src/Ganeti/Utils/MultiMap.hs
@@ -59,6 +59,7 @@ import Prelude hiding (lookup, null, elem)
 import Control.Monad
 import qualified Data.Foldable as F
 import qualified Data.Map as M
+import qualified Data.Semigroup as Sem
 import Data.Maybe (fromMaybe, isJust)
 import Data.Monoid
 import qualified Data.Set as S
@@ -72,9 +73,12 @@ import Ganeti.Lens
 newtype MultiMap k v = MultiMap { getMultiMap :: M.Map k (S.Set v) }
   deriving (Eq, Ord, Show)
 
+instance (Ord v, Ord k) => Sem.Semigroup (MultiMap k v) where
+  (MultiMap x) <> (MultiMap y) = MultiMap $ M.unionWith S.union x y
+
 instance (Ord v, Ord k) => Monoid (MultiMap k v) where
   mempty = MultiMap M.empty
-  mappend (MultiMap x) (MultiMap y) = MultiMap $ M.unionWith S.union x y
+  mappend = (Sem.<>)
 
 instance F.Foldable (MultiMap k) where
   foldMap f = F.foldMap (F.foldMap f) . getMultiMap

--- a/src/Ganeti/WConfd/Monad.hs
+++ b/src/Ganeti/WConfd/Monad.hs
@@ -197,7 +197,7 @@ instance MonadBaseControl IO WConfdMonadInt where
 #if MIN_VERSION_monad_control(1,0,0)
 -- Needs Undecidable instances
   type StM WConfdMonadInt b = StM WConfdMonadIntType b
-  liftBaseWith f = WConfdMonadInt . liftBaseWith
+  liftBaseWith f = WConfdMonadInt $ liftBaseWith
                    $ \r -> f (r . getWConfdMonadInt)
   restoreM = WConfdMonadInt . restoreM
 #else

--- a/src/Ganeti/WConfd/Monad.hs
+++ b/src/Ganeti/WConfd/Monad.hs
@@ -82,6 +82,7 @@ import Control.Monad.Trans.Control
 import Data.Functor.Identity
 import Data.IORef.Lifted
 import Data.Monoid (Any(..), Monoid(..))
+import qualified Data.Semigroup as Sem
 import qualified Data.Set as S
 import Data.Tuple (swap)
 import System.Posix.Process (getProcessID)
@@ -109,11 +110,14 @@ import Ganeti.WConfd.TempRes
 -- | Data type describing where the configuration has to be distributed to.
 data DistributionTarget = Everywhere | ToGroups (S.Set String) deriving Show
 
+instance Sem.Semigroup DistributionTarget where
+  Everywhere <> _ = Everywhere
+  _ <> Everywhere = Everywhere
+  (ToGroups a) <> (ToGroups b) = ToGroups (a `S.union` b)
+
 instance Monoid DistributionTarget where
   mempty = ToGroups S.empty
-  mappend Everywhere _ = Everywhere
-  mappend _ Everywhere = Everywhere
-  mappend (ToGroups a) (ToGroups b) = ToGroups (a `S.union` b)
+  mappend = (Sem.<>)
 
 -- * Pure data types used in the monad
 

--- a/src/Ganeti/WConfd/TempRes.hs
+++ b/src/Ganeti/WConfd/TempRes.hs
@@ -85,6 +85,7 @@ import Data.Maybe
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Monoid
+import qualified Data.Semigroup as Sem
 import qualified Data.Set as S
 import System.Random
 import qualified Text.JSON as J
@@ -160,9 +161,12 @@ instance J.JSON IPv4Reservation where
 newtype TempRes j a = TempRes { getTempRes :: MM.MultiMap j a }
   deriving (Eq, Ord, Show)
 
+instance (Ord j, Ord a) => Sem.Semigroup (TempRes j a) where
+  (TempRes x) <> (TempRes y) = TempRes $ x <> y
+
 instance (Ord j, Ord a) => Monoid (TempRes j a) where
   mempty = TempRes mempty
-  mappend (TempRes x) (TempRes y) = TempRes $ x <> y
+  mappend = (Sem.<>)
 
 instance (J.JSON j, Ord j, J.JSON a, Ord a) => J.JSON (TempRes j a) where
   showJSON = J.showJSON . getTempRes

--- a/test/hs/Test/Ganeti/JQueue.hs
+++ b/test/hs/Test/Ganeti/JQueue.hs
@@ -171,11 +171,12 @@ prop_ListJobIDs = monadicIO $ do
     full_dir <- extractJobIDs $ getJobIDs [tempdir]
     invalid_dir <- getJobIDs [tempdir </> "no-such-dir"]
     return (empty_dir, sortJobIDs full_dir, invalid_dir)
-  stop $ conjoin [ counterexample "empty directory" $ e ==? []
-                 , counterexample "directory with valid names" $
-                   f ==? sortJobIDs jobs
-                 , counterexample "invalid directory" $ isBad g
-                 ]
+  _ <- stop $ conjoin [ counterexample "empty directory" $ e ==? []
+                      , counterexample "directory with valid names" $
+                        f ==? sortJobIDs jobs
+                      , counterexample "invalid directory" $ isBad g
+                      ]
+  return ()
 
 -- | Tests loading jobs from disk.
 prop_LoadJobs :: Property
@@ -207,12 +208,13 @@ prop_LoadJobs = monadicIO $ do
     writeFile live_path "invalid job"
     broken <- load True
     return (missing, current, archived, missing_current, broken)
-  stop $ conjoin [ missing ==? noSuchJob
-                 , current ==? Ganeti.BasicTypes.Ok (job, False)
-                 , archived ==? Ganeti.BasicTypes.Ok (job, True)
-                 , missing_current ==? noSuchJob
-                 , counterexample "broken job" (isBad broken)
-                 ]
+  _ <- stop $ conjoin [ missing ==? noSuchJob
+                      , current ==? Ganeti.BasicTypes.Ok (job, False)
+                      , archived ==? Ganeti.BasicTypes.Ok (job, True)
+                      , missing_current ==? noSuchJob
+                      , counterexample "broken job" (isBad broken)
+                      ]
+  return ()
 
 -- | Tests computing job directories. Creates random directories,
 -- files and stale symlinks in a directory, and checks that we return
@@ -237,10 +239,11 @@ prop_DetermineDirs = monadicIO $ do
     invalid_root <- determineJobDirectories (tempdir </> "no-such-subdir") True
     return (tempdir, non_arch, with_arch, invalid_root)
   let arch_dir = tempdir </> jobQueueArchiveSubDir
-  stop $ conjoin [ non_arch ==? [tempdir]
-                 , sort with_arch ==? sort (tempdir:map (arch_dir </>) valid)
-                 , invalid_root ==? [tempdir </> "no-such-subdir"]
-                 ]
+  _ <- stop $ conjoin [ non_arch ==? [tempdir]
+                      , sort with_arch ==? sort (tempdir:map (arch_dir </>) valid)
+                      , invalid_root ==? [tempdir </> "no-such-subdir"]
+                      ]
+  return ()
 
 -- | Tests the JSON serialisation for 'InputOpCode'.
 prop_InputOpCode :: MetaOpCode -> Int -> Property

--- a/test/hs/Test/Ganeti/Luxi.hs
+++ b/test/hs/Test/Ganeti/Luxi.hs
@@ -149,7 +149,8 @@ prop_ClientServer dnschars = monadicIO $ do
       (Luxi.getLuxiClient fpath)
       Luxi.closeClient
       (`luxiClientPong` msgs)
-  stop $ replies ==? msgs
+  _ <- stop $ replies ==? msgs
+  return ()
 
 -- | Check that Python and Haskell define the same Luxi requests list.
 case_AllDefined :: Assertion

--- a/test/hs/Test/Ganeti/Objects.hs
+++ b/test/hs/Test/Ganeti/Objects.hs
@@ -341,9 +341,6 @@ instance Arbitrary ClusterOsParams where
 instance Arbitrary ClusterBeParams where
   arbitrary = (GenericContainer . Map.fromList) <$> arbitrary
 
-instance Arbitrary TagSet where
-  arbitrary = Set.fromList <$> genTags
-
 instance Arbitrary IAllocatorParams where
   arbitrary = return $ GenericContainer Map.empty
 

--- a/test/hs/Test/Ganeti/Query/Filter.hs
+++ b/test/hs/Test/Ganeti/Query/Filter.hs
@@ -64,8 +64,9 @@ checkQueryResults :: ConfigData -> Query -> String
                   -> [[ResultEntry]] -> Property
 checkQueryResults cfg qr descr expected = monadicIO $ do
   result <- run (query cfg False qr) >>= resultProp
-  stop $ counterexample ("Inconsistent results in " ++ descr)
-         (qresData result ==? expected)
+  _ <- stop $ counterexample ("Inconsistent results in " ++ descr)
+              (qresData result ==? expected)
+  return ()
 
 -- | Makes a node name query, given a filter.
 makeNodeQuery :: Filter FilterField -> Query

--- a/test/hs/Test/Ganeti/Query/Query.hs
+++ b/test/hs/Test/Ganeti/Query/Query.hs
@@ -87,15 +87,16 @@ prop_queryNode_noUnknown =
                               [field] EmptyFilter)) >>= resultProp
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields (ItemTypeOpCode QRNode) [field])
-  stop $ conjoin
-         [ counterexample ("Got unknown fields via query (" ++
-                           show fdefs ++ ")") (hasUnknownFields fdefs)
-         , counterexample ("Got unknown result status via query (" ++
-                           show fdata ++ ")")
-           (all (all ((/= RSUnknown) . rentryStatus)) fdata)
-         , counterexample ("Got unknown fields via query fields (" ++
-                           show fdefs'++ ")") (hasUnknownFields fdefs')
-         ]
+  _ <- stop $ conjoin
+              [ counterexample ("Got unknown fields via query (" ++
+                                show fdefs ++ ")") (hasUnknownFields fdefs)
+              , counterexample ("Got unknown result status via query (" ++
+                                show fdata ++ ")")
+                (all (all ((/= RSUnknown) . rentryStatus)) fdata)
+              , counterexample ("Got unknown fields via query fields (" ++
+                                show fdefs'++ ")") (hasUnknownFields fdefs')
+              ]
+  return ()
 
 -- | Tests that an unknown field is returned as such.
 prop_queryNode_Unknown :: Property
@@ -108,18 +109,19 @@ prop_queryNode_Unknown =
                               [field] EmptyFilter)) >>= resultProp
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields (ItemTypeOpCode QRNode) [field])
-  stop $ conjoin
-         [ counterexample ("Got known fields via query (" ++ show fdefs ++ ")")
-           (not $ hasUnknownFields fdefs)
-         , counterexample ("Got /= ResultUnknown result status via query (" ++
-                           show fdata ++ ")")
-           (all (all ((== RSUnknown) . rentryStatus)) fdata)
-         , counterexample ("Got a Just in a result value (" ++
-                           show fdata ++ ")")
-           (all (all (isNothing . rentryValue)) fdata)
-         , counterexample ("Got known fields via query fields (" ++ show fdefs'
-                           ++ ")") (not $ hasUnknownFields fdefs')
-         ]
+  _ <- stop $ conjoin
+              [ counterexample ("Got known fields via query (" ++ show fdefs ++ ")")
+                (not $ hasUnknownFields fdefs)
+              , counterexample ("Got /= ResultUnknown result status via query (" ++
+                                show fdata ++ ")")
+                (all (all ((== RSUnknown) . rentryStatus)) fdata)
+              , counterexample ("Got a Just in a result value (" ++
+                                show fdata ++ ")")
+                (all (all (isNothing . rentryValue)) fdata)
+              , counterexample ("Got known fields via query fields (" ++ show fdefs'
+                                ++ ")") (not $ hasUnknownFields fdefs')
+              ]
+  return ()
 
 -- | Checks that a result type is conforming to a field definition.
 checkResultType :: FieldDefinition -> ResultEntry -> Property
@@ -154,16 +156,17 @@ prop_queryNode_types =
   QueryResult fdefs fdata <-
     run (query cfg False (Query (ItemTypeOpCode QRNode)
                           [field] EmptyFilter)) >>= resultProp
-  stop $ conjoin
-         [ counterexample ("Inconsistent result entries (" ++ show fdata ++ ")")
-           (conjoin $ map (conjoin . zipWith checkResultType fdefs) fdata)
-         , counterexample "Wrong field definitions length"
-           (length fdefs ==? 1)
-         , counterexample "Wrong field result rows length"
-           (all ((== 1) . length) fdata)
-         , counterexample "Wrong number of result rows"
-           (length fdata ==? numnodes)
-         ]
+  _ <- stop $ conjoin
+              [ counterexample ("Inconsistent result entries (" ++ show fdata ++ ")")
+                (conjoin $ map (conjoin . zipWith checkResultType fdefs) fdata)
+              , counterexample "Wrong field definitions length"
+                (length fdefs ==? 1)
+              , counterexample "Wrong field result rows length"
+                (all ((== 1) . length) fdata)
+              , counterexample "Wrong number of result rows"
+                (length fdata ==? numnodes)
+              ]
+  return ()
 
 -- | Test that queryFields with empty fields list returns all node fields.
 case_queryNode_allfields :: Assertion
@@ -200,10 +203,11 @@ prop_queryNode_filter =
     QueryResult _ fdata <-
       run (query cluster False (Query (ItemTypeOpCode QRNode)
                                 ["name"] flt)) >>= resultProp
-    stop $ conjoin
-      [ counterexample "Invalid node names" $
-        map (map rentryValue) fdata ==? map (\f -> [Just (showJSON f)]) fqdns
-      ]
+    _ <- stop $ conjoin
+           [ counterexample "Invalid node names" $
+             map (map rentryValue) fdata ==? map (\f -> [Just (showJSON f)]) fqdns
+           ]
+    return ()
 
 -- ** Group queries
 
@@ -217,15 +221,16 @@ prop_queryGroup_noUnknown =
            resultProp
     QueryFieldsResult fdefs' <-
       resultProp $ queryFields (QueryFields (ItemTypeOpCode QRGroup) [field])
-    stop $ conjoin
-     [ counterexample ("Got unknown fields via query (" ++ show fdefs ++ ")")
-          (hasUnknownFields fdefs)
-     , counterexample ("Got unknown result status via query (" ++
-                       show fdata ++ ")")
-       (all (all ((/= RSUnknown) . rentryStatus)) fdata)
-     , counterexample ("Got unknown fields via query fields (" ++ show fdefs'
-                       ++ ")") (hasUnknownFields fdefs')
-     ]
+    _ <- stop $ conjoin
+      [ counterexample ("Got unknown fields via query (" ++ show fdefs ++ ")")
+           (hasUnknownFields fdefs)
+      , counterexample ("Got unknown result status via query (" ++
+                        show fdata ++ ")")
+        (all (all ((/= RSUnknown) . rentryStatus)) fdata)
+      , counterexample ("Got unknown fields via query fields (" ++ show fdefs'
+                        ++ ")") (hasUnknownFields fdefs')
+      ]
+    return ()
 
 prop_queryGroup_Unknown :: Property
 prop_queryGroup_Unknown =
@@ -237,7 +242,7 @@ prop_queryGroup_Unknown =
                               [field] EmptyFilter)) >>= resultProp
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields (ItemTypeOpCode QRGroup) [field])
-  stop $ conjoin
+  _ <- stop $ conjoin
          [ counterexample ("Got known fields via query (" ++ show fdefs ++ ")")
            (not $ hasUnknownFields fdefs)
          , counterexample ("Got /= ResultUnknown result status via query (" ++
@@ -249,6 +254,7 @@ prop_queryGroup_Unknown =
          , counterexample ("Got known fields via query fields (" ++ show fdefs'
                            ++ ")") (not $ hasUnknownFields fdefs')
          ]
+  return ()
 
 prop_queryGroup_types :: Property
 prop_queryGroup_types =
@@ -258,13 +264,14 @@ prop_queryGroup_types =
   QueryResult fdefs fdata <-
     run (query cfg False (Query (ItemTypeOpCode QRGroup)
                           [field] EmptyFilter)) >>= resultProp
-  stop $ conjoin
+  _ <- stop $ conjoin
          [ counterexample ("Inconsistent result entries (" ++ show fdata ++ ")")
            (conjoin $ map (conjoin . zipWith checkResultType fdefs) fdata)
          , counterexample "Wrong field definitions length" (length fdefs ==? 1)
          , counterexample "Wrong field result rows length"
            (all ((== 1) . length) fdata)
          ]
+  return ()
 
 case_queryGroup_allfields :: Assertion
 case_queryGroup_allfields = do
@@ -288,10 +295,11 @@ prop_queryGroup_nodeCount =
     QueryResult _ fdata <-
       run (query cluster False (Query (ItemTypeOpCode QRGroup)
                                 ["node_cnt"] EmptyFilter)) >>= resultProp
-    stop $ conjoin
-      [ counterexample "Invalid node count" $
-        map (map rentryValue) fdata ==? [[Just (showJSON nodes)]]
-      ]
+    _ <- stop $ conjoin
+           [ counterexample "Invalid node count" $
+             map (map rentryValue) fdata ==? [[Just (showJSON nodes)]]
+           ]
+    return ()
 
 -- ** Job queries
 
@@ -311,15 +319,16 @@ prop_queryJob_noUnknown =
     run (query undefined False (Query qtype [field] flt)) >>= resultProp
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields qtype [field])
-  stop $ conjoin
-         [ counterexample ("Got unknown fields via query (" ++
-                           show fdefs ++ ")") (hasUnknownFields fdefs)
-         , counterexample ("Got unknown result status via query (" ++
-                           show fdata ++ ")")
-           (all (all ((/= RSUnknown) . rentryStatus)) fdata)
-         , counterexample ("Got unknown fields via query fields (" ++
-                           show fdefs'++ ")") (hasUnknownFields fdefs')
-         ]
+  _ <- stop $ conjoin
+              [ counterexample ("Got unknown fields via query (" ++
+                                show fdefs ++ ")") (hasUnknownFields fdefs)
+              , counterexample ("Got unknown result status via query (" ++
+                                show fdata ++ ")")
+                (all (all ((/= RSUnknown) . rentryStatus)) fdata)
+              , counterexample ("Got unknown fields via query fields (" ++
+                                show fdefs'++ ")") (hasUnknownFields fdefs')
+              ]
+  return ()
 
 -- | Tests that an unknown field is returned as such.
 prop_queryJob_Unknown :: Property
@@ -334,7 +343,7 @@ prop_queryJob_Unknown =
     run (query undefined False (Query qtype [field] flt)) >>= resultProp
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields qtype [field])
-  stop $ conjoin
+  _ <- stop $ conjoin
          [ counterexample ("Got known fields via query (" ++ show fdefs ++ ")")
            (not $ hasUnknownFields fdefs)
          , counterexample ("Got /= ResultUnknown result status via query (" ++
@@ -346,6 +355,7 @@ prop_queryJob_Unknown =
          , counterexample ("Got known fields via query fields (" ++ show fdefs'
                            ++ ")") (not $ hasUnknownFields fdefs')
          ]
+  return ()
 
 -- ** Misc other tests
 

--- a/test/hs/Test/Ganeti/Rpc.hs
+++ b/test/hs/Test/Ganeti/Rpc.hs
@@ -115,7 +115,8 @@ runOfflineTest :: (Rpc.Rpc a b, Eq b, Show b) => a -> Property
 runOfflineTest call =
   forAll (arbitrary `suchThat` Objects.nodeOffline) $ \node -> monadicIO $ do
       res <- run $ Rpc.executeRpcCall [node] call
-      stop $ res ==? [(node, Left Rpc.OfflineNodeError)]
+      _ <- stop $ res ==? [(node, Left Rpc.OfflineNodeError)]
+      return ()
 
 prop_noffl_request_allinstinfo :: Rpc.RpcCallAllInstancesInfo -> Property
 prop_noffl_request_allinstinfo = runOfflineTest

--- a/test/hs/Test/Ganeti/TestCommon.hs
+++ b/test/hs/Test/Ganeti/TestCommon.hs
@@ -118,15 +118,20 @@ import Numeric
 
 import qualified Ganeti.BasicTypes as BasicTypes
 import Ganeti.JSON (ArrayObject(..))
+import Ganeti.Objects (TagSet)
 import Ganeti.Types
 import Ganeti.Utils.Monad (unfoldrM)
 
 -- * Arbitrary orphan instances
 
+#if !MIN_VERSION_QuickCheck(2,8,0)
 instance (Ord k, Arbitrary k, Arbitrary a) => Arbitrary (M.Map k a) where
   arbitrary = M.fromList <$> arbitrary
   shrink m = M.fromList <$> shrink (M.toList m)
 
+instance Arbitrary TagSet where
+  arbitrary = Set.fromList <$> genTags
+#endif
 
 -- * Constants
 

--- a/test/hs/Test/Ganeti/TestHelper.hs
+++ b/test/hs/Test/Ganeti/TestHelper.hs
@@ -127,7 +127,7 @@ mkRegularArbitrary name cons = do
             [x] -> return $ mkConsArbitrary (conInfo x)
             xs -> appE (varE 'oneof) $
                   listE (map (return . mkConsArbitrary . conInfo) xs)
-  return [InstanceD [] (AppT (ConT ''Arbitrary) (ConT name))
+  return [InstanceD Nothing [] (AppT (ConT ''Arbitrary) (ConT name))
           [ValD (VarP 'arbitrary) (NormalB expr) []]]
 
 -- | Builds a default Arbitrary instance for a type. This requires
@@ -140,9 +140,9 @@ genArbitrary :: Name -> Q [Dec]
 genArbitrary name = do
   r <- reify name
   case r of
-    TyConI (DataD _ _ _ cons _) ->
+    TyConI (DataD _ _ _ _ cons _) ->
       mkRegularArbitrary name cons
-    TyConI (NewtypeD _ _ _ con _) ->
+    TyConI (NewtypeD _ _ _ _ con _) ->
       mkRegularArbitrary name [con]
     TyConI (TySynD _ _ (ConT tn)) -> genArbitrary tn
     _ -> fail $ "Invalid type in call to genArbitrary for " ++ show name

--- a/test/hs/Test/Ganeti/Utils.hs
+++ b/test/hs/Test/Ganeti/Utils.hs
@@ -43,7 +43,11 @@ import Test.HUnit
 import Control.Applicative ((<$>), (<*>))
 import Data.Char (isSpace)
 import qualified Data.Either as Either
+#if MIN_VERSION_base(4,8,0)
+import Data.List hiding (isSubsequenceOf)
+#else
 import Data.List
+#endif
 import Data.Maybe (listToMaybe)
 import qualified Data.Set as S
 import System.Time


### PR DESCRIPTION
This makes stable-2.16 build with GHC 8.0 - 8.4, without breaking pre-GHC 8 compatibility. Commits up to and including bb9ead6  are direct cherry-picks from master, the subsequent commits restore compatibility where it was broken.

Tested on Jessie (GHC 7.6), Stretch (GHC 8.0) and Buster (GHC 8.4) and it seems to work.