### PR TITLE
Fix references to code.google.com

### DIFF
--- a/doc/admin.rst
+++ b/doc/admin.rst
@@ -1999,8 +1999,8 @@ Other Ganeti projects
 
 Below is a list (which might not be up-to-date) of additional projects
 that can be useful in a Ganeti deployment. They can be downloaded from
-the project site (http://code.google.com/p/ganeti/) and the repositories
-are also on the project git site (http://git.ganeti.org).
+the project site (http://www.ganeti.org) and the repositories
+are also on the project git site (https://github.com/ganeti).
 
 NBMA tools
 ++++++++++

--- a/doc/design-node-security.rst
+++ b/doc/design-node-security.rst
@@ -26,7 +26,7 @@ design is to limit the set of nodes that can establish ssh and RPC
 connections to the master and master candidates.
 
 As pointed out in
-`issue 377 <https://code.google.com/p/ganeti/issues/detail?id=377>`_, this
+`issue 433 <https://github.com/ganeti/ganeti/issues/433>`_, this
 is a security risk. Since all nodes have these keys, compromising
 any of those nodes would possibly give an attacker access to all other
 machines in the cluster. Reducing the set of nodes that are able to

--- a/doc/design-ssh-ports.rst
+++ b/doc/design-ssh-ports.rst
@@ -16,10 +16,10 @@ Current state and shortcomings
 ==============================
 
 All SSH daemons are expected to be running on the default port 22. It has been
-requested by Ganeti users (`Issue 235`_) to allow SSH daemons run on
+requested by Ganeti users (`Issue 291`_) to allow SSH daemons run on
 non-standard ports as well.
 
-.. _`Issue 235`: https://code.google.com/p/ganeti/issues/detail?id=235
+.. _`Issue 291`: https://github.com/ganeti/ganeti/issues/291 
 
 
 Proposed Changes

--- a/epydoc.conf.in
+++ b/epydoc.conf.in
@@ -1,7 +1,7 @@
 [epydoc]
 
 name: Ganeti
-url: http://code.google.com/p/ganeti/
+url: https://github.com/ganeti/ganeti/
 
 output: html
 

--- a/lib/storage/drbd.py
+++ b/lib/storage/drbd.py
@@ -1019,7 +1019,7 @@ class DRBD8Dev(base.BlockDev):
     """
     # Zero the metadata first, in order to make sure drbdmeta doesn't
     # try to auto-detect existing filesystems or similar (see
-    # http://code.google.com/p/ganeti/issues/detail?id=182); we only
+    # https://github.com/ganeti/ganeti/issues/238); we only
     # care about the first 128MB of data in the device, even though it
     # can be bigger
     result = utils.RunCmd([constants.DD_CMD,

--- a/man/footer.rst
+++ b/man/footer.rst
@@ -1,7 +1,7 @@
 REPORTING BUGS
 --------------
 
-Report bugs to `project website <http://code.google.com/p/ganeti/>`_
+Report bugs to the `project's issue tracker <https://github.com/ganeti/ganeti/issues>`_
 or contact the developers using the `Ganeti mailing list
 <ganeti@googlegroups.com>`_.
 


### PR DESCRIPTION
The codebase/man pages/documentation contain a number of
references to code.google.com. All these occurences have
been replaced by up-to-date URLs.

Signed-off-by: Rudolph Bott <r@spam.wtf>