### PR TITLE
fix long lines, breaking the release script

### DIFF
--- a/test/py/ganeti.utils.version_unittest.py
+++ b/test/py/ganeti.utils.version_unittest.py
@@ -56,11 +56,11 @@ class UpgradeRangeTest(unittest.TestCase):
         self.assertEquals(version.UpgradeRange((2,11,3), current=(2,12,99)),
                           None)
         self.assertEqual(version.UpgradeRange((3,0,0), current=(2,12,0)),
-                          "major version up- or downgrades are only supported " \
-                          "between 2.16 and 3.0")
+                         "major version up- or downgrades are only supported"
+                         " between 2.16 and 3.0")
         self.assertEqual(version.UpgradeRange((2,12,0), current=(3,0,0)),
-                          "major version up- or downgrades are only supported " \
-                          "between 2.16 and 3.0")
+                         "major version up- or downgrades are only supported"
+                         " between 2.16 and 3.0")
         self.assertEqual(version.UpgradeRange((2,10,0), current=(2,12,0)),
                           "can only downgrade one minor version at a time")
         self.assertEquals(version.UpgradeRange((2,9,0), current=(2,10,0)),


### PR DESCRIPTION
while doing the devel/release for 2.16.2 it turns out:
```
test/py/ganeti.utils.version_unittest.py:59:                          "major version up- or downgrades are only supported " \
test/py/ganeti.utils.version_unittest.py:62:                          "major version up- or downgrades are only supported " \
Longest line in test/py/ganeti.utils.version_unittest.py is longer than 80 characters
Found 1 problem(s) while checking code.
make[2]: *** [Makefile:4861: check-local] Error 1
```
So fixing my own fault here.