### PR TITLE
Fix sphinx 'manpage' role

### DIFF
--- a/lib/build/sphinx_ext.py
+++ b/lib/build/sphinx_ext.py
@@ -360,6 +360,7 @@ def _ManPageNodeClass(*args, **kwargs):
 
   # Force custom title
   kwargs["refexplicit"] = True
+  kwargs["refdomain"] = None
 
   return sphinx.addnodes.pending_xref(*args, **kwargs)
 


### PR DESCRIPTION
The 'manpage' role is broken since sphinx 1.6 due to an internal change. This fixes #1453 by triggering sphinx's own handling for this change.