### PR TITLE
Ubuntu 18.04 compatibility

### DIFF
--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -45,7 +45,7 @@ library
     , array                         >= 0.4.0.0
     , bytestring                    >= 0.9.2.1
     , containers                    >= 0.4.2.1
-    , cryptonite                    >= 0.25
+    , cryptonite                    >= 0.23
     , deepseq                       >= 1.3.0.0
     , directory                     >= 1.1.0.2
     , filepath                      >= 1.3.0.0

--- a/src/Ganeti/Query/Exec.hs
+++ b/src/Ganeti/Query/Exec.hs
@@ -75,6 +75,7 @@ import Ganeti.OpCodes
 import qualified Ganeti.Path as P
 import Ganeti.Types
 import Ganeti.UDSServer
+import Ganeti.Compat (getPid')
 
 connectConfig :: ConnectConfig
 connectConfig = ConnectConfig { recvTmo    = 30
@@ -116,7 +117,7 @@ spawnJobProcess jid = withErrorLogAt CRITICAL (show jid) $
         close_fds = True}
 
     (_, _, _, hchild) <- createProcess jobProc
-    pid <- getPid hchild
+    pid <- getPid' hchild
 
     return (fromJust pid, master)
 


### PR DESCRIPTION
This PR addresses building Ganeti-3.0 from source on Ubuntu 18.04 (Bionic). Therefore two things need to be done:

### lower dependency of cryptonite to 0.23
Ubuntu 18.04 ships with Haskell library cryptonite-0.23, where Debain Buster ships 0.25. It is assumed, that there is no explicit dependency for the Buster version.

### support Haskell process before 1.6.3
Commit 219b2ab9 moves away from unreliable forkProcess to System.Process.createProcess and friends. The process library >=1.6.3 introduced the getPid function ([see here](https://hackage.haskell.org/package/process-1.6.3.0/changelog)), which is used in the mentioned commit: https://github.com/ganeti/ganeti/blob/bdeeccedd4cdeec5bee40145e71b876f427e1109/src/Ganeti/Query/Exec.hs#L119 On Ubuntu 18.04 there is only process-1.4.3 available. This PR introduces a wrapper function, that conditionally switches to an included implementation, if process is < 1.6.3

This will support Ganeti-3.0 builds from source on Ubuntu 18.04 (Bionic). ATM it is unknown if this PR would pass qa-suite on Ubuntu-18.04. At least it compiles and passes unit tests.

Because I'm a total Haskell moron, review should be done by an Haskell expert. I used copy&paste like methods (from [original code](https://github.com/haskell/process/pull/109/files)) + trail and error, not understanding much of the syntax/concepts.

Everybody is invited to discuss, whether to support build from source on Ubuntu 18.04 or not. It should be mentioned, that users already tried to build Ganeti-3.0 on Ubuntu 18.04 (see #1452).