### PR TITLE
add missing file colors.py to qa_scripts list

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1332,7 +1332,8 @@ qa_scripts = \
 	qa/qa_performance.py \
 	qa/qa_rapi.py \
 	qa/qa_tags.py \
-	qa/qa_utils.py
+	qa/qa_utils.py \
+	qa/colors.py
 
 bin_SCRIPTS = $(HS_BIN_PROGS)
 install-exec-hook:


### PR DESCRIPTION
The `qa/` folder contains a set of Python scripts to carry out QA tests. For Debian these scripts are also packaged as `ganeti-testsuite`. The Makefile has a list of all files to consider stored in the variable `qa_scripts` - but it is missing the file `colors.py`. Since the Debian packaging relies on this variable to fetch all required files the package currently available in Debian Buster does not work (due to the missing `colors.py` file).

This simple patch fixes that.