### PR TITLE
Fix a little typo in commit 6d4e3ca

### DIFF
--- a/lib/client/gnt_instance.py
+++ b/lib/client/gnt_instance.py
@@ -757,7 +757,7 @@ def FailoverInstance(opts, args):
 
   if ignore_consistency:
     usertext = ("To failover instance %s, the source node must be marked"
-                " offline first. Is this aready the case?") % instance_name
+                " offline first. Is this already the case?") % instance_name
     if not AskUser(usertext):
       return 1
 


### PR DESCRIPTION
In commit 6d4e3ca42ef241f196ea82b87f5202cdc838b445 (from issue #1162), there was a little typo.
This fixes it.

Signed-off-by: Sascha Lucas <sascha_lucas@web.de>