### PR TITLE
QuickCheck 2.12 compatibility

### DIFF
--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -85,7 +85,7 @@ library
   if flag(htest)
     build-depends:
         HUnit                         >= 1.2.4.2    && < 1.7
-      , QuickCheck                    >= 2.8        && < 2.12
+      , QuickCheck                    >= 2.8        && < 2.13
       , test-framework                >= 0.6        && < 0.9
       , test-framework-hunit          >= 0.2.7      && < 0.4
       , test-framework-quickcheck2    >= 0.2.12.1   && < 0.4

--- a/test/hs/Test/Ganeti/JQScheduler.hs
+++ b/test/hs/Test/Ganeti/JQScheduler.hs
@@ -224,16 +224,16 @@ prop_reasonRateLimit =
         newSlotsNoLimits = slotMapFromJobWithStat (qRunning q ++ enqueued)
 
     in -- Ensure it's unlikely that jobs are all in different buckets.
-       cover
-         (any ((> 1) . slotOccupied) . Map.elems $ newSlotsNoLimits)
+       cover'
          50
+         (any ((> 1) . slotOccupied) . Map.elems $ newSlotsNoLimits)
          "some jobs have the same rate-limit bucket"
 
        -- Ensure it's likely that rate limiting has any effect.
-       . cover
+       . cover'
+           50
            (overfullKeys newSlotsNoLimits
               `difference` overfullKeys oldSlots /= Set.empty)
-           50
            "queued jobs cannot be started because of rate limiting"
 
        $ conjoin


### PR DESCRIPTION
QuickCheck 2.12 has some breaking changes, in particular it swapped the
order of the two first arguments of `cover' and changed the percentage
from Int to Double.

For the first change, adapt the code to the new order and provide a
compatibility function for older QuickCheck versions. When time comes to
drop support for pre-2.12 QuickCheck versions, we can simply drop the
compatibility function and unhide the original.

For the latter change, just add a fromIntegral conversion which
shouldn't harm anyway.