### PR TITLE
Fix distcheck-release and dist-release for 2.16.1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -303,7 +303,9 @@ maintainer-clean-local:
 CLEANFILES = \
 	$(addsuffix /*.py[co],$(DIRS)) \
 	$(addsuffix /*.hi,$(HS_DIRS)) \
+	$(addsuffix /*.dyn_hi,$(HS_DIRS)) \
 	$(addsuffix /*.o,$(HS_DIRS)) \
+	$(addsuffix /*.dyn_o,$(HS_DIRS)) \
 	$(addsuffix /*.$(HTEST_SUFFIX)_hi,$(HS_DIRS)) \
 	$(addsuffix /*.$(HTEST_SUFFIX)_o,$(HS_DIRS)) \
 	$(HASKELL_PACKAGE_VERSIONS_FILE) \

--- a/Makefile.am
+++ b/Makefile.am
@@ -270,6 +270,7 @@ BUILDTIME_DIRS = \
 	$(BUILDTIME_DIR_AUTOCREATE) \
 	apps \
 	dist \
+	dist/build \
 	doc/html \
 	doc/man-html
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -2812,7 +2812,7 @@ distcheck-hook:
 # unnecessary warnings for packagers. Directories used by automake during
 # distcheck must be excluded.
 	if find $(top_distdir) -empty -and -not \( \
-	    -path $(top_distdir)/_build -or \
+	    -regex '$(top_distdir)/_build\(/.*\)?' -or \
 	    -path $(top_distdir)/_inst \) | grep .; then \
 	  echo "Found empty files or directories in final archive." 1>&2; \
 	  exit 1; \

--- a/NEWS
+++ b/NEWS
@@ -70,6 +70,8 @@ Compatibility fixes:
  - Handle the new output format of ``rbd showmapped`` introduced in Ceph
    Mimic (#1339) (Ansgar Jazdzewski)
  - Support current versions of python-psutil (George Diamantopoulos)
+ - Fix distcheck-hook with automake versions >= 1.15 (Apollon
+   Oikonomopoulos)
 
 Bugfixes:
  - Allow IPv6 addresses in the ``vnc_bind_address`` KVM hypervisor

--- a/NEWS
+++ b/NEWS
@@ -72,6 +72,8 @@ Compatibility fixes:
  - Support current versions of python-psutil (George Diamantopoulos)
  - Fix distcheck-hook with automake versions >= 1.15 (Apollon
    Oikonomopoulos)
+ - Fix cli tests with shelltestrunner versions >= 1.9 (Apollon
+   Oikonomopoulos)
 
 Bugfixes:
  - Allow IPv6 addresses in the ``vnc_bind_address`` KVM hypervisor

--- a/configure.ac
+++ b/configure.ac
@@ -531,8 +531,8 @@ else
 
   # Note: Character classes ([...]) need to be double quoted due to autoconf
   # using m4
-  elif ! echo "$sphinxver" | grep -q -E \
-       '^(Sphinx|sphinx-build[[1-9]]?)([[[:space:]]]+|\(sphinx-build[[1-9]]?\)|v)*[[1-9]]\>'; then
+  elif ! echo "$sphinxver" | grep -q -i -E \
+     '^sphinx(-build\d?)?([[[:space:]]]+|\(sphinx-build\d?\)|v)*[[1-9]]\>'; then
     AC_MSG_ERROR([Sphinx 1.0 or higher is required])
   fi
 fi

--- a/devel/release
+++ b/devel/release
@@ -79,17 +79,21 @@ done
 ./configure
 
 VERSION=$(sed -n -e '/^PACKAGE_VERSION =/ s/^PACKAGE_VERSION = // p' Makefile)
+ARCHIVE="ganeti-${VERSION}.tar.gz"
 
 make distcheck-release
 fakeroot make dist-release
-tar tzvf ganeti-$VERSION.tar.gz
+tar tzvf "$ARCHIVE"
 
 echo
 echo 'MD5:'
-md5sum ganeti-$VERSION.tar.gz
+md5sum "$ARCHIVE"
 echo
 echo 'SHA1:'
-sha1sum ganeti-$VERSION.tar.gz
+sha1sum "$ARCHIVE"
 echo
-echo "The archive is at $PWD/ganeti-$VERSION.tar.gz"
+echo 'SHA256:'
+sha256sum "$ARCHIVE"
+echo
+echo "The archive is at ${PWD}/${ARCHIVE}"
 echo "Please copy it and remove the temporary directory when done."

--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -47,7 +47,8 @@ try:
   import psutil   # pylint: disable=F0401
   if psutil.version_info < (2, 0, 0):
     # The psutil version seems too old, we ignore it
-    psutil_err = "too old (2.x.x or newer needed, %s found)" % psutil.__version__
+    psutil_err = \
+        "too old (2.x.x or newer needed, %s found)" % psutil.__version__
     psutil = None
   else:
     psutil_err = "<no error>"

--- a/src/Ganeti/JQScheduler.hs
+++ b/src/Ganeti/JQScheduler.hs
@@ -298,7 +298,8 @@ attachWatcher state jWS = when (isNothing $ jINotify jWS) $ do
      let fpath = liveJobFile qdir . qjId $ jJob jWS
          jWS' = jWS { jINotify=Just inotify }
      logDebug $ "Attaching queue watcher for " ++ fpath
-     _ <- addWatch inotify [Modify, Delete] (toInotifyPath fpath) $ jobWatcher state jWS'
+     _ <- addWatch inotify [Modify, Delete] (toInotifyPath fpath)
+            $ jobWatcher state jWS'
      modifyJobs state . onRunningJobs $ updateJobStatus jWS'
    else logDebug $ "Not attaching watcher for job "
                    ++ (show . fromJobId . qjId $ jJob jWS)

--- a/src/Ganeti/Metad/WebServer.hs
+++ b/src/Ganeti/Metad/WebServer.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE CPP, FlexibleContexts, OverloadedStrings, ConstraintKinds, DeriveDataTypeable #-}
+{-# LANGUAGE CPP, FlexibleContexts, OverloadedStrings #-}
+{-# LANGUAGE ConstraintKinds, DeriveDataTypeable #-}
 {-| Web server for the metadata daemon.
 
 -}

--- a/src/Ganeti/THH.hs
+++ b/src/Ganeti/THH.hs
@@ -1354,7 +1354,8 @@ paramFieldNames field_pfx fd =
 paramFieldTypeInfo :: String -> Field -> VarStrictTypeQ
 paramFieldTypeInfo field_pfx fd = do
   t <- actualFieldType fd
-  return (snd $ paramFieldNames field_pfx fd, myNotStrict, AppT (ConT ''Maybe) t)
+  return (snd $ paramFieldNames field_pfx fd,
+          myNotStrict, AppT (ConT ''Maybe) t)
 
 -- | Build a parameter declaration.
 --

--- a/src/Ganeti/THH/Field.hs
+++ b/src/Ganeti/THH/Field.hs
@@ -50,6 +50,7 @@ module Ganeti.THH.Field
   , processIdField
   ) where
 
+import Control.Applicative ((<$>))
 import Control.Monad
 import qualified Data.ByteString as BS
 import qualified Data.Set as Set

--- a/src/Ganeti/Utils.hs
+++ b/src/Ganeti/Utils.hs
@@ -726,8 +726,8 @@ watchFileBy fpath timeout check read_fn = do
                        logDebug $ "Notified of change in " ++ fpath
                                     ++ "; event: " ++ show e
                        when (e == Ignored)
-                         (addWatch inotify [Modify, Delete] (toInotifyPath fpath) do_watch
-                            >> return ())
+                         (addWatch inotify [Modify, Delete]
+                           (toInotifyPath fpath) do_watch >> return ())
                        fstat' <- getFStatSafe fpath
                        writeIORef ref fstat'
     _ <- addWatch inotify [Modify, Delete] (toInotifyPath fpath) do_watch

--- a/test/hs/Test/Ganeti/JQScheduler.hs
+++ b/test/hs/Test/Ganeti/JQScheduler.hs
@@ -381,7 +381,8 @@ prop_applyingFilter :: Property
 prop_applyingFilter =
   forAllShrink arbitrary shrink $ \job ->
   forAllShrink (arbitrary `suchThat`
-                (isJust . flip applyingFilter job . Set.fromList)) shrink $ \filters ->
+                (isJust . flip applyingFilter job . Set.fromList)) shrink
+                $ \filters ->
 
     let applying = applyingFilter (Set.fromList filters) job
 
@@ -541,8 +542,8 @@ prop_jobFiltering =
                  . filter ((frUuid fr ==) . frUuid)
                  . mapMaybe (applyingFilter filters)
                  $ map jJob jobs)
-          {- TODO(#1318): restore coverage checks after a way to do it nicely has
-                          been found.
+          {- TODO(#1318): restore coverage checks after a way to do it nicely
+                          has been found.
 
           -- Helpers for ensuring sensible coverage.
 

--- a/test/hs/Test/Ganeti/JQueue.hs
+++ b/test/hs/Test/Ganeti/JQueue.hs
@@ -240,7 +240,8 @@ prop_DetermineDirs = monadicIO $ do
     return (tempdir, non_arch, with_arch, invalid_root)
   let arch_dir = tempdir </> jobQueueArchiveSubDir
   _ <- stop $ conjoin [ non_arch ==? [tempdir]
-                      , sort with_arch ==? sort (tempdir:map (arch_dir </>) valid)
+                      , sort with_arch ==?
+                          sort (tempdir:map (arch_dir </>) valid)
                       , invalid_root ==? [tempdir </> "no-such-subdir"]
                       ]
   return ()

--- a/test/hs/Test/Ganeti/Query/Query.hs
+++ b/test/hs/Test/Ganeti/Query/Query.hs
@@ -110,17 +110,17 @@ prop_queryNode_Unknown =
   QueryFieldsResult fdefs' <-
     resultProp $ queryFields (QueryFields (ItemTypeOpCode QRNode) [field])
   _ <- stop $ conjoin
-              [ counterexample ("Got known fields via query (" ++ show fdefs ++ ")")
-                (not $ hasUnknownFields fdefs)
-              , counterexample ("Got /= ResultUnknown result status via query (" ++
-                                show fdata ++ ")")
-                (all (all ((== RSUnknown) . rentryStatus)) fdata)
-              , counterexample ("Got a Just in a result value (" ++
-                                show fdata ++ ")")
-                (all (all (isNothing . rentryValue)) fdata)
-              , counterexample ("Got known fields via query fields (" ++ show fdefs'
-                                ++ ")") (not $ hasUnknownFields fdefs')
-              ]
+          [ counterexample ("Got known fields via query (" ++ show fdefs ++ ")")
+            (not $ hasUnknownFields fdefs)
+          , counterexample ("Got /= ResultUnknown result status via query (" ++
+                            show fdata ++ ")")
+            (all (all ((== RSUnknown) . rentryStatus)) fdata)
+          , counterexample ("Got a Just in a result value (" ++
+                            show fdata ++ ")")
+            (all (all (isNothing . rentryValue)) fdata)
+          , counterexample ("Got known fields via query fields (" ++ show fdefs'
+                            ++ ")") (not $ hasUnknownFields fdefs')
+          ]
   return ()
 
 -- | Checks that a result type is conforming to a field definition.
@@ -157,15 +157,15 @@ prop_queryNode_types =
     run (query cfg False (Query (ItemTypeOpCode QRNode)
                           [field] EmptyFilter)) >>= resultProp
   _ <- stop $ conjoin
-              [ counterexample ("Inconsistent result entries (" ++ show fdata ++ ")")
-                (conjoin $ map (conjoin . zipWith checkResultType fdefs) fdata)
-              , counterexample "Wrong field definitions length"
-                (length fdefs ==? 1)
-              , counterexample "Wrong field result rows length"
-                (all ((== 1) . length) fdata)
-              , counterexample "Wrong number of result rows"
-                (length fdata ==? numnodes)
-              ]
+         [ counterexample ("Inconsistent result entries (" ++ show fdata ++ ")")
+           (conjoin $ map (conjoin . zipWith checkResultType fdefs) fdata)
+         , counterexample "Wrong field definitions length"
+           (length fdefs ==? 1)
+         , counterexample "Wrong field result rows length"
+           (all ((== 1) . length) fdata)
+         , counterexample "Wrong number of result rows"
+           (length fdata ==? numnodes)
+         ]
   return ()
 
 -- | Test that queryFields with empty fields list returns all node fields.
@@ -204,9 +204,9 @@ prop_queryNode_filter =
       run (query cluster False (Query (ItemTypeOpCode QRNode)
                                 ["name"] flt)) >>= resultProp
     _ <- stop $ conjoin
-           [ counterexample "Invalid node names" $
-             map (map rentryValue) fdata ==? map (\f -> [Just (showJSON f)]) fqdns
-           ]
+         [ counterexample "Invalid node names" $
+           map (map rentryValue) fdata ==? map (\f -> [Just (showJSON f)]) fqdns
+         ]
     return ()
 
 -- ** Group queries

--- a/test/py/ganeti-cli.test
+++ b/test/py/ganeti-cli.test
@@ -1,27 +1,27 @@
 # test the various gnt-commands for common options
-$DAEMONS/ganeti-noded --help
+sh -c "$DAEMONS/ganeti-noded --help"
 >>>/Usage:/
 >>>2
 >>>= 0
-$DAEMONS/ganeti-noded --version
+sh -c "$DAEMONS/ganeti-noded --version"
 >>>/^ganeti-/
 >>>2
 >>>= 0
 
-$DAEMONS/ganeti-rapi --help
+sh -c "$DAEMONS/ganeti-rapi --help"
 >>>/Usage:/
 >>>2
 >>>= 0
-$DAEMONS/ganeti-rapi --version
+sh -c "$DAEMONS/ganeti-rapi --version"
 >>>/^ganeti-/
 >>>2
 >>>= 0
 
-$DAEMONS/ganeti-watcher --help
+sh -c "$DAEMONS/ganeti-watcher --help"
 >>>/Usage:/
 >>>2
 >>>= 0
-$DAEMONS/ganeti-watcher --version
+sh -c "$DAEMONS/ganeti-watcher --version"
 >>>/^ganeti-/
 >>>2
 >>>= 0

--- a/test/py/gnt-cli.test
+++ b/test/py/gnt-cli.test
@@ -1,104 +1,104 @@
 # test the various gnt-commands for common options
-$SCRIPTS/gnt-node --help
+sh -c "$SCRIPTS/gnt-node --help"
 >>>/Usage:/
 >>>2
 >>>= 0
-$SCRIPTS/gnt-node UNKNOWN
+sh -c "$SCRIPTS/gnt-node UNKNOWN"
 >>>/Usage:/
 >>>2
 >>>= 1
-$SCRIPTS/gnt-node --version
+sh -c "$SCRIPTS/gnt-node --version"
 >>>/^gnt-/
 >>>2
 >>>= 0
 
-$SCRIPTS/gnt-instance --help
+sh -c "$SCRIPTS/gnt-instance --help"
 >>>/Usage:/
 >>>2
 >>>= 0
-$SCRIPTS/gnt-instance UNKNOWN
+sh -c "$SCRIPTS/gnt-instance UNKNOWN"
 >>>/Usage:/
 >>>2
 >>>= 1
-$SCRIPTS/gnt-instance --version
+sh -c "$SCRIPTS/gnt-instance --version"
 >>>/^gnt-instance/
 >>>2
 >>>= 0
 
-$SCRIPTS/gnt-os --help
+sh -c "$SCRIPTS/gnt-os --help"
 >>>/Usage:/
 >>>2
 >>>= 0
-$SCRIPTS/gnt-os UNKNOWN
+sh -c "$SCRIPTS/gnt-os UNKNOWN"
 >>>/Usage:/
 >>>2
 >>>= 1
-$SCRIPTS/gnt-os --version
+sh -c "$SCRIPTS/gnt-os --version"
 >>>/^gnt-/
 >>>2
 >>>= 0
 
-$SCRIPTS/gnt-group --help
+sh -c "$SCRIPTS/gnt-group --help"
 >>>/Usage:/
 >>>2
 >>>= 0
-$SCRIPTS/gnt-group UNKNOWN
+sh -c "$SCRIPTS/gnt-group UNKNOWN"
 >>>/Usage:/
 >>>2
 >>>= 1
-$SCRIPTS/gnt-group --version
+sh -c "$SCRIPTS/gnt-group --version"
 >>>/^gnt-/
 >>>2
 >>>= 0
 
-$SCRIPTS/gnt-job --help
+sh -c "$SCRIPTS/gnt-job --help"
 >>>/Usage:/
 >>>2
 >>>= 0
-$SCRIPTS/gnt-job UNKNOWN
+sh -c "$SCRIPTS/gnt-job UNKNOWN"
 >>>/Usage:/
 >>>2
 >>>= 1
-$SCRIPTS/gnt-job --version
+sh -c "$SCRIPTS/gnt-job --version"
 >>>/^gnt-/
 >>>2
 >>>= 0
 
-$SCRIPTS/gnt-cluster --help
+sh -c "$SCRIPTS/gnt-cluster --help"
 >>>/Usage:/
 >>>2
 >>>= 0
-$SCRIPTS/gnt-cluster UNKNOWN
+sh -c "$SCRIPTS/gnt-cluster UNKNOWN"
 >>>/Usage:/
 >>>2
 >>>= 1
-$SCRIPTS/gnt-cluster --version
+sh -c "$SCRIPTS/gnt-cluster --version"
 >>>/^gnt-/
 >>>2
 >>>= 0
 
-$SCRIPTS/gnt-backup --help
+sh -c "$SCRIPTS/gnt-backup --help"
 >>>/Usage:/
 >>>2
 >>>= 0
-$SCRIPTS/gnt-backup UNKNOWN
+sh -c "$SCRIPTS/gnt-backup UNKNOWN"
 >>>/Usage:/
 >>>2
 >>>= 1
-$SCRIPTS/gnt-backup --version
+sh -c "$SCRIPTS/gnt-backup --version"
 >>>/^gnt-/
 >>>2
 >>>= 0
 
-$SCRIPTS/gnt-debug --help
+sh -c "$SCRIPTS/gnt-debug --help"
 >>>/Usage:/
 >>>2
 >>>= 0
-$SCRIPTS/gnt-debug UNKNOWN
+sh -c "$SCRIPTS/gnt-debug UNKNOWN"
 >>>/Usage:/
 >>>2
 >>>= 1
-$SCRIPTS/gnt-debug --version
+sh -c "$SCRIPTS/gnt-debug --version"
 >>>/^gnt-/
 >>>2
 >>>= 0


### PR DESCRIPTION
This is a final set of fixes to allow `devel/release` to work. Broadly they fall in two categories:

 - Regressions (mostly overlong lines) introduced by changes since 2.16.0
 - Compatibility with newer build/test tool versions

With these changes, `devel/release` works properly on Debian Buster and we can go on and release 2.16.1 (separate PR will follow).