### PR TITLE
Specify the entire sshd-restart-command at build-time

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2492,7 +2492,7 @@ $(REPLACE_VARS_SED): $(SHELL_ENV_INIT) Makefile stamp-directories
 	  echo 's#@''CUSTOM_XEN_INITRD@#$(XEN_INITRD)#g'; \
 	  echo 's#@''CUSTOM_IALLOCATOR_SEARCH_PATH@#$(IALLOCATOR_SEARCH_PATH)#g'; \
 	  echo 's#@''CUSTOM_EXPORT_DIR@#$(EXPORT_DIR)#g'; \
-	  echo 's#@''RPL_SSH_INITD_SCRIPT@#$(SSH_INITD_SCRIPT)#g'; \
+	  echo 's#@''RPL_SSHD_RESTART_COMMAND@#$(SSHD_RESTART_COMMAND)#g'; \
 	  echo 's#@''PKGLIBDIR@#$(libdir)/ganeti#g'; \
 	  echo 's#@''GNTMASTERUSER@#$(MASTERD_USER)#g'; \
 	  echo 's#@''GNTRAPIUSER@#$(RAPI_USER)#g'; \

--- a/configure.ac
+++ b/configure.ac
@@ -136,14 +136,14 @@ AC_ARG_WITH([haskell-flags],
   [hextra_configure=""])
 AC_SUBST(HEXTRA_CONFIGURE, $hextra_configure)
 
-# --with-ssh-initscript=...
-AC_ARG_WITH([ssh-initscript],
-  [AS_HELP_STRING([--with-ssh-initscript=SCRIPT],
-    [SSH init script to use (default is /etc/init.d/ssh)]
+# --with-sshd-restart-command=...
+AC_ARG_WITH([sshd-restart-command],
+  [AS_HELP_STRING([--with-sshd-restart-command=SCRIPT],
+    [SSH restart command to use (default is /usr/sbin/service ssh restart)]
   )],
-  [ssh_initd_script="$withval"],
-  [ssh_initd_script="/etc/init.d/ssh"])
-AC_SUBST(SSH_INITD_SCRIPT, $ssh_initd_script)
+  [sshd_restart_command="$withval"],
+  [sshd_restart_command="/usr/sbin/service ssh restart"])
+AC_SUBST(SSHD_RESTART_COMMAND, $sshd_restart_command)
 
 # --with-export-dir=...
 AC_ARG_WITH([export-dir],

--- a/daemons/daemon-util.in
+++ b/daemons/daemon-util.in
@@ -441,7 +441,7 @@ rotate_all_logs() {
 
 # Reloads the SSH keys
 reload_ssh_keys() {
-  local ssh_initd_script=@RPL_SSH_INITD_SCRIPT@
+  local ssh_initd_script="@RPL_SSH_INITD_SCRIPT@"
 
   if use_systemctl; then
     systemctl restart ${ssh_initd_script##*/}.service

--- a/daemons/daemon-util.in
+++ b/daemons/daemon-util.in
@@ -441,13 +441,7 @@ rotate_all_logs() {
 
 # Reloads the SSH keys
 reload_ssh_keys() {
-  local ssh_initd_script="@RPL_SSH_INITD_SCRIPT@"
-
-  if use_systemctl; then
-    systemctl restart ${ssh_initd_script##*/}.service
-  else
-    $ssh_initd_script restart
-  fi
+  @RPL_SSHD_RESTART_COMMAND@
 }
 
 # Read @SYSCONFDIR@/rc.d/init.d/functions if start-stop-daemon not available


### PR DESCRIPTION
An older commit moved the RPL_SSH_INITD_SCRIPT command from direct execution into a variable named sshd_init_script (4d482b06778da6ae6af734cb6583be041a7f669f). If the command contains spaces (e.g. for parameters), the variable will only hold everything up to the first space.

I have added quotes to fix this behaviour.