### PR TITLE
Open vSwitch: Do not fail to add node when the ovs_name or ovs_link already exists

### DIFF
--- a/lib/backend.py
+++ b/lib/backend.py
@@ -5865,14 +5865,14 @@ def ConfigureOVS(ovs_name, ovs_link):
 
   """
   # Initialize the OpenvSwitch
-  result = utils.RunCmd(["ovs-vsctl", "add-br", ovs_name])
+  result = utils.RunCmd(["ovs-vsctl", "--may-exist", "add-br", ovs_name])
   if result.failed:
     _Fail("Failed to create openvswitch. Script return value: %s, output: '%s'"
           % (result.exit_code, result.output), log=True)
 
   # And connect it to a physical interface, if given
   if ovs_link:
-    result = utils.RunCmd(["ovs-vsctl", "add-port", ovs_name, ovs_link])
+    result = utils.RunCmd(["ovs-vsctl", "--may-exist", "add-port", ovs_name, ovs_link])
     if result.failed:
       _Fail("Failed to connect openvswitch to  interface %s. Script return"
             " value: %s, output: '%s'" % (ovs_link, result.exit_code,


### PR DESCRIPTION
`gnt-node add` will unconditionally attempt to create the switch and connect the uplink specified in the node group.  It is possible that the switch is already configured by external tools.  This PR makes it not fail when that is the case.