### PR TITLE
Remove leftover calls to "python" interpreter, enable pylint3/python3-coverage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2777,7 +2777,7 @@ hlint: $(HS_BUILT_SRCS) src/lint-hints.hs
 	@test -n "$(HLINT)" || { echo 'hlint' not found during configure; exit 1; }
 	@rm -f doc/hs-lint.html
 	if tty -s; then C="-c"; else C=""; fi; \
-	$(HLINT) --utf8 --report=doc/hs-lint.html --cross $$C \
+	$(HLINT) --report=doc/hs-lint.html --cross $$C \
 	  --hint src/lint-hints \
 	  --cpp-file=$(HASKELL_PACKAGE_VERSIONS_FILE) \
 	  $(filter-out $(HLINT_EXCLUDES),$(HS_LIBTEST_SRCS) $(HS_PROG_SRCS))

--- a/Makefile.am
+++ b/Makefile.am
@@ -3030,7 +3030,7 @@ apps/%.hs.stamp: Makefile
 # Builds the cabal file
 ganeti.cabal: cabal/ganeti.template.cabal Makefile cabal/cabal-from-modules.py $(CABAL_EXECUTABLES_APPS_STAMPS)
 	@echo $(subst /,.,$(patsubst %.hs,%,$(patsubst test/hs/%,%,$(patsubst src/%,%,$(HS_SRCS))))) \
-	  | python $(abs_top_srcdir)/cabal/cabal-from-modules.py $(abs_top_srcdir)/cabal/ganeti.template.cabal > $@
+	  | python3 $(abs_top_srcdir)/cabal/cabal-from-modules.py $(abs_top_srcdir)/cabal/ganeti.template.cabal > $@
 
 	for p in $(CABAL_EXECUTABLES); do \
 	  echo                                   >> $@; \

--- a/autotools/ac_python_module.m4
+++ b/autotools/ac_python_module.m4
@@ -26,7 +26,7 @@
 AC_DEFUN([AC_PYTHON_MODULE],[
     if test -z $PYTHON;
     then
-        PYTHON="python"
+        PYTHON="python3"
     fi
     PYTHON_NAME=`basename $PYTHON`
     AC_MSG_CHECKING($PYTHON_NAME module: $1)

--- a/configure.ac
+++ b/configure.ac
@@ -571,9 +571,9 @@ then
                             documentation rebuild not possible]))
 fi
 
-# Check for pylint
-AC_ARG_VAR(PYLINT, [pylint path])
-AC_PATH_PROG(PYLINT, [pylint], [])
+# Check for pylint3
+AC_ARG_VAR(PYLINT, [pylint3 path])
+AC_PATH_PROG(PYLINT, [pylint3], [])
 if test -z "$PYLINT"
 then
   AC_MSG_WARN([pylint not found, checking code will not be possible])
@@ -588,9 +588,9 @@ then
 fi
 AM_CONDITIONAL([HAS_PEP8], [test -n "$PEP8"])
 
-# Check for python-coverage
-AC_ARG_VAR(PYCOVERAGE, [python-coverage path])
-AC_PATH_PROGS(PYCOVERAGE, [python-coverage coverage], [])
+# Check for python3-coverage
+AC_ARG_VAR(PYCOVERAGE, [python3-coverage path])
+AC_PATH_PROGS(PYCOVERAGE, [python3-coverage coverage], [])
 if test -z "$PYCOVERAGE"
 then
   AC_MSG_WARN(m4_normalize([python-coverage or coverage not found, evaluating

--- a/test/py/check-cert-expired_unittest.bash
+++ b/test/py/check-cert-expired_unittest.bash
@@ -30,7 +30,7 @@
 set -e
 set -o pipefail
 
-export PYTHON=${PYTHON:=python}
+export PYTHON=${PYTHON:=python3}
 
 CCE=tools/check-cert-expired
 

--- a/test/py/ganeti-cleaner_unittest.bash
+++ b/test/py/ganeti-cleaner_unittest.bash
@@ -30,7 +30,7 @@
 set -e -u
 set -o pipefail
 
-export PYTHON=${PYTHON:=python}
+export PYTHON=${PYTHON:=python3}
 
 GNTC=daemons/ganeti-cleaner
 CCE=$PWD/tools/check-cert-expired

--- a/test/py/ganeti.utils.process_unittest.py
+++ b/test/py/ganeti.utils.process_unittest.py
@@ -264,7 +264,7 @@ class TestRunCmd(testutils.GanetiTestCase):
 
   def testSignal(self):
     """Test signal"""
-    result = utils.RunCmd(["python", "-c",
+    result = utils.RunCmd(["python3", "-c",
                            "import os; os.kill(os.getpid(), 15)"])
     self.assertEqual(result.signal, 15)
     self.assertEqual(result.output, "")

--- a/test/py/import-export_unittest.bash
+++ b/test/py/import-export_unittest.bash
@@ -30,7 +30,7 @@
 set -e
 set -o pipefail
 
-export PYTHON=${PYTHON:=python}
+export PYTHON=${PYTHON:=python3}
 
 impexpd="$PYTHON daemons/import-export -d"
 


### PR DESCRIPTION
I have tried building on a pure Python 3 Debian system and found some references to /usr/bin/python (which does not exist in this case). These should be fixed now. This allows the build and the python tests to pass.

I will also open a separate issue and list all critical errors pylint3 has found.