### PR TITLE
Fix pygments highlighting in design-impext2.rst.

### DIFF
--- a/doc/design-impexp2.rst
+++ b/doc/design-impexp2.rst
@@ -512,6 +512,8 @@ second. The second line in each row is the CPU time spent in userland
 respective system (measured for the CGI/FastCGI program using ``time
 -v``).
 
+.. highlight:: none
+
 ::
 
   ----------------------------------------------------------------------


### PR DESCRIPTION
Greetings,

When trying to rebuild the manuals from scratch, I hit a (fatal) warning from the Sphinx/pygments parser.  It tries parsing a code block from `design-impexp2.rst` as Python code, and fails because it is not actually Python code.

Explicitly mark the block with `highlight: none` to avoid parsing it as Python.