### PR TITLE
Make gnt-cluster.8 manual page generation deterministic.

### DIFF
--- a/lib/build/sphinx_ext.py
+++ b/lib/build/sphinx_ext.py
@@ -108,7 +108,7 @@ CV_ECODES_DOC = "ecodes"
 # pylint: disable=W0621
 CV_ECODES_DOC_LIST = [(name, doc) for (_, name, doc) in constants.CV_ALL_ECODES]
 DOCUMENTED_CONSTANTS = {
-  CV_ECODES_DOC: CV_ECODES_DOC_LIST,
+  CV_ECODES_DOC: sorted(CV_ECODES_DOC_LIST, key=lambda tup: tup[0]),
   }
 
 


### PR DESCRIPTION
This PR sorts the ecode entries in `gnt-cluster(8)` by name.  In addition to being more human-friendly, this one-line change incidentally makes the Ganeti build process [reproducible](https://reproducible-builds.org/).