### PR TITLE
Fixed usage of NamedTemporaryFile with Python 3 in testsuite

### DIFF
--- a/qa/qa_cluster.py
+++ b/qa/qa_cluster.py
@@ -1275,7 +1275,7 @@ def TestClusterRenewCrypto():
                                          pathutils.RAPI_CERT_FILE)
   try:
     # Custom RAPI certificate
-    fh = tempfile.NamedTemporaryFile()
+    fh = tempfile.NamedTemporaryFile(mode="w")
 
     # Ensure certificate doesn't cause "gnt-cluster verify" to complain
     validity = constants.SSL_CERT_EXPIRATION_WARN * 3
@@ -1528,7 +1528,7 @@ def TestClusterCopyfile():
   uniqueid = utils.NewUUID()
 
   # Create temporary file
-  f = tempfile.NamedTemporaryFile()
+  f = tempfile.NamedTemporaryFile(mode="w")
   f.write(uniqueid)
   f.flush()
   f.seek(0)

--- a/qa/qa_rapi.py
+++ b/qa/qa_rapi.py
@@ -138,7 +138,7 @@ def ReloadCertificates(ensure_presence=True):
          qa_utils.MakeNodePath(master, pathutils.RAPI_CERT_FILE)]
 
   # Write to temporary file
-  _rapi_ca = tempfile.NamedTemporaryFile()
+  _rapi_ca = tempfile.NamedTemporaryFile(mode="w")
   _rapi_ca.write(qa_utils.GetCommandOutput(master.primary,
                                            utils.ShellQuoteArgs(cmd)))
   _rapi_ca.flush()
@@ -181,7 +181,7 @@ def _CreateRapiUser(rapi_user):
   rapi_users_path = qa_utils.MakeNodePath(master, pathutils.RAPI_USERS_FILE)
   rapi_dir = os.path.dirname(rapi_users_path)
 
-  fh = tempfile.NamedTemporaryFile()
+  fh = tempfile.NamedTemporaryFile(mode="w")
   try:
     fh.write("%s %s write\n" % (rapi_user, rapi_secret))
     fh.flush()
@@ -1222,7 +1222,7 @@ def TestInterClusterInstanceMove(src_instance, dest_instance,
   """Test tools/move-instance"""
   master = qa_config.GetMasterNode()
 
-  rapi_pw_file = tempfile.NamedTemporaryFile()
+  rapi_pw_file = tempfile.NamedTemporaryFile(mode="w")
   rapi_pw_file.write(_rapi_password)
   rapi_pw_file.flush()
 


### PR DESCRIPTION
The Ganeti QA testsuite makes use of NamedTemporaryFile in several places. With Python 3, the i/o mode needs to be either binary (default) or string. The QA testsuite only needs string modes so the code was fixed accordingly.

Development has been paired with @geigi

Reported in #1418