### PR TITLE
configure.ac: fall back to pylint if pylint3 not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -571,12 +571,24 @@ then
                             documentation rebuild not possible]))
 fi
 
-# Check for pylint3
-AC_ARG_VAR(PYLINT, [pylint3 path])
+# Check for pylint
+AC_ARG_VAR(PYLINT, [pylint path])
 AC_PATH_PROG(PYLINT, [pylint3], [])
 if test -z "$PYLINT"
 then
-  AC_MSG_WARN([pylint not found, checking code will not be possible])
+  AC_PATH_PROG(PYLINT, [pylint], [])
+  if test -z "$PYLINT"
+  then
+    AC_MSG_WARN([pylint not found, checking code will not be possible])
+  else
+    if $PYLINT --version 2>/dev/null | grep -q '^pylint 1\.'
+    then
+      # Make sure this is not pylint 1
+      AC_MSG_WARN([pylint 1.x found, checking code will not be possible.
+                   Please upgrade pylint to at least 2.0.])
+      PYLINT=
+    fi
+  fi
 fi
 
 # Check for pep8


### PR DESCRIPTION
Pylint has dropped Py2 support upstream[1], so Pylint versions after 2.0
effectively only support Python 3. Debian shipped with dual pylint
versions in Buster: 1.9 as plain `pylint` for checking Python 2 code,
and 2.2.2 as `pylint3` for checking Python 3 code. On Debian Sid
however, as of today, there is only one `pylint` package, offering
`/usr/bin/pylint` which is Python-3-only, so our current strategy of
looking for pylint3 won't work. I expect most distributions will end
up calling pylint simply `pylint` (as Debian Bullseye does) and only
support Python 3.

Fix this by checking for `pylint3`, and then for `pylint` if the former
was not found. In case we end up with `pylint`, we also need to check that
this is not some ancient 1.x version possibly running on/supporting only
Python 2.

[1] https://github.com/PyCQA/pylint/issues/1763