### PR TITLE
utils.process: use soft NOFILE limit in CloseFDs

### DIFF
--- a/lib/utils/process.py
+++ b/lib/utils/process.py
@@ -1093,12 +1093,8 @@ def CloseFDs(noclose_fds=None):
   else:
     MAXFD = 1024
 
-  maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
-  if maxfd == resource.RLIM_INFINITY:
-    maxfd = MAXFD
-
   # Iterate through and close all file descriptors (except the standard ones)
-  for fd in range(3, maxfd):
+  for fd in range(3, MAXFD):
     if noclose_fds and fd in noclose_fds:
       continue
     utils_wrapper.CloseFdNoError(fd)


### PR DESCRIPTION
CloseFDs is used by utils.RunCmd and friends to make sure we don't leak
any file descriptors to child processes. The way CloseFDs operates, is
by attempting to close all FDs up to the RLIMIT_NOFILE *hard* limit,
or up to SC_OPEN_MAX if the former is set to infinity.

SC_OPEN_MAX is internally set by glibc to the *soft* RLIMIT_NOFILE
limit, usually around 1024. The *hard* RLIMIT_NOFILE limit has
traditionally been set around 65k - still manageable to iterate over.
However, recent kernel and systemd versions bumped tha hard limit to 1M,
which takes a considerable amount of time to handle:

  timeit.timeit("RunCmd('/bin/true', noclose_fds=[1])",
                setup="from ganeti.utils import RunCmd",
                number=10)
  18.81471085548401

Note that CloseFDs is only used when the noclose_fds is set, otherwise
we rely on subprocess.Popen()'s built-in logic which merely closes FDs 3
through SC_OPEN_MAX.

Now, should we care about the *hard* limit at all? The answer is
probably no. From getrlimit(2):

  Each resource has an associated soft and  hard  limit,  as defined by
  the rlimit structure:

      struct rlimit {
          rlim_t rlim_cur;  /* Soft limit */
          rlim_t rlim_max;  /* Hard limit (ceiling for rlim_cur) */
      };

  The  soft limit is the value that the kernel enforces for the
  corresponding resource. The hard limit acts as a ceiling for the soft
  limit: an unprivileged process may set only its soft limit to a value
  in the range from 0 up to the hard limit, and (irreversibly) lower its
  hard limit. A privileged process (under Linux: one with the
  CAP_SYS_RESOURCE capability in the initial user namespace) may
  make arbitrary changes to either limit value.

So what we should care about is the *soft* limit instead, which we
already do through SC_OPEN_MAX. Removing the getrlimit logic completely
yields a massive speedup:

  timeit.timeit("RunCmd('/bin/true', noclose_fds=[1])",
                setup="from ganeti.utils import RunCmd",
                number=10)
  0.0466561317444

This reduces the runtime of the ganeti.utils.process tests
significantly.