### PR TITLE
Fix KVM test rejecting '-machine'

### DIFF
--- a/test/py/ganeti.hypervisor.hv_kvm_unittest.py
+++ b/test/py/ganeti.hypervisor.hv_kvm_unittest.py
@@ -607,7 +607,7 @@ class TestKvmRuntime(testutils.GanetiTestCase):
       if '-S' in cmd:
         self.mocks['pid_alive'].return_value = ('file', -1, True)
         return mock.Mock(failed=False)
-      elif '-M' in cmd:
+      elif '-machine' in cmd:
         return mock.Mock(failed=False, output='')
       elif '-device' in cmd:
         return mock.Mock(failed=False, output='name "virtio-blk-pci"')


### PR DESCRIPTION
a05ff2f79dce1f4f5135fefde097a05a92a56177 replaced the '-M' KVM command
line argument with '-machine', but did not update the KVM test which
continues to expect '-M'.