### PR TITLE
Bring master to a release-able state

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -374,6 +374,7 @@ clean-local:
 	rm -rf tools/shebang
 	rm -rf apps
 	rm -rf dist
+	find -D exec . -type d -name __pycache__ -exec rm -rf {} +
 
 HS_GENERATED_FILES = $(HS_PROGS) src/hluxid src/ganeti-luxid \
 	src/hconfd src/ganeti-confd

--- a/autotools/check-header
+++ b/autotools/check-header
@@ -75,7 +75,7 @@ _BSD2 = [
   ]
 
 
-_SHEBANG = re.compile(r"^#(?:|!(?:/usr/bin/python(?:| -u)|/bin/(?:|ba)sh))$")
+_SHEBANG = re.compile(r"^#(?:|!(?:/usr/bin/python3?(?:| -u)|/bin/(?:|ba)sh))$")
 _COPYRIGHT_YEAR = r"20[01][0-9]"
 _COPYRIGHT = re.compile(r"# Copyright \(C\) (%s(?:, %s)*) Google Inc\.$" %
                         (_COPYRIGHT_YEAR, _COPYRIGHT_YEAR))

--- a/autotools/check-header
+++ b/autotools/check-header
@@ -138,7 +138,7 @@ def Main():
     lines = zip(itertools.count(1), content.splitlines())
 
     try:
-      _CheckHeader(compat.partial(next(lines), 0))
+      _CheckHeader(compat.partial(next, lines))
     except HeaderError as err:
       report = str(err)
       print("%s: %s" % (filename, report))

--- a/autotools/check-imports
+++ b/autotools/check-imports
@@ -40,7 +40,7 @@ import sys
 
 # All modules imported after this line are removed from the global list before
 # importing a module to be checked
-_STANDARD_MODULES = sys.modules.keys()
+_STANDARD_MODULES = set(sys.modules.keys())
 
 import os.path
 

--- a/autotools/check-imports
+++ b/autotools/check-imports
@@ -87,16 +87,20 @@ def main():
         checkmodpath = getattr(checkmod, "__file__")
       except AttributeError:
         # Built-in module
-        pass
-      else:
-        abscheckmodpath = os.path.abspath(checkmodpath)
+        continue
 
-        if abscheckmodpath == script_path:
-          # Ignore check script
-          continue
+      if checkmodpath is None and hasattr(checkmod, "__path__"):
+        # Namespace module
+        continue
 
