### PR TITLE
RPC: prevent cURL from sending Expect: 100-Continue

### DIFF
--- a/src/Ganeti/Rpc.hs
+++ b/src/Ganeti/Rpc.hs
@@ -150,6 +150,7 @@ curlOpts = [ CurlFollowLocation False
            , CurlSSLCertType "PEM"
            , CurlSSLKeyType "PEM"
            , CurlConnectTimeout (fromIntegral C.rpcConnectTimeout)
+           , CurlHttpHeaders ["Expect:"]
            ]
 
 -- | Data type for RPC error reporting.


### PR DESCRIPTION
Curl sends POST/PUT requests using the Expect mechanism, to avoid doing
unnecessary work in case the server rejects the request. While doing so,
curl waits 1 second for a '100 Continue' or other response and then
sends the request body anyway in order to cope with broken/incomplete
HTTP server implementations.

Our HTTP server implementation unfortunately does not handle the Expect
dance, so by default all curl POST/PUT requests will incur a 1-second
overhead. Note that this had been previously fixed for the Python RPC
client in 8e29563f ("RPC: disable curl's Expect header"), but was never
done for the Haskell RPC client. This commit fixes the issue for the
Haskell RPC client, eliminating the 1-second delay found in many query
calls that pass through LuxiD (e.g. gnt-instance list).

Eventually we should probably switch to a more feature-complete HTTP
server implementation, but for now this will have to do.