### PR TITLE
Some more Python 3 fixes

### DIFF
--- a/daemons/import-export
+++ b/daemons/import-export
@@ -521,16 +521,15 @@ def VerifyOptions():
 
 
 class ChildProcess(subprocess.Popen):
-  def __init__(self, env, cmd, noclose_fds):
+  def __init__(self, env, cmd, pass_fds):
     """Initializes this class.
 
     """
-    self._noclose_fds = noclose_fds
-
     # Not using close_fds because doing so would also close the socat stderr
     # pipe, which we still need.
-    subprocess.Popen.__init__(self, cmd, env=env, shell=False, close_fds=False,
-                              stderr=subprocess.PIPE, stdout=None, stdin=None,
+    subprocess.Popen.__init__(self, cmd, env=env, shell=False,
+                              pass_fds=pass_fds, stderr=subprocess.PIPE,
+                              stdout=None, stdin=None,
                               preexec_fn=self._ChildPreexec)
     self._SetProcessGroup()
 
@@ -541,9 +540,6 @@ class ChildProcess(subprocess.Popen):
     # Move to separate process group. By sending a signal to its process group
     # we can kill the child process and all grandchildren.
     os.setpgid(0, 0)
-
-    # Close almost all file descriptors
-    utils.CloseFDs(noclose_fds=self._noclose_fds)
 
   def _SetProcessGroup(self):
     """Sets the child's process group.

--- a/daemons/import-export
+++ b/daemons/import-export
@@ -225,10 +225,10 @@ def ProcessChildIO(child, socat_stderr_read_fd, dd_stderr_read_fd,
   # Buffer size 0 is important, otherwise .read() with a specified length
   # might buffer data while poll(2) won't mark its file descriptor as
   # readable again.
-  socat_stderr_read = os.fdopen(socat_stderr_read_fd, "r", 0)
-  dd_stderr_read = os.fdopen(dd_stderr_read_fd, "r", 0)
-  dd_pid_read = os.fdopen(dd_pid_read_fd, "r", 0)
-  exp_size_read = os.fdopen(exp_size_read_fd, "r", 0)
+  socat_stderr_read = os.fdopen(socat_stderr_read_fd, "rb", 0)
+  dd_stderr_read = os.fdopen(dd_stderr_read_fd, "rb", 0)
+  dd_pid_read = os.fdopen(dd_pid_read_fd, "rb", 0)
+  exp_size_read = os.fdopen(exp_size_read_fd, "rb", 0)
 
   tp_samples = DD_THROUGHPUT_SAMPLES
 

--- a/lib/client/gnt_job.py
+++ b/lib/client/gnt_job.py
@@ -70,10 +70,10 @@ def _FormatStatus(value):
 
 
 def _FormatSummary(value):
-  """Formats a job's summary. Takes possible non-ascii encoding into account.
+  """Formats a job's summary.
 
   """
-  return ','.encode('utf-8').join(item.encode('utf-8') for item in value)
+  return ','.join(value)
 
 
 _JOB_LIST_FORMAT = {

--- a/lib/cmdlib/instance_storage.py
+++ b/lib/cmdlib/instance_storage.py
@@ -1883,7 +1883,7 @@ class LUInstanceGrowDisk(LogicalUnit):
 
     if wipe_disks:
       inst_disks = self.cfg.GetInstanceDisks(self.instance.uuid)
-      assert inst_disks[self.op.disk] == self.disk
+      assert inst_disks[self.op.disk].ToDict() == self.disk.ToDict()
 
       # Wipe newly added disk space
       WipeDisks(self, self.instance,

--- a/lib/serializer.py
+++ b/lib/serializer.py
@@ -39,6 +39,7 @@ backend (currently json).
 # function and not a constant
 
 import re
+from copy import deepcopy
 
 # Python 2.6 and above contain a JSON module based on simplejson. Unfortunately
 # the standard library version is significantly slower than the external
@@ -274,6 +275,13 @@ class Private(object):
 
   def __format__(self, *_1, **_2):
     return self.__str__()
+
+  def __copy__(self):
+    return Private(self._item, self._descr)
+
+  def __deepcopy__(self, memo):
+    new_item = deepcopy(self._item, memo)
+    return Private(new_item, self._descr)
 
   def __getattr__(self, attr):
     return Private(getattr(self._item, attr),

--- a/lib/storage/drbd.py
+++ b/lib/storage/drbd.py
@@ -115,7 +115,7 @@ class DRBD8(object):
     @rtype: int
 
     """
-    highest = None
+    highest = -1
     info = DRBD8.GetProcInfo()
     for minor in info.GetMinors():
       status = info.GetMinorStatus(minor)
@@ -123,8 +123,6 @@ class DRBD8(object):
         return minor
       highest = max(highest, minor)
 
-    if highest is None: # there are no minors in use at all
-      return 0
     if highest >= DRBD8._MAX_MINORS:
       logging.error("Error: no free drbd minors!")
       raise errors.BlockDeviceError("Can't find a free DRBD minor")

--- a/lib/utils/__init__.py
+++ b/lib/utils/__init__.py
@@ -687,8 +687,8 @@ class SignalWakeupFd(object):
     # Once these succeeded, the file descriptors will be closed automatically.
     # Buffer size 0 is important, otherwise .read() with a specified length
     # might buffer data and the file descriptors won't be marked readable.
-    self._read_fh = os.fdopen(read_fd, "r", 0)
-    self._write_fh = os.fdopen(write_fd, "w", 0)
+    self._read_fh = os.fdopen(read_fd, "rb", 0)
+    self._write_fh = os.fdopen(write_fd, "wb", 0)
 
     self._previous = self._SetWakeupFd(self._write_fh.fileno())
 

--- a/lib/utils/__init__.py
+++ b/lib/utils/__init__.py
@@ -664,25 +664,17 @@ def TimeoutExpired(epoch, timeout, _time_fn=time.time):
 
 
 class SignalWakeupFd(object):
-  try:
-    # This is only supported in Python 2.5 and above (some distributions
-    # backported it to Python 2.4)
-    _set_wakeup_fd_fn = signal.set_wakeup_fd
-  except AttributeError:
-    # Not supported
-
-    def _SetWakeupFd(self, _): # pylint: disable=R0201
-      return -1
-  else:
-
-    def _SetWakeupFd(self, fd):
-      return self._set_wakeup_fd_fn(fd)
+  def _SetWakeupFd(self, fd):
+    return signal.set_wakeup_fd(fd)
 
   def __init__(self):
     """Initializes this class.
 
     """
     (read_fd, write_fd) = os.pipe()
+
+    # signal.set_wakeup_fd requires the FD to be non-blocking
+    SetNonblockFlag(write_fd, True)
 
     # Once these succeeded, the file descriptors will be closed automatically.
     # Buffer size 0 is important, otherwise .read() with a specified length

--- a/lib/utils/text.py
+++ b/lib/utils/text.py
@@ -549,7 +549,7 @@ def FormatSeconds(secs):
 
 
 class LineSplitter(object):
-  """Splits data chunks into lines separated by newline.
+  """Splits byte data chunks into lines of text separated by newline.
 
   Instances provide a file-like interface.
 
@@ -571,12 +571,12 @@ class LineSplitter(object):
       self._line_fn = line_fn
 
     self._lines = collections.deque()
-    self._buffer = ""
+    self._buffer = b""
 
   def write(self, data):
-    parts = (self._buffer + data).split("\n")
+    parts = (self._buffer + data).split(b"\n")
     self._buffer = parts.pop()
-    self._lines.extend(parts)
+    self._lines.extend(p.decode() for p in parts)
 
   def flush(self):
     while self._lines:
@@ -585,7 +585,7 @@ class LineSplitter(object):
   def close(self):
     self.flush()
     if self._buffer:
-      self._line_fn(self._buffer)
+      self._line_fn(self._buffer.decode())
 
 
 def IsValidShellParam(word):

--- a/test/py/ganeti.utils.text_unittest.py
+++ b/test/py/ganeti.utils.text_unittest.py
@@ -545,11 +545,11 @@ class TestLineSplitter(unittest.TestCase):
   def test(self):
     lines = []
     ls = utils.LineSplitter(lines.append)
-    ls.write("Hello World\n")
+    ls.write(b"Hello World\n")
     self.assertEqual(lines, [])
-    ls.write("Foo\n Bar\r\n ")
-    ls.write("Baz")
-    ls.write("Moo")
+    ls.write(b"Foo\n Bar\r\n ")
+    ls.write(b"Baz")
+    ls.write(b"Moo")
     self.assertEqual(lines, [])
     ls.flush()
     self.assertEqual(lines, ["Hello World", "Foo", " Bar"])
@@ -564,11 +564,11 @@ class TestLineSplitter(unittest.TestCase):
   def testExtraArgsNoFlush(self):
     lines = []
     ls = utils.LineSplitter(self._testExtra, lines, 999, "extra")
-    ls.write("\n\nHello World\n")
-    ls.write("Foo\n Bar\r\n ")
-    ls.write("")
-    ls.write("Baz")
-    ls.write("Moo\n\nx\n")
+    ls.write(b"\n\nHello World\n")
+    ls.write(b"Foo\n Bar\r\n ")
+    ls.write(b"")
+    ls.write(b"Baz")
+    ls.write(b"Moo\n\nx\n")
     self.assertEqual(lines, [])
     ls.close()
     self.assertEqual(lines, ["", "", "Hello World", "Foo", " Bar", " BazMoo",


### PR DESCRIPTION
These issues turned up when running `burnin` in a real cluster. With these commits I'm able to run a full burnin for the `plain`, `drbd` and `file` disk templates without issues.

A lot of the changes go into the import-export daemon and related infrastructure, which unfortunately seem fragile.