### PR TITLE
Expose disk size to OS install scripts.

### DIFF
--- a/lib/backend.py
+++ b/lib/backend.py
@@ -4305,6 +4305,7 @@ def OSEnvironment(instance, inst_os, debug=0):
     uri = _CalculateDeviceURI(instance, disk, real_disk)
     result["DISK_%d_ACCESS" % idx] = disk.mode
     result["DISK_%d_UUID" % idx] = disk.uuid
+    result["DISK_%d_SIZE" % idx] = str(disk.size)
     if real_disk.dev_path:
       result["DISK_%d_PATH" % idx] = real_disk.dev_path
     if uri:

--- a/man/ganeti-os-interface.rst
+++ b/man/ganeti-os-interface.rst
@@ -73,6 +73,9 @@ DISK_%N_PATH
     ``DISK_0_PATH=/dev/drbd0``. If the disk is only accessible via a
     userspace URI, this not be set.
 
+DISK_%N_SIZE
+    The configured size of disk N in mebibytes (available since Ganeti 3.0).
+
 DISK_%N_URI
     The userspace URI to the storage for disk N of the instance, if
     configured.


### PR DESCRIPTION
Hi,

This is a minor change to the OS API which allows OS providers to query the configured disk size.  It is useful for providers such as [instance-guix](https://github.com/mbakke/ganeti-instance-guix) which creates a disk image outside of Ganeti (no chroot etc) and copies it into place.  In particular, it is needed to reinstall file disks, but also to work with different storage providers without needing intimate knowledge of how to query the size.