### PR TITLE
allow downgrades from 3.0 to 2.16

### DIFF
--- a/lib/utils/version.py
+++ b/lib/utils/version.py
@@ -122,7 +122,16 @@ def UpgradeRange(target, current=CURRENT_VERSION):
     return "automatic upgrades only supported from 2.10 onwards"
 
   if target[0] != current[0]:
-    return "different major versions"
+    # allow major upgrade from 2.16 to 3.0
+    if current[0:2] == (2,16) and target[0:2] == (3,0):
+      return None
+    # allow major downgrade from 3.0 to 2.16
+    if current[0:2] == (3,0) and target[0:2] == (2,16):
+      return None
+
+    # forbid any other major version up-/downgrades
+    return "major version up- or downgrades are only supported between " \
+      "2.16 and 3.0"
 
   if target[1] < current[1] - 1:
     return "can only downgrade one minor version at a time"

--- a/test/py/ganeti.utils.version_unittest.py
+++ b/test/py/ganeti.utils.version_unittest.py
@@ -56,15 +56,21 @@ class UpgradeRangeTest(unittest.TestCase):
         self.assertEqual(version.UpgradeRange((2,11,3), current=(2,12,99)),
                           None)
         self.assertEqual(version.UpgradeRange((3,0,0), current=(2,12,0)),
-                          "different major versions")
+                          "major version up- or downgrades are only supported " \
+                          "between 2.16 and 3.0")
         self.assertEqual(version.UpgradeRange((2,12,0), current=(3,0,0)),
-                          "different major versions")
+                          "major version up- or downgrades are only supported " \
+                          "between 2.16 and 3.0")
         self.assertEqual(version.UpgradeRange((2,10,0), current=(2,12,0)),
                           "can only downgrade one minor version at a time")
         self.assertEqual(version.UpgradeRange((2,9,0), current=(2,10,0)),
                           "automatic upgrades only supported from 2.10 onwards")
         self.assertEqual(version.UpgradeRange((2,10,0), current=(2,9,0)),
                           "automatic upgrades only supported from 2.10 onwards")
+        self.assertEqual(version.UpgradeRange((3,0,0), current=(2,16,1)),
+                          None)
+        self.assertEqual(version.UpgradeRange((2,16,1), current=(3,0,0)),
+                          None)
 
 class ShouldCfgdowngradeTest(unittest.TestCase):
     def testShouldCfgDowngrade(self):


### PR DESCRIPTION
This PR cherry-picks the "allow upgrades from 2.16 to 3.0" from the stable-2.16 branch into master - and hence allows downgrades from 3.0 back to 2.16.