### PR TITLE
allow up-/downgrades between 2.16 and 3.0

### DIFF
--- a/lib/utils/version.py
+++ b/lib/utils/version.py
@@ -122,7 +122,16 @@ def UpgradeRange(target, current=CURRENT_VERSION):
     return "automatic upgrades only supported from 2.10 onwards"
 
   if target[0] != current[0]:
-    return "different major versions"
+    # allow major upgrade from 2.16 to 3.0
+    if current[0:2] == (2,16) and target[0:2] == (3,0):
+      return None
+    # allow major downgrade from 3.0 to 2.16
+    if current[0:2] == (3,0) and target[0:2] == (2,16):
+      return None
+
+    # forbid any other major version up-/downgrades
+    return "major version up- or downgrades are only supported between " \
+      "2.16 and 3.0"
 
   if target[1] < current[1] - 1:
     return "can only downgrade one minor version at a time"

--- a/test/py/ganeti.utils.version_unittest.py
+++ b/test/py/ganeti.utils.version_unittest.py
@@ -55,16 +55,22 @@ class UpgradeRangeTest(unittest.TestCase):
                           None)
         self.assertEquals(version.UpgradeRange((2,11,3), current=(2,12,99)),
                           None)
-        self.assertEquals(version.UpgradeRange((3,0,0), current=(2,12,0)),
-                          "different major versions")
-        self.assertEquals(version.UpgradeRange((2,12,0), current=(3,0,0)),
-                          "different major versions")
-        self.assertEquals(version.UpgradeRange((2,10,0), current=(2,12,0)),
+        self.assertEqual(version.UpgradeRange((3,0,0), current=(2,12,0)),
+                          "major version up- or downgrades are only supported " \
+                          "between 2.16 and 3.0")
+        self.assertEqual(version.UpgradeRange((2,12,0), current=(3,0,0)),
+                          "major version up- or downgrades are only supported " \
+                          "between 2.16 and 3.0")
+        self.assertEqual(version.UpgradeRange((2,10,0), current=(2,12,0)),
                           "can only downgrade one minor version at a time")
         self.assertEquals(version.UpgradeRange((2,9,0), current=(2,10,0)),
                           "automatic upgrades only supported from 2.10 onwards")
         self.assertEquals(version.UpgradeRange((2,10,0), current=(2,9,0)),
                           "automatic upgrades only supported from 2.10 onwards")
+        self.assertEqual(version.UpgradeRange((3,0,0), current=(2,16,1)),
+                          None)
+        self.assertEqual(version.UpgradeRange((2,16,1), current=(3,0,0)),
+                          None)
 
 class ShouldCfgdowngradeTest(unittest.TestCase):
     def testShouldCfgDowngrade(self):


### PR DESCRIPTION
This will allow up- and downgrades between version 2.16 and 3.0.
Hence the minimum Python version needed is 3.6, Ganeti-3.0 will only
be available for Debian Buster/Ubuntu Bionic or later. Both ship
with Ganeti-2.16. Apparently no other versions are needed.

Probably not the best program flow and hard coded exceptional versions.

Limited testing, by running UpgradeRange() standalone (extra python script) and feeding different target/current versions (no real upgrade test done).

This is against stable-2.16, for allowing upgrade to upcoming 3.0. Needs also merging into master for allowing downgrade back to 2.16.

this addresses issue #1423