### PR TITLE
Rework job process creation to not rely on forkProcess

### DIFF
--- a/lib/utils/livelock.py
+++ b/lib/utils/livelock.py
@@ -43,23 +43,6 @@ from ganeti.utils.algo import NiceSort
 from ganeti import pathutils
 
 
-class LiveLockName(object):
-  def __init__(self, name):
-    self._name = name
-
-  def GetPath(self):
-    return self._name
-
-  def close(self):
-    """Clean up the lockfile.
-
-    """
-    os.remove(self._name)
-
-  def __str__(self):
-    return "LiveLockName(" + self.GetPath() + ")"
-
-
 class LiveLock(object):
   """Utility for a lockfile needed to request resources from WconfD.
 

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -4391,19 +4391,6 @@ luxidMaximalRunningJobsDefault = 20
 luxidMaximalTrackedJobsDefault :: Int
 luxidMaximalTrackedJobsDefault = 25
 
--- | The number of retries when trying to @fork@ a new job.
--- Due to a bug in GHC, this can fail even though we synchronize all forks
--- and restrain from other @IO@ operations in the thread.
-luxidRetryForkCount :: Int
-luxidRetryForkCount = 5
-
--- | The average time period (in /us/) to wait between two @fork@ attempts.
--- The forking thread wait a random time period between @0@ and twice the
--- number, and with each attempt it doubles the step.
--- See 'luxidRetryForkCount'.
-luxidRetryForkStepUS :: Int
-luxidRetryForkStepUS = 500000
-
 -- * Luxid job death testing
 
 -- | The number of attempts to prove that a job is dead after sending it a

--- a/src/Ganeti/Query/Exec.hs
+++ b/src/Ganeti/Query/Exec.hs
@@ -48,11 +48,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -}
 
 module Ganeti.Query.Exec
-  ( isForkSupported
-  , forkJobProcess
+  ( forkJobProcess
   ) where
 
-import Control.Concurrent (rtsSupportsBoundThreads)
 import Control.Concurrent.Lifted (threadDelay)
 import Control.Monad
 import Control.Monad.Error
@@ -77,9 +75,6 @@ import Ganeti.OpCodes
 import qualified Ganeti.Path as P
 import Ganeti.Types
 import Ganeti.UDSServer
-
-isForkSupported :: IO Bool
-isForkSupported = return $ not rtsSupportsBoundThreads
 
 connectConfig :: ConnectConfig
 connectConfig = ConnectConfig { recvTmo    = 30

--- a/src/Ganeti/Query/Server.hs
+++ b/src/Ganeti/Query/Server.hs
@@ -663,9 +663,6 @@ checkMain = handleMasterVerificationOptions
 -- | Prepare function for luxid.
 prepMain :: PrepFn () PrepResult
 prepMain _ _ = do
-  Exec.isForkSupported
-    >>= flip exitUnless "The daemon must be compiled without -threaded"
-
   socket_path <- Path.defaultQuerySocket
   cleanupSocket socket_path
   s <- describeError "binding to the Luxi socket"

--- a/src/Ganeti/UDSServer.hs
+++ b/src/Ganeti/UDSServer.hs
@@ -56,6 +56,7 @@ module Ganeti.UDSServer
   , acceptClient
   , closeClient
   , clientToFd
+  , clientToHandle
   , closeServer
   , buildResponse
   , parseResponse
@@ -282,6 +283,12 @@ clientToFd client | rh == wh  = join (,) <$> handleToFd rh
   where
     rh = rsocket client
     wh = wsocket client
+
+-- | Extracts the read (first) and the write (second) handles of a client.
+-- The purpose of this function is to allow using a client's handles as
+-- input/output streams elsewhere.
+clientToHandle :: Client -> (Handle, Handle)
+clientToHandle client = (rsocket client, wsocket client)
 
 -- | Sends a message over a transport.
 sendMsg :: Client -> String -> IO ()


### PR DESCRIPTION
This PR refactors the whole job process creation code to not rely on `forkProcess`, using the API provided by `System.Process` instead. This aims at increasing the reliability of job process creation, which currently is very fragile and prone to false-starts (and probably double writes, see #1323).

Note that the move over to `System.Process.createProcess` means that we can't do any setup in the child process before invoking the Python interpreter, however there is nothing that can't be done in the Python code itself. Handling this requires some changes in the master <-> child communication protocol, as livelock creation will now be done in Python itself. Note that this shifts livelock creation after exec() (it used to be after fork() but before exec()), but this should not make any difference in terms of reliability.

This PR fixes #1410, and most likely #1323 as well.