### PR TITLE
Ignore files/folders from common IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@
 *.stat
 .hpc/
 
+# files and folders belonging to common editors/IDEs
+/.vscode
+/.idea
+
 # /
 /.hsenv
 /Makefile


### PR DESCRIPTION
Lately the use of Visual Studio Code or e.g. the Jetbrains family of tools (PyCharms and others) have become more popular so it makes sense to automatically exclude their files and folders from any commits.
