### PR TITLE
Relax python-psutil version check

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -47,10 +47,7 @@ try:
   import psutil   # pylint: disable=F0401
   if psutil.version_info < (2, 0, 0):
     # The psutil version seems too old, we ignore it
-    psutil_err = "too old (2.x.x needed, %s found)" % psutil.__version__
-    psutil = None
-  elif psutil.version_info >= (3,):
-    psutil_err = "too new (2.x.x needed, %s found)" % psutil.__version__
+    psutil_err = "too old (2.x.x or newer needed, %s found)" % psutil.__version__
     psutil = None
   else:
     psutil_err = "<no error>"


### PR DESCRIPTION
CPU pinning on KVM would fail with psutil versions greater than 2.x.x due to there being a check in ganeti explicitly rejecting any version of psutil other than 2.x.x.
Pinning functionality has been tested and is working with python-psutil versions 5.0.1 (shipping with debian stretch) and 5.5.1 (debian buster soft freeze), so it should be safe to relax this restriction to allow versions 2 through 5 inclusive.

However, further discussion in the pull request resulted in dropping entirely the upper bound, as @apoikos mentioned that "psutil does not follow semantic versioning rules".