### PR TITLE
KVM: fix regression breaking migrations

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -2561,9 +2561,9 @@ class KVMHypervisor(hv_base.BaseHypervisor):
         instance.hvparams[constants.HV_MIGRATION_DOWNTIME])
 
     migration_caps = instance.hvparams[constants.HV_KVM_MIGRATION_CAPS]
-    migration_caps = migration_caps.split(_MIGRATION_CAPS_DELIM)
     if migration_caps:
-      self.qmp.SetMigrationCapabilities(migration_caps)
+      migration_caps_list = migration_caps.split(_MIGRATION_CAPS_DELIM)
+      self.qmp.SetMigrationCapabilities(migration_caps_list)
 
     self.qmp.StartMigration(target, port)
 


### PR DESCRIPTION
Commit 034b22c0 tried to break a long line and as a result ended up breaking live migrations, since `''.split(':')` is always true. Split the migration capabilities inside the conditional and use a different
variable name for clarity.