### PR TITLE
Python 3.8 compatibility

### DIFF
--- a/test/py/ganeti.cli_unittest.py
+++ b/test/py/ganeti.cli_unittest.py
@@ -1135,7 +1135,7 @@ class TestFormatPolicyInfo(unittest.TestCase):
       ]:
       self._RenameDictItem(parsed, pretty, raw)
     for minmax in parsed[constants.ISPECS_MINMAX]:
-      for key in minmax:
+      for key in set(minmax.keys()):
         keyparts = key.split("/", 1)
         if len(keyparts) > 1:
           self._RenameDictItem(minmax, key, keyparts[0])

--- a/test/py/ganeti.objects_unittest.py
+++ b/test/py/ganeti.objects_unittest.py
@@ -543,7 +543,7 @@ class TestInstancePolicy(unittest.TestCase):
     bad_ipolicy = copy.deepcopy(good_ipolicy)
     for minmax in bad_ipolicy[constants.ISPECS_MINMAX]:
       for (key, spec) in minmax.items():
-        for param in spec:
+        for param in set(spec.keys()):
           oldv = spec[param]
           del spec[param]
           self._AssertPolicyIsBad(bad_ipolicy)
@@ -554,7 +554,7 @@ class TestInstancePolicy(unittest.TestCase):
     assert bad_ipolicy == good_ipolicy
 
     stdspec = bad_ipolicy[constants.ISPECS_STD]
-    for param in stdspec:
+    for param in set(stdspec.keys()):
       oldv = stdspec[param]
       del stdspec[param]
       self._AssertPolicyIsBad(bad_ipolicy, True)

--- a/test/py/ganeti.serializer_unittest.py
+++ b/test/py/ganeti.serializer_unittest.py
@@ -202,11 +202,11 @@ class TestPrivate(unittest.TestCase):
     pDict = serializer.PrivateDict()
     pDict["bar"] = "egg"
 
-    self.assertTrue("egg" is pDict["bar"].Get(),
+    self.assertTrue("egg" == pDict["bar"].Get(),
                     "Value not returned by Private.Get()")
-    self.assertTrue("egg" is pDict.GetPrivate("bar"),
+    self.assertTrue("egg" == pDict.GetPrivate("bar"),
                     "Value not returned by Private.GetPrivate()")
-    self.assertTrue("egg" is pDict.Unprivate()["bar"],
+    self.assertTrue("egg" == pDict.Unprivate()["bar"],
                     "Value not returned by PrivateDict.Unprivate()")
 
     json = serializer.Dump(pDict,
@@ -215,7 +215,7 @@ class TestPrivate(unittest.TestCase):
 
   def testDictGet(self):
     result = serializer.PrivateDict().GetPrivate("bar", "tar")
-    self.assertTrue("tar" is result,
+    self.assertTrue("tar" == result,
                     "Private.GetPrivate() did not handle the default case")
 
   def testZeronessPrivate(self):


### PR DESCRIPTION
A couple of our tests break with Python 3.8, due to:
 - ElementTree changing the serialized output, by sorting attributes by insertion rather than by name (https://bugs.python.org/issue34160)
 - Python 3.8 detecting previously-undetected corner-cases of in-loop dictionary modifications (https://bugs.python.org/issue36452)

Fix these cases by adapting the code in a backwards-compatible manner.

While at it, also fix a `SyntaxWarning` caused by using `is` to compare string literals.

This fixes #1476 