### PR TITLE
Copy hmac.key to new nodes

### DIFF
--- a/lib/bootstrap.py
+++ b/lib/bootstrap.py
@@ -934,6 +934,8 @@ def SetupNodeDaemon(opts, cluster_name, node, ssh_port):
     constants.NDS_CLUSTER_NAME: cluster_name,
     constants.NDS_NODE_DAEMON_CERTIFICATE:
       utils.ReadFile(pathutils.NODED_CERT_FILE),
+    constants.NDS_HMAC:
+      utils.ReadFile(pathutils.CONFD_HMAC_KEY),
     constants.NDS_SSCONF: ssconf.SimpleStore().ReadAll(),
     constants.NDS_START_NODE_DAEMON: True,
     constants.NDS_NODE_NAME: node,

--- a/lib/tools/common.py
+++ b/lib/tools/common.py
@@ -184,6 +184,19 @@ def VerifyClusterName(data, error_fn, cluster_name_constant,
   return name
 
 
+def VerifyHmac(data, error_fn):
+  """Verifies the presence of the hmac secret.
+
+  @type data: dict
+
+  """
+  hmac = data.get(constants.NDS_HMAC)
+  if not hmac:
+    raise error_fn("Hmac key must be provided")
+
+  return hmac
+
+
 def LoadData(raw, data_check):
   """Parses and verifies input data.
 

--- a/lib/tools/node_daemon_setup.py
+++ b/lib/tools/node_daemon_setup.py
@@ -51,6 +51,7 @@ from ganeti.tools import common
 _DATA_CHECK = ht.TStrictDict(False, True, {
   constants.NDS_CLUSTER_NAME: ht.TNonEmptyString,
   constants.NDS_NODE_DAEMON_CERTIFICATE: ht.TNonEmptyString,
+  constants.NDS_HMAC: ht.TNonEmptyString,
   constants.NDS_SSCONF: ht.TDictOf(ht.TNonEmptyString, ht.TString),
   constants.NDS_START_NODE_DAEMON: ht.TBool,
   constants.NDS_NODE_NAME: ht.TString,
@@ -127,10 +128,17 @@ def Main():
     cluster_name = common.VerifyClusterName(data, SetupError,
                                             constants.NDS_CLUSTER_NAME)
     cert_pem = common.VerifyCertificateStrong(data, SetupError)
+    hmac_key = common.VerifyHmac(data, SetupError)
     ssdata = VerifySsconf(data, cluster_name)
 
     logging.info("Writing ssconf files ...")
     ssconf.WriteSsconfFiles(ssdata, dry_run=opts.dry_run)
+
+    logging.info("Writing hmac.key ...")
+    utils.WriteFile(pathutils.CONFD_HMAC_KEY, data=hmac_key,
+                    mode=pathutils.NODED_CERT_MODE,
+                    uid=getent.masterd_uid, gid=getent.masterd_gid,
+                    dry_run=opts.dry_run)
 
     logging.info("Writing node daemon certificate ...")
     utils.WriteFile(pathutils.NODED_CERT_FILE, data=cert_pem,

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -4833,6 +4833,9 @@ ndsNodeDaemonCertificate = "node_daemon_certificate"
 ndsSsconf :: String
 ndsSsconf = "ssconf"
 
+ndsHmac :: String
+ndsHmac = "hmac_key"
+
 ndsStartNodeDaemon :: String
 ndsStartNodeDaemon = "start_node_daemon"
 


### PR DESCRIPTION
Hello,

This is a cherry-pick of three commits (c99ad7bd9c84b134050ed5d0ae47b65708aa0fa6, ab9210123b4d89989da3b18b743c0472516f986c, 4f3b03037db26f7634ac493365d8679a9746475e) from stable-2.17 that went missing as part of #1328.  They are marked as TODO in https://github.com/ganeti/ganeti/wiki/AtticMasterCherrypicks.

It fixes #1182 (again).