### PR TITLE
Add check-local to Github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      LC_ALL: C
     steps:
       - uses: actions/checkout@v1
 
@@ -23,6 +25,11 @@ jobs:
         with:
           args: make -j 2
 
+      - name: Run local checks
+        uses: docker://ganeti/ci:buster-py3
+        with:
+          args: make -j 2 check-local
+
       - name: Python tests
         uses: docker://ganeti/ci:buster-py3
         with:
@@ -32,3 +39,4 @@ jobs:
         uses: docker://ganeti/ci:buster-py3
         with:
           args: make -j 2 hs-tests
+

--- a/Makefile.am
+++ b/Makefile.am
@@ -2598,7 +2598,7 @@ ganeti:
 .PHONY: check-dirs
 check-dirs: $(GENERATED_FILES)
 	@set -e; \
-	find . -type d -not -name '.' -not -path './.*' | { \
+	find . -type d \( -name . -o -name .git -prune -o -name .github -prune -o -print \) | { \
 	  error=; \
 	  while read dir; do \
 	    case "$$dir" in \

--- a/Makefile.am
+++ b/Makefile.am
@@ -2598,7 +2598,7 @@ ganeti:
 .PHONY: check-dirs
 check-dirs: $(GENERATED_FILES)
 	@set -e; \
-	find . -type d -not -name '.' -not -path '*/\.*' | { \
+	find . -type d -not -name '.' -not -path './.*' | { \
 	  error=; \
 	  while read dir; do \
 	    case "$$dir" in \

--- a/Makefile.am
+++ b/Makefile.am
@@ -2598,7 +2598,7 @@ ganeti:
 .PHONY: check-dirs
 check-dirs: $(GENERATED_FILES)
 	@set -e; \
-	find . -type d \( -name . -o -name .git -prune -o -print \) | { \
+	find . -type d -not -name '.' -not -path '*/\.*' | { \
 	  error=; \
 	  while read dir; do \
 	    case "$$dir" in \
@@ -2657,7 +2657,8 @@ check-local: check-dirs check-news $(GENERATED_FILES)
 	    error=1; \
 	  fi; \
 	done; \
-	test -z "$$error"
+	test -z "$$error" ; \
+	echo "All checks passed successfully"
 
 .PHONY: hs-test-%
 hs-test-%: test/hs/htest


### PR DESCRIPTION
This PR will add `make check-local` to the Github Actions workflow - hence add additional checks which uncover release-critical errors.

The NEWS file in the current master does not pass this test, but a fixed one is on its way with the `prepare-3.0` branch. Once that has been merged, I will rebase this PR.

Until then, reviews are welcome :-) 