### PR TITLE
don't print double newline

### DIFF
--- a/autotools/docpp
+++ b/autotools/docpp
@@ -56,7 +56,7 @@ def main():
       for i in builder(fields):
         print(i)
     else:
-      print(line)
+      print(line, end='')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
According to [[1](https://docs.python.org/2/library/fileinput.html)][[2](https://docs.python.org/3/library/fileinput.html)] "Lines are returned with any newlines intact" in `fileinput.input()`. During the python3 migration everything changed to the `print()` function (see commit 2802400e9b). For some reason, this behaves differently regarding the newlines. Instruct `print()` here to explicitly end with an empty string.

This fixes #1485 and partially #1453.