### PR TITLE
Cabal 3.0 compatibility

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1395,7 +1395,8 @@ HASKELL_PACKAGE_VERSIONS_FILE = cabal_macros.h
 $(HASKELL_PACKAGE_VERSIONS_FILE): Makefile ganeti.cabal \
                                   cabal/CabalDependenciesMacros.hs
 	touch empty-cabal-config
-	$(CABAL) --config-file=empty-cabal-config configure --user \
+	$(CABAL) --config-file=empty-cabal-config \
+	  $(CABAL_CONFIGURE_CMD) --user \
 	  -f`test $(HTEST) == yes && echo "htest" || echo "-htest"` \
 	  -f`test $(ENABLE_MOND) == True && echo "mond" || echo "-mond"` \
 	  -f`test $(ENABLE_METADATA) == True && echo "metad" || echo "-metad"`

--- a/cabal/CabalDependenciesMacros.hs
+++ b/cabal/CabalDependenciesMacros.hs
@@ -5,7 +5,14 @@ import Control.Applicative
 import qualified Data.Set as Set
 import qualified Distribution.Simple.Build.Macros as Macros
 import Distribution.Simple.Configure (getPersistBuildConfig)
+#if MIN_VERSION_Cabal(3,0,0)
+import Distribution.Types.UnitId (UnitId)
+import Distribution.Types.MungedPackageId (MungedPackageId)
+import Distribution.Types.ComponentLocalBuildInfo (componentPackageDeps, componentUnitId)
+import Data.List (nub)
+#else
 import Distribution.Simple.LocalBuildInfo (externalPackageDeps)
+#endif
 import Distribution.PackageDescription (packageDescription)
 
 -- Common Cabal 2.x dependencies
@@ -28,6 +35,26 @@ import System.Environment (getArgs)
 
 #if !MIN_VERSION_Cabal(2,0,0)
 readGenericPackageDescription = readPackageDescription
+#endif
+
+#if MIN_VERSION_Cabal(3,0,0)
+generate = Macros.generateCabalMacrosHeader
+#else
+generate = Macros.generate
+#endif
+
+#if MIN_VERSION_Cabal(3,0,0)
+externalPackageDeps :: LocalBuildInfo.LocalBuildInfo -> [(UnitId, MungedPackageId)]
+externalPackageDeps lbi =
+    nub [ (ipkgid, pkgid)
+        | clbi            <- clbis
+        , (ipkgid, pkgid) <- componentPackageDeps clbi
+        , not (internal ipkgid) ]
+  where
+    -- True if this dependency is an internal one (depends on the library
+    -- defined in the same package).
+    internal ipkgid = any ((==ipkgid) . componentUnitId) clbis
+    clbis = Graph.toList $ LocalBuildInfo.componentGraph lbi
 #endif
 
 main :: IO ()
@@ -56,7 +83,7 @@ main = do
   case clbi' of
      Nothing -> error "Unable to read componentLocalBuildInfo for the library"
      Just clbi -> do
-      writeFile macrosPath $ Macros.generate pkgDesc conf clbi
+      writeFile macrosPath $ generate pkgDesc conf clbi
 #else
-  writeFile macrosPath $ Macros.generate pkgDesc conf
+  writeFile macrosPath $ generate pkgDesc conf
 #endif

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -1,5 +1,5 @@
 name:                ganeti
-version:             2.16
+version:             2.99
 homepage:            http://www.ganeti.org
 license:             BSD2
 license-file:        COPYING

--- a/configure.ac
+++ b/configure.ac
@@ -672,6 +672,15 @@ if test -z "$CABAL"; then
   AC_MSG_FAILURE([cabal not found, compilation will not be possible])
 fi
 
+AC_MSG_CHECKING([for the appropriate cabal configure command])
+if $CABAL --help 2>&1 | grep -qw v1-configure; then
+  CABAL_CONFIGURE_CMD="v1-configure"
+else
+  CABAL_CONFIGURE_CMD="configure"
+fi
+AC_MSG_RESULT($CABAL_CONFIGURE_CMD)
+AC_SUBST(CABAL_CONFIGURE_CMD)
+
 # check for standard modules
 AC_GHC_PKG_REQUIRE(Cabal)
 AC_GHC_PKG_REQUIRE(curl)


### PR DESCRIPTION
This PR adds compatibility with Cabal 3.0 by adapting to Cabal API and command-line changes. You can see #1492 for details and links, but it basically boils down to:

 - inlining  `Distribution.Simple.LocalBuildInfo.externalPackageDeps` which was removed upstream
 - detecting and using the `v1-configure` command rather than plain `configure` which now does a NIX-style build
 - handling some renamed functions.

Closes #1492.