### PR TITLE
TagSet changes for better test coverage

### DIFF
--- a/src/Ganeti/Objects.hs
+++ b/src/Ganeti/Objects.hs
@@ -84,7 +84,7 @@ module Ganeti.Objects
   , SerialNoObject(..) -- re-exported from Types
   , TagsObject(..) -- re-exported from Types
   , DictObject(..) -- re-exported from THH
-  , TagSet -- re-exported from THH
+  , TagSet(..) -- re-exported from THH
   , emptyTagSet -- re-exported from THH
   , Network(..)
   , AddressPool(..)

--- a/src/Ganeti/Objects.hs
+++ b/src/Ganeti/Objects.hs
@@ -85,6 +85,7 @@ module Ganeti.Objects
   , TagsObject(..) -- re-exported from Types
   , DictObject(..) -- re-exported from THH
   , TagSet -- re-exported from THH
+  , emptyTagSet -- re-exported from THH
   , Network(..)
   , AddressPool(..)
   , Ip4Address()
@@ -735,4 +736,3 @@ $(buildObject "MasterNetworkParameters" "masterNetworkParameters"
   , simpleField "netdev"    [t| String   |]
   , simpleField "ip_family" [t| IpFamily |]
   ])
-

--- a/src/Ganeti/Objects/Lens.hs
+++ b/src/Ganeti/Objects/Lens.hs
@@ -64,7 +64,7 @@ class SerialNoObject a => SerialNoObjectL a where
 
 -- | Class of objects that have tags.
 class TagsObject a => TagsObjectL a where
-  tagsL :: Lens' a (Set.Set String)
+  tagsL :: Lens' a TagSet
 
 $(makeCustomLenses ''AddressPool)
 

--- a/src/Ganeti/THH/Field.hs
+++ b/src/Ganeti/THH/Field.hs
@@ -44,6 +44,7 @@ module Ganeti.THH.Field
   , uuidFields
   , serialFields
   , TagSet
+  , emptyTagSet
   , tagsFields
   , fileModeAsIntField
   , processIdField
@@ -124,9 +125,13 @@ uuidFields = [ presentInForthcoming $ simpleField "uuid" [t| BS.ByteString |] ]
 -- | Tag set type alias.
 type TagSet = Set.Set String
 
+-- | Empty tag set value.
+emptyTagSet :: TagSet
+emptyTagSet = Set.empty
+
 -- | Tag field description.
 tagsFields :: [Field]
