### PR TITLE
LuxiD: wait for a job's process to exit before archiving it

### DIFF
--- a/lib/watcher/__init__.py
+++ b/lib/watcher/__init__.py
@@ -357,7 +357,10 @@ def _VerifyDisks(cl, uuid, nodes, instances):
   job_id = cl.SubmitJob([op])
   ((_, offline_disk_instances, _), ) = \
     cli.PollJob(job_id, cl=cl, feedback_fn=logging.debug)
-  cl.ArchiveJob(job_id)
+  try:
+    cl.ArchiveJob(job_id)
+  except Exception as err:
+    logging.exception("Error while archiving job %d" % job_id)
 
   if not offline_disk_instances:
     # nothing to do


### PR DESCRIPTION
There's a race condition in ArchiveJob that may result in stale jobfiles remaining on master candidates. The race is due to the fact that ArchiveJob checks whether a job has finished relying solely on the job status, while the actual job process might be still alive and replicating the finalized job file to the master candidates - which is the last thing it does before exiting.

LuxiD is usually faster than Python and so the archival event will be replicated to some master candidates before the original jobfile reaches them through the Python replication loop. As a result, master candidates end up with an earlier version of the job file in the archive and the finalized job file in their regular queue.

Note that master candidates do not perform their own archival and only rely on archival events replicated from the master. Because the affected jobs have already been archived on the master, there will be no future attempts to archive them again and they will remain on each affected master candidate until the mc gets promoted to master.

This bug affects solely the OP_GROUP_VERIFY_DISKS jobs submitted by the watcher, which the watcher archives after finishing. The problem is especially prominent on large clusters, where job replication may take a non-trivial amount of time, making the race more probable. The result is the accumulation of hundreds of jobs per day, which LuxiD will eventually try to load when promoted to master, making its startup time and resource usage skyrocket to the point where the master failover operation may fail.

Close this race by making sure the job's process is indeed dead before performing any archival operation. We wait up to 30 seconds for the job to exit after having finalized its job status, otherwise abort the whole operation and let the job be bulk-archived by the watcher in the future. This timeout seems a bit high, but it's there to allow for the delays caused by some master candidates being offline.

While at it, we move the status check before the process check, to avoid waiting for processes of jobs not in a finalized stage. Moving the check outside the queue lock is in order, since we are not manipulating the queue at this point.

This fixes #1266.
