### PR TITLE
document the unit of cli option shutdown-timeout

### DIFF
--- a/lib/cli_opts.py
+++ b/lib/cli_opts.py
@@ -1204,7 +1204,7 @@ NOSHUTDOWN_OPT = cli_option("--noshutdown", dest="shutdown",
 
 TIMEOUT_OPT = cli_option("--timeout", dest="timeout", type="int",
                          default=constants.DEFAULT_SHUTDOWN_TIMEOUT,
-                         help="Maximum time to wait")
+                         help="Maximum number of minutes to wait")
 
 COMPRESS_OPT = cli_option("--compress", dest="compress",
                           type="string", default=constants.IEC_NONE,
@@ -1218,8 +1218,8 @@ TRANSPORT_COMPRESSION_OPT = \
 SHUTDOWN_TIMEOUT_OPT = cli_option("--shutdown-timeout",
                                   dest="shutdown_timeout", type="int",
                                   default=constants.DEFAULT_SHUTDOWN_TIMEOUT,
-                                  help="Maximum time to wait for instance"
-                                  " shutdown")
+                                  help="Maximum number of minutes to wait for"
+                                  " instance shutdown")
 
 INTERVAL_OPT = cli_option("--interval", dest="interval", type="int",
                           default=None,

--- a/lib/cli_opts.py
+++ b/lib/cli_opts.py
@@ -1204,7 +1204,7 @@ NOSHUTDOWN_OPT = cli_option("--noshutdown", dest="shutdown",
 
 TIMEOUT_OPT = cli_option("--timeout", dest="timeout", type="int",
                          default=constants.DEFAULT_SHUTDOWN_TIMEOUT,
-                         help="Maximum number of minutes to wait")
+                         help="Maximum time (in minutes) to wait")
 
 COMPRESS_OPT = cli_option("--compress", dest="compress",
                           type="string", default=constants.IEC_NONE,
@@ -1218,7 +1218,7 @@ TRANSPORT_COMPRESSION_OPT = \
 SHUTDOWN_TIMEOUT_OPT = cli_option("--shutdown-timeout",
                                   dest="shutdown_timeout", type="int",
                                   default=constants.DEFAULT_SHUTDOWN_TIMEOUT,
-                                  help="Maximum number of minutes to wait for"
+                                  help="Maximum time (in minutes) to wait for"
                                   " instance shutdown")
 
 INTERVAL_OPT = cli_option("--interval", dest="interval", type="int",

--- a/man/gnt-backup.rst
+++ b/man/gnt-backup.rst
@@ -41,7 +41,7 @@ compression mode is used to try and speed up moves during the export.
 Valid values are 'none', and any values defined in the
 'compression_tools' cluster parameter.
 
-The ``--shutdown-timeout`` is used to specify how much time to wait
+The ``--shutdown-timeout`` is used to specify how many minutes to wait
 before forcing the shutdown (xm destroy in xen, killing the kvm
 process, for kvm). By default two minutes are given to each
 instance to stop.

--- a/man/gnt-backup.rst
+++ b/man/gnt-backup.rst
@@ -41,10 +41,10 @@ compression mode is used to try and speed up moves during the export.
 Valid values are 'none', and any values defined in the
 'compression_tools' cluster parameter.
 
-The ``--shutdown-timeout`` is used to specify how many minutes to wait
-before forcing the shutdown (xm destroy in xen, killing the kvm
-process, for kvm). By default two minutes are given to each
-instance to stop.
+The ``--shutdown-timeout`` is used to specify how much time (in
+minutes) to wait before forcing the shutdown (xm destroy in xen,
+killing the kvm process, for kvm). By default two minutes are given
+to each instance to stop.
 
 The ``--noshutdown`` option will create a snapshot disk of the
 instance without shutting it down first. While this is faster and

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -1270,7 +1270,7 @@ even in the presence of errors during the removal of the instance
 (e.g. during the shutdown or the disk removal). If this option is not
 given, the command will stop at the first error.
 
-The ``--shutdown-timeout`` is used to specify how much time to wait
+The ``--shutdown-timeout`` is used to specify how many minutes to wait
 before forcing the shutdown (e.g. ``xm destroy`` in Xen, killing the
 kvm process for KVM, etc.). By default two minutes are given to each
 instance to stop.
@@ -1701,7 +1701,7 @@ during a hardcoded interval (currently 2 minutes), it will forcibly
 stop the instance (equivalent to switching off the power on a physical
 machine).
 
-The ``--timeout`` is used to specify how much time to wait before
+The ``--timeout`` is used to specify how many minutes to wait before
 forcing the shutdown (e.g. ``xm destroy`` in Xen, killing the kvm
 process for KVM, etc.). By default two minutes are given to each
 instance to stop.
@@ -1765,7 +1765,7 @@ The ``--instance``, ``--node``, ``--primary``, ``--secondary``,
 ``--sec-node-tags`` options are similar as for the **startup** command
 and they influence the actual instances being rebooted.
 
-The ``--shutdown-timeout`` is used to specify how much time to wait
+The ``--shutdown-timeout`` is used to specify how many minutes to wait
 before forcing the shutdown (xm destroy in xen, killing the kvm
 process, for kvm). By default two minutes are given to each instance
 to stop.
@@ -2066,7 +2066,7 @@ having the instance running on two machines in parallel (on
 disconnected DRBD drives). This flag requires the source node to be
 marked offline first to succeed.
 
-The ``--shutdown-timeout`` is used to specify how much time to wait
+The ``--shutdown-timeout`` is used to specify how many minutes to wait
 before forcing the shutdown (xm destroy in xen, killing the kvm
 process, for kvm). By default two minutes are given to each instance
 to stop.
@@ -2209,7 +2209,7 @@ The ``--compress`` option is used to specify which compression mode
 is used during the move. Valid values are 'none' (the default) and any
 values specified in the 'compression_tools' cluster parameter.
 
-The ``--shutdown-timeout`` is used to specify how much time to wait
+The ``--shutdown-timeout`` is used to specify how many minutes to wait
 before forcing the shutdown (e.g. ``xm destroy`` in XEN, killing the
 kvm process for KVM, etc.). By default two minutes are given to each
 instance to stop.

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -1270,10 +1270,10 @@ even in the presence of errors during the removal of the instance
 (e.g. during the shutdown or the disk removal). If this option is not
 given, the command will stop at the first error.
 
-The ``--shutdown-timeout`` is used to specify how many minutes to wait
-before forcing the shutdown (e.g. ``xm destroy`` in Xen, killing the
-kvm process for KVM, etc.). By default two minutes are given to each
-instance to stop.
+The ``--shutdown-timeout`` is used to specify how much time (in
+minutes) to wait before forcing the shutdown (e.g. ``xm destroy`` in
+Xen, killing the kvm process for KVM, etc.). By default two minutes
+are given to each instance to stop.
 
 The ``--force`` option is used to skip the interactive confirmation.
 
@@ -1701,10 +1701,10 @@ during a hardcoded interval (currently 2 minutes), it will forcibly
 stop the instance (equivalent to switching off the power on a physical
 machine).
 
-The ``--timeout`` is used to specify how many minutes to wait before
-forcing the shutdown (e.g. ``xm destroy`` in Xen, killing the kvm
-process for KVM, etc.). By default two minutes are given to each
-instance to stop.
+The ``--timeout`` is used to specify how much time (in minutes) to
+wait before forcing the shutdown (e.g. ``xm destroy`` in Xen, killing
+the kvm process for KVM, etc.). By default two minutes are given to
+each instance to stop.
 
 The ``--instance``, ``--node``, ``--primary``, ``--secondary``,
 ``--all``, ``--tags``, ``--node-tags``, ``--pri-node-tags`` and
@@ -1765,10 +1765,10 @@ The ``--instance``, ``--node``, ``--primary``, ``--secondary``,
 ``--sec-node-tags`` options are similar as for the **startup** command
 and they influence the actual instances being rebooted.
 
-The ``--shutdown-timeout`` is used to specify how many minutes to wait
-before forcing the shutdown (xm destroy in xen, killing the kvm
-process, for kvm). By default two minutes are given to each instance
-to stop.
+The ``--shutdown-timeout`` is used to specify how much time (in
+minutes) to wait before forcing the shutdown (xm destroy in xen,
+killing the kvm process, for kvm). By default two minutes are given
+to each instance to stop.
 
 The ``--force-multiple`` will skip the interactive confirmation in the
 case the more than one instance will be affected.
@@ -2066,10 +2066,10 @@ having the instance running on two machines in parallel (on
 disconnected DRBD drives). This flag requires the source node to be
 marked offline first to succeed.
 
-The ``--shutdown-timeout`` is used to specify how many minutes to wait
-before forcing the shutdown (xm destroy in xen, killing the kvm
-process, for kvm). By default two minutes are given to each instance
-to stop.
+The ``--shutdown-timeout`` is used to specify how much time (in
+minutes) to wait before forcing the shutdown (xm destroy in xen,
+killing the kvm process, for kvm). By default two minutes are given
+to each instance to stop.
 
 If ``--ignore-ipolicy`` is given any instance policy violations occuring
 during this operation are ignored.
@@ -2209,10 +2209,10 @@ The ``--compress`` option is used to specify which compression mode
 is used during the move. Valid values are 'none' (the default) and any
 values specified in the 'compression_tools' cluster parameter.
 
-The ``--shutdown-timeout`` is used to specify how many minutes to wait
-before forcing the shutdown (e.g. ``xm destroy`` in XEN, killing the
-kvm process for KVM, etc.). By default two minutes are given to each
-instance to stop.
+The ``--shutdown-timeout`` is used to specify how much time (in
+minutes) to wait before forcing the shutdown (e.g. ``xm destroy`` in
+XEN, killing the kvm process for KVM, etc.). By default two minutes
+are given to each instance to stop.
 
 The ``--ignore-consistency`` option will make Ganeti ignore any errors
 in trying to shutdown the instance on its node; useful if the


### PR DESCRIPTION
Clarify the unit of measurement for the cli option --timeout respectively
--shutdown-timeout in gnt-instance(8), gnt-backup(8) and their command
help output. This fixes issue #1300.

Signed-off-by: Sascha Lucas <sascha_lucas@web.de>