-tagsFields = [ defaultField [| Set.empty |] $
+tagsFields = [ defaultField [| emptyTagSet |] $
                simpleField "tags" [t| TagSet |] ]
 
 -- ** Fields related to POSIX data types

--- a/src/Ganeti/THH/Field.hs
+++ b/src/Ganeti/THH/Field.hs
@@ -43,7 +43,7 @@ module Ganeti.THH.Field
   , timeStampFields
   , uuidFields
   , serialFields
-  , TagSet
+  , TagSet(..)
   , emptyTagSet
   , tagsFields
   , fileModeAsIntField
@@ -122,12 +122,17 @@ serialFields =
 uuidFields :: [Field]
 uuidFields = [ presentInForthcoming $ simpleField "uuid" [t| BS.ByteString |] ]
 
--- | Tag set type alias.
-type TagSet = Set.Set String
+-- | Tag set type.
+newtype TagSet = TagSet { unTagSet :: Set.Set String }
+  deriving (Eq, Show)
+
+instance JSON.JSON TagSet where
+  showJSON = JSON.showJSON . unTagSet
+  readJSON = (TagSet <$>) . JSON.readJSON
 
 -- | Empty tag set value.
 emptyTagSet :: TagSet
-emptyTagSet = Set.empty
+emptyTagSet = TagSet Set.empty
 
 -- | Tag field description.
 tagsFields :: [Field]

--- a/src/Ganeti/Types.hs
+++ b/src/Ganeti/Types.hs
@@ -195,12 +195,12 @@ import Control.Monad (liftM)
 import qualified Text.JSON as JSON
 import Text.JSON (JSON, readJSON, showJSON)
 import Data.Ratio (numerator, denominator)
-import qualified Data.Set as Set
 import System.Time (ClockTime)
 
 import qualified Ganeti.ConstantUtils as ConstantUtils
 import Ganeti.JSON (Container, HasStringRepr(..))
 import qualified Ganeti.THH as THH
+import Ganeti.THH.Field (TagSet)
 import Ganeti.Utils
 
 -- * Generic types
@@ -1069,5 +1069,4 @@ class SerialNoObject a where
 
 -- | Class of objects that have tags.
 class TagsObject a where
-  tagsOf :: a -> Set.Set String
-
+  tagsOf :: a -> TagSet

--- a/src/Ganeti/WConfd/Ssconf.hs
+++ b/src/Ganeti/WConfd/Ssconf.hs
@@ -88,7 +88,7 @@ mkSSConfHvparams cluster = map (id &&& hvparams) [minBound..maxBound]
 mkSSConf :: ConfigData -> SSConf
 mkSSConf cdata = SSConf . M.fromList $
     [ (SSClusterName, return $ clusterClusterName cluster)
-    , (SSClusterTags, toList $ tagsOf cluster)
+    , (SSClusterTags, toList . unTagSet $ tagsOf cluster)
     , (SSFileStorageDir, return $ clusterFileStorageDir cluster)
     , (SSSharedFileStorageDir, return $ clusterSharedFileStorageDir cluster)
     , (SSGlusterStorageDir, return $ clusterGlusterStorageDir cluster)

--- a/test/hs/Test/Ganeti/Objects.hs
+++ b/test/hs/Test/Ganeti/Objects.hs
@@ -405,7 +405,7 @@ genValidNetwork = do
   ctime <- arbitrary
   mtime <- arbitrary
   let n = Network name mac_prefix (mkIp4Network net netmask) net6 gateway
-          gateway6 res ext_res uuid ctime mtime 0 Set.empty
+          gateway6 res ext_res uuid ctime mtime 0 emptyTagSet
   return n
 
 -- | Generate an arbitrary string consisting of '0' and '1' of the given length.

--- a/test/hs/Test/Ganeti/Objects.hs
+++ b/test/hs/Test/Ganeti/Objects.hs
@@ -102,7 +102,7 @@ instance Arbitrary Node where
               <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
               <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
               <*> fmap UTF8.fromString genUUID <*> arbitrary
-              <*> (Set.fromList <$> genTags)
+              <*> arbitrary
 
 $(genArbitrary ''BlockDriver)
 
@@ -193,7 +193,7 @@ instance Arbitrary ForthcomingInstanceData where
       -- serial
       <*> arbitrary
       -- tags
-      <*> (Set.fromList <$> genTags)
+      <*> arbitrary
 
 instance Arbitrary RealInstanceData where
   arbitrary =
@@ -234,7 +234,7 @@ instance Arbitrary RealInstanceData where
       -- serial
       <*> arbitrary
       -- tags
-      <*> (Set.fromList <$> genTags)
+      <*> arbitrary
 
 instance Arbitrary Instance where
   arbitrary = frequency [ (1, ForthcomingInstance <$> arbitrary)
@@ -648,7 +648,7 @@ genNodeGroup = do
   mtime <- arbitrary
   uuid <- genFQDN `suchThat` (/= name)
   serial <- arbitrary
-  tags <- Set.fromList <$> genTags
+  tags <- arbitrary
   let group = NodeGroup name members ndparams alloc_policy ipolicy diskparams
               net_map hv_state disk_state ctime mtime (UTF8.fromString uuid)
               serial tags

--- a/test/hs/Test/Ganeti/Query/Instance.hs
+++ b/test/hs/Test/Ganeti/Query/Instance.hs
@@ -40,7 +40,6 @@ module Test.Ganeti.Query.Instance
 
 import qualified Data.ByteString.UTF8 as UTF8
 import qualified Data.Map as Map
-import qualified Data.Set as Set
 import System.Time (ClockTime(..))
 
 import Ganeti.JSON
@@ -64,7 +63,7 @@ createInstance name pnodeUuid adminState adminStateSource =
     (PartialBeParams Nothing Nothing Nothing Nothing Nothing Nothing)
     (GenericContainer Map.empty) (GenericContainer Map.empty)
     adminState adminStateSource [] [] False Nothing epochTime epochTime
-    (UTF8.fromString "") 0 Set.empty
+    (UTF8.fromString "") 0 emptyTagSet
   where epochTime = TOD 0 0
 
 -- | A fake InstanceInfo to be used to check values.

--- a/test/hs/Test/Ganeti/TestCommon.hs
+++ b/test/hs/Test/Ganeti/TestCommon.hs
@@ -118,19 +118,19 @@ import Numeric
 
 import qualified Ganeti.BasicTypes as BasicTypes
 import Ganeti.JSON (ArrayObject(..))
-import Ganeti.Objects (TagSet)
+import Ganeti.Objects (TagSet(..))
 import Ganeti.Types
 import Ganeti.Utils.Monad (unfoldrM)
 
 -- * Arbitrary orphan instances
 
+instance Arbitrary TagSet where
+  arbitrary = (TagSet . Set.fromList) <$> genTags
+
 #if !MIN_VERSION_QuickCheck(2,8,0)
 instance (Ord k, Arbitrary k, Arbitrary a) => Arbitrary (M.Map k a) where
   arbitrary = M.fromList <$> arbitrary
   shrink m = M.fromList <$> shrink (M.toList m)
-
-instance Arbitrary TagSet where
-  arbitrary = Set.fromList <$> genTags
 #endif
 
 -- * Constants


### PR DESCRIPTION
I'm sending this to stable-2.16 since it's a regression in tests, and would be good to get back good coverage in preparation for 2.16.1 (and actually non-failing tests). The changes are really trivial and non-invasive, so I think this has low risk of breaking things.

The only (Haskell) test failing is jobFiltering, in getting proper coverage, which was failing before as well.