### PR TITLE
Support Live Migration with QEMU 4.2+ (use QMP for migration parameters)

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -2555,13 +2555,14 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     if not live_migration:
       self._CallMonitorCommand(instance_name, "stop")
 
-    migrate_command = ("migrate_set_speed %dm" %
-                       instance.hvparams[constants.HV_MIGRATION_BANDWIDTH])
-    self._CallMonitorCommand(instance_name, migrate_command)
-
-    migrate_command = ("migrate_set_downtime %dms" %
-                       instance.hvparams[constants.HV_MIGRATION_DOWNTIME])
-    self._CallMonitorCommand(instance_name, migrate_command)
+    qmp = QmpConnection(self._InstanceQmpMonitor(instance_name))
+    qmp.connect()
+    max_bandwidth_in_bytes = instance.hvparams[constants.HV_MIGRATION_BANDWIDTH] * 1024 * 1024
+    arguments = {
+      "max-bandwidth": max_bandwidth_in_bytes,
+      "downtime-limit": instance.hvparams[constants.HV_MIGRATION_DOWNTIME],
+    }
+    qmp.Execute("migrate-set-parameters", arguments)
 
     migration_caps = instance.hvparams[constants.HV_KVM_MIGRATION_CAPS]
     if migration_caps:


### PR DESCRIPTION
This PR implements setting the QEMU/KVM live migration parameters through the QMP function `migrate-set-parameters`. The old way is now deprecated (see [QEMU 4.2 changelog](https://wiki.qemu.org/ChangeLog/4.2#New_deprecated_options_and_features)

This change has been tested against Debian Bullseye (which contains QEMU 4.2) and also works on Debian Buster (which contains QEMU 3.1).

Parameters that could be set through the QMP function are listed here:
https://github.com/qemu/qemu/blob/28db64fce555a03b4ca256d5b6f4290abdfbd9e8/qapi/migration.json#L734-L826