### PR TITLE
remove call to brctl and advance to iproute2

### DIFF
--- a/tools/net-common.in
+++ b/tools/net-common.in
@@ -70,7 +70,7 @@ function setup_bridge {
     ip link set $INTERFACE mtu $(</sys/class/net/${LINK}/mtu)
 
     # Connect the interface to the bridge
-    brctl addif $LINK $INTERFACE
+    ip link set $INTERFACE master $LINK
   fi
 }
 


### PR DESCRIPTION
This is the only place, where brctl is called. To get rid of the dependency
of bridge-utils substitute it by a proper iproute2 call.