### PR TITLE
htests binary: GC: use large allocation area size

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -864,9 +864,9 @@ HEXTRA_COMBINED = $(HEXTRA) $(HEXTRA_CONFIGURE)
 # errors in the JQueue tests with the threaded runtime.
 # See https://ghc.haskell.org/trac/ghc/ticket/7646
 if GHC_LE_76
-HEXTRA_TEST =
+HEXTRA_TEST = -with-rtsopts="-A32m" -rtsopts
 else
-HEXTRA_TEST = -threaded -with-rtsopts=-N
+HEXTRA_TEST = -threaded -with-rtsopts="-N -A32m" -rtsopts
 endif
 
 # exclude options for coverage reports


### PR DESCRIPTION
For programs that generate/cycle through large amounts of data, a
large default allocation area size shows improvements that make the
program scale better with the core count. 16m does not show any
meaningful difference (workload size?), but 32m does.

Speed-ups (core count) in wall clock time, with -a50:

- 1: N/A, noise
- 2: ~5.6%
- 4: ~10%
- 8: ~15%

Speed-ups in actual used CPU time are similar.

On a different platform with 24 cores, the speedup is even more
extreme: 2× faster on wall-clock, ~3.8× faster in terms of CPU
time. All this is due to reducing the GC count, from ~7500 gen0 + 45
gen1, to 30 + 10 (!!), and the known issue on how parallel GC scales
badly with many cores.

The memory usage is slightly increased, on my machine is see maximum
RSS increasing from ~850MiB to ~1GiB (< 20%), which I think is a fair
trade-off for less waiting.

Signed-off-by: Iustin Pop <iustin@k1024.org>