### PR TITLE
Add missing GHC dependencies to `configure.ac`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -692,6 +692,8 @@ AC_GHC_PKG_REQUIRE(cryptonite)
 AC_GHC_PKG_REQUIRE(lifted-base)
 AC_GHC_PKG_REQUIRE(lens)
 AC_GHC_PKG_REQUIRE(regex-pcre)
+AC_GHC_PKG_REQUIRE(old-time)
+AC_GHC_PKG_REQUIRE(temporary)
 
 #extra modules for monitoring daemon functionality; also needed for tests
 MONITORING_PKG=


### PR DESCRIPTION
This patch adds the missing dependencies `old-time` and `temporary` to the GHC packages checked in `configure.ac` and closes #1461



