### PR TITLE
Build using GHC 8.6/network 2.8

### DIFF
--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -70,7 +70,7 @@ library
     , lens                          >= 3.10       && < 5.0
     , lifted-base                   >= 0.2.0.3    && < 0.3
     , monad-control                 >= 0.3.1.3    && < 1.1
-    , network                       >= 2.3.0.13   && < 2.7
+    , network                       >= 2.3.0.13   && < 2.9
     , parallel                      >= 3.2.0.2    && < 3.3
     , regex-pcre                    >= 0.94.2     && < 0.95
     , temporary                     >= 1.1.2.3    && < 1.4

--- a/src/Ganeti/BasicTypes.hs
+++ b/src/Ganeti/BasicTypes.hs
@@ -91,6 +91,7 @@ import Data.Set (Set)
 import qualified Data.Set as Set (empty)
 import Text.JSON (JSON)
 import qualified Text.JSON as JSON (readJSON, showJSON)
+import qualified Control.Monad.Fail as Fail
 
 -- Remove after we require >= 1.8.58
 -- See: https://github.com/ndmitchell/hlint/issues/24
@@ -145,6 +146,9 @@ instance Applicative (GenericResult a) where
   (Bad f) <*> _       = Bad f
   _       <*> (Bad x) = Bad x
   (Ok f)  <*> (Ok x)  = Ok $ f x
+
+instance (Error a) => Fail.MonadFail (GenericResult a) where
+  fail = Bad . strMsg
 
 -- | This is a monad transformation for Result. It's implementation is
 -- based on the implementations of MaybeT and ErrorT.

--- a/src/Ganeti/Compat.hs
+++ b/src/Ganeti/Compat.hs
@@ -47,6 +47,8 @@ import qualified Data.ByteString.UTF8 as UTF8
 import System.FilePath (FilePath)
 import System.Posix.ByteString.FilePath (RawFilePath)
 import qualified System.INotify
+import qualified Text.JSON
+import qualified Control.Monad.Fail as Fail
 
 -- | Wrappers converting ByteString filepaths to Strings and vice versa
 --
@@ -71,3 +73,9 @@ maybeFilePath' = System.INotify.maybeFilePath
 toInotifyPath :: FilePath -> FilePath
 toInotifyPath = id
 #endif
+
+-- | MonadFail.Fail instance definitions for JSON results
+-- Required as of GHC 8.6 because of
+-- https://gitlab.haskell.org/ghc/ghc/wikis/migration/8.6#monadfaildesugaring-by-default
+instance Fail.MonadFail Text.JSON.Result where
+  fail = Fail.fail

--- a/src/Ganeti/Errors.hs
+++ b/src/Ganeti/Errors.hs
@@ -55,6 +55,7 @@ import System.Exit
 
 import Ganeti.THH
 import Ganeti.BasicTypes
+import Ganeti.Compat()
 import qualified Ganeti.Constants as C
 
 -- | Error code types for 'OpPrereqError'.


### PR DESCRIPTION
Add MonadFail instances for a couple of types to allow building against GHC 8.6, see [here](https://gitlab.haskell.org/ghc/ghc/wikis/migration/8.6#monadfaildesugaring-by-default) and [here](https://prime.haskell.org/wiki/Libraries/Proposals/MonadFail#Adaptingoldcode).

Also relax the dependency on network, since Ganeti builds fine with network 2.8.