### PR TITLE
Add support for natively reloading ssh keys under systemd

### DIFF
--- a/daemons/daemon-util.in
+++ b/daemons/daemon-util.in
@@ -440,7 +440,13 @@ rotate_all_logs() {
 
 # Reloads the SSH keys
 reload_ssh_keys() {
-  @RPL_SSH_INITD_SCRIPT@ restart
+  local ssh_initd_script=@RPL_SSH_INITD_SCRIPT@
+
+  if use_systemctl; then
+    systemctl restart ${ssh_initd_script##*/}.service
+  else
+    $ssh_initd_script restart
+  fi
 }
 
 # Read @SYSCONFDIR@/rc.d/init.d/functions if start-stop-daemon not available


### PR DESCRIPTION
If Ganeti is running under systemd, use systemd to reload ssh keys.