### PR TITLE
CI: use docker images from GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [bionic, buster, focal, debian-testing]
     container:
-      image: ganeti/ci:${{ matrix.os }}-py3
+      image: ${{ github.actor }}:${{ github.token }}@docker.pkg.github.com/ganeti/ci-images/${{ matrix.os }}:latest
       options: "--init"
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Our CI images now live on GitHub (https://github.com/ganeti/ci-images) and are automatically published to
GitHub Packages. Change the CI workflow to use these images instead of
the ones on DockerHub.