-        if commonprefix([abscheckmodpath, srcdir]) == srcdir:
-          result.append(name)
+      abscheckmodpath = os.path.abspath(checkmodpath)
+
+      if abscheckmodpath == script_path:
+        # Ignore check script
+        continue
+
+      if commonprefix([abscheckmodpath, srcdir]) == srcdir:
+        result.append(name)
 
     if result:
       raise Exception("Module '%s' has illegal imports: %s" %

--- a/autotools/check-tar
+++ b/autotools/check-tar
@@ -44,7 +44,7 @@ def ReportError(member, msg):
 
 
 def main():
-  tf = tarfile.open(fileobj=sys.stdin)
+  tf = tarfile.open(fileobj=sys.stdin.buffer)
 
   success = True
 

--- a/devel/release
+++ b/devel/release
@@ -40,6 +40,7 @@ set -e
 
 : ${URL:=git://git.ganeti.org/ganeti.git}
 TAG="$1"
+: ${PARALLEL:=$(egrep -c "^processor\s+:" /proc/cpuinfo)}
 
 if [[ -z "$TAG" ]]; then
   echo "Usage: $0 <tree-ish>" >&2
@@ -81,8 +82,8 @@ done
 VERSION=$(sed -n -e '/^PACKAGE_VERSION =/ s/^PACKAGE_VERSION = // p' Makefile)
 ARCHIVE="ganeti-${VERSION}.tar.gz"
 
-make distcheck-release
-fakeroot make dist-release
+make -j$PARALLEL distcheck-release
+fakeroot make -j$PARALLEL dist-release
 tar tzvf "$ARCHIVE"
 
 echo

--- a/devel/release
+++ b/devel/release
@@ -38,7 +38,7 @@
 
 set -e
 
-: ${URL:=git://git.ganeti.org/ganeti.git}
+: ${URL:=https://github.com/ganeti/ganeti}
 TAG="$1"
 : ${PARALLEL:=$(egrep -c "^processor\s+:" /proc/cpuinfo)}
 

--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -173,7 +173,8 @@ def _with_qmp(fn):
           instance = arg
           break
       else:
-        raise(RuntimeError("QMP decorator could not find a valid ganeti instance object"))
+        raise(RuntimeError("QMP decorator could not find"
+                           " a valid ganeti instance object"))
       filename = self._InstanceQmpMonitor(instance.name)# pylint: disable=W0212
       self.qmp = QmpConnection(filename)
     return fn(self, *args, **kwargs)
@@ -2554,12 +2555,15 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     if not live_migration:
       self.qmp.StopGuestEmulation()
 
-    max_bandwidth_in_bytes = instance.hvparams[constants.HV_MIGRATION_BANDWIDTH] * 1024 * 1024
-    self.qmp.SetMigrationParameters(max_bandwidth_in_bytes, instance.hvparams[constants.HV_MIGRATION_DOWNTIME])
+    max_bandwidth_in_bytes = \
+        instance.hvparams[constants.HV_MIGRATION_BANDWIDTH] * 1024 * 1024
+    self.qmp.SetMigrationParameters(max_bandwidth_in_bytes,
+        instance.hvparams[constants.HV_MIGRATION_DOWNTIME])
 
     migration_caps = instance.hvparams[constants.HV_KVM_MIGRATION_CAPS]
+    migration_caps = migration_caps.split(_MIGRATION_CAPS_DELIM)
     if migration_caps:
-      self.qmp.SetMigrationCapabilities(migration_caps.split(_MIGRATION_CAPS_DELIM))
+      self.qmp.SetMigrationCapabilities(migration_caps)
 
     self.qmp.StartMigration(target, port)
 
@@ -2608,7 +2612,8 @@ class KVMHypervisor(hv_base.BaseHypervisor):
           migration_status = objects.MigrationStatus(status=
                                                      query_migrate["status"])
           if "ram" in query_migrate:
-            migration_status.transferred_ram = query_migrate["ram"]["transferred"]
+            migration_status.transferred_ram = \
+                query_migrate["ram"]["transferred"]
             migration_status.total_ram = query_migrate["ram"]["total"]
 
           return migration_status

--- a/qa/qa_job_utils.py
+++ b/qa/qa_job_utils.py
@@ -282,8 +282,10 @@ class QAThread(threading.Thread):
     """ Reraises any exceptions that might have occured during thread execution.
 
     """
-    if self._exc_info is not None:
-      raise self._exc_info[0](self._exc_info[1]).with_traceback(self._exc_info[2])
+    if self._exc_info is None:
+      return
+
+    raise self._exc_info[0](self._exc_info[1]).with_traceback(self._exc_info[2])
 
 
 class QAThreadGroup(object):

--- a/qa/qa_rapi.py
+++ b/qa/qa_rapi.py
@@ -403,7 +403,8 @@ def _DoGetPutTests(get_uri, modify_uri, opcode_params, rapi_only_aliases=None,
 
   info = _rapi_client._SendRequest("GET", get_uri, None, {})
 
-  missing_params = [x for x in params_of_interest if x not in info and x not in exceptions]
+  missing_params = [x for x in params_of_interest
+                    if x not in info and x not in exceptions]
   if missing_params:
     raise qa_error.Error("The parameters %s which can be set through the "
                          "appropriate opcode are not present in the response "

--- a/src/Ganeti/Compat.hs
+++ b/src/Ganeti/Compat.hs
@@ -75,7 +75,7 @@ toInotifyPath = id
 #endif
 
 -- | MonadFail.Fail instance definitions for JSON results
--- Required as of GHC 8.6 because of
--- https://gitlab.haskell.org/ghc/ghc/wikis/migration/8.6#monadfaildesugaring-by-default
+-- Required as of GHC 8.6 because MonadFailDesugaring is on by default:
+-- https://gitlab.haskell.org/ghc/ghc/wikis/migration/8.6
 instance Fail.MonadFail Text.JSON.Result where
   fail = Fail.fail

--- a/src/Ganeti/Hash.hs
+++ b/src/Ganeti/Hash.hs
@@ -53,7 +53,8 @@ type HashKey = [Word8]
 computeMac :: HashKey -> Maybe String -> String -> String
 computeMac key salt text =
   let hashable = maybe text (++ text) salt
-  in show . hmacGetDigest $ (hmac (B.pack key) (BU.fromString hashable) :: HMAC SHA1)
+  in show . hmacGetDigest $
+    (hmac (B.pack key) (BU.fromString hashable) :: HMAC SHA1)
 
 -- | Verifies the HMAC for a given message.
 verifyMac :: HashKey -> Maybe String -> String -> String -> Bool

--- a/src/Ganeti/JQScheduler.hs
+++ b/src/Ganeti/JQScheduler.hs
@@ -55,7 +55,8 @@ import Control.Exception
 import Control.Monad
 import Control.Monad.IO.Class
 import Data.Function (on)
-import Data.IORef (IORef, atomicModifyIORef, atomicModifyIORef', newIORef, readIORef)
+import Data.IORef (IORef, atomicModifyIORef,
+                   atomicModifyIORef', newIORef, readIORef)
 import Data.List
 import Data.Maybe
 import qualified Data.Map as Map

--- a/test/hs/Test/Ganeti/Objects.hs
+++ b/test/hs/Test/Ganeti/Objects.hs
@@ -395,7 +395,8 @@ genValidNetwork = do
   let hostLen = 32-netmask
   name <- genName >>= mkNonEmpty
   mac_prefix <- genMaybe genName
-  net <- Objects.ip4AddressFromNumber . (* 2^hostLen) . fromIntegral <$> choose (1::Int, 2^netmask-1)
+  net <- Objects.ip4AddressFromNumber . (* 2^hostLen) . fromIntegral <$>
+    choose (1::Int, 2^netmask-1)
   net6 <- genMaybe genIp6Net
   gateway <- genMaybe arbitrary
   gateway6 <- genMaybe genIp6Addr

--- a/test/py/ganeti.rapi.client_unittest.py
+++ b/test/py/ganeti.rapi.client_unittest.py
@@ -162,7 +162,8 @@ class TestConstants(unittest.TestCase):
     self.assertEqual(client.ECODE_ALL, errors.ECODE_ALL)
 
     # Make sure all error codes are in both RAPI client and errors module
-    for name in [s for s in dir(client) if (s.startswith("ECODE_") and s != "ECODE_ALL")]:
+    for name in [s for s in dir(client)
+                 if (s.startswith("ECODE_") and s != "ECODE_ALL")]:
       value = getattr(client, name)
       self.assertEqual(value, getattr(errors, name))
       self.assertTrue(value in client.ECODE_ALL)

--- a/test/py/ganeti.rpc_unittest.py
+++ b/test/py/ganeti.rpc_unittest.py
@@ -399,7 +399,8 @@ class TestStaticResolver(unittest.TestCase):
     addresses = ["192.0.2.%d" % n for n in range(0, 123, 7)]
     nodes = ["node%s.example.com" % n for n in range(0, 123, 7)]
     res = rpc._StaticResolver(addresses)
-    self.assertEqual(res(nodes, NotImplemented), list(zip(nodes, addresses, nodes)))
+    self.assertEqual(res(nodes, NotImplemented),
+                     list(zip(nodes, addresses, nodes)))
 
   def testWrongLength(self):
     res = rpc._StaticResolver([])


### PR DESCRIPTION
This is a collection of fixes and optimizations to the build toolchain, as well as some linting to the code, that bring the master branch to a release-able state. In short:

 - Fix all tools under autotools/ to play nice with Python 3
 - Have devel/release run parallel builds by default (optimization, makes building faster)
 - Fix some overlong lines that crept into the code during the Python 3 / GHC 8.6 conversion.

With these changes, `make distcheck-release && make dist-release` succeeds and we are only missing the 3.0.0~beta1 changelog to make a release.