### PR TITLE
Relax QuickCheck version restriction

### DIFF
--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -85,7 +85,7 @@ library
   if flag(htest)
     build-depends:
         HUnit                         >= 1.2.4.2    && < 1.7
-      , QuickCheck                    >= 2.8        && < 2.13
+      , QuickCheck                    >= 2.8        && < 2.14
       , test-framework                >= 0.6        && < 0.9
       , test-framework-hunit          >= 0.2.7      && < 0.4
       , test-framework-quickcheck2    >= 0.2.12.1   && < 0.4


### PR DESCRIPTION
Hi!  Long time user, first time contributor.  All tests pass with QuickCheck 2.13.2 which happens to be current on my distro, so bump the version range accordingly.