### PR TITLE
Add configuration option for the rbd user id

### DIFF
--- a/doc/design-ceph-ganeti-support.rst
+++ b/doc/design-ceph-ganeti-support.rst
@@ -72,11 +72,20 @@ scripts.
 
 Updated commands
 ----------------
-::
-  $ gnt-instance info
+
+The following are the affected commands::
+
+ $ gnt-instance info
 
 ``access:userspace/kernelspace`` will be added to Disks category. This
-output applies to KVM based instances only.
+output applies to KVM based instances only::
+
+  $ gnt-cluster modify -D rbd:user-id=foobar
+
+The user id for ceph authentication is an optional setting. If it is not
+provided, then no special option is passed to ceph. If it is provided,
+then all ceph commands are run with the ``--user`` option and the
+configured username.
 
 Ceph configuration on Ganeti nodes
 ==================================
@@ -124,17 +133,17 @@ appropriate services on the newly assigned node.
 Updated Commands
 ----------------
 
-Following are the affected commands.::
+Following are the affected commands::
 
   $ gnt-cluster init -S ceph:disk=/dev/sdb,option=value...
 
 During cluster initialization, ceph specific options are provided which
-apply at cluster-level.::
+apply at cluster-level::
 
   $ gnt-cluster modify -S ceph:option=value2...
 
 For now, cluster modification will be allowed when there is no
-initialized storage cluster.::
+initialized storage cluster::
 
   $ gnt-storage init-distributed-storage -s{--storage-type} ceph \
     <node-group>
@@ -142,18 +151,18 @@ initialized storage cluster.::
 Ensure that no other node-group is configured as distributed storage
 cluster and configure ceph on the specified node-group. If there is no
 node in the node-group, it'll only be marked as distributed storage
-enabled and no action will be taken.::
+enabled and no action will be taken::
 
   $ gnt-group assign-nodes <group> <node>
 
 It ensures that the node is offline if the node-group specified is
 distributed storage capable. Ceph configuration on the newly assigned
-node is not performed at this step.::
+node is not performed at this step::
 
   $ gnt-node --offline
 
 If the node is part of storage node-group, an offline call will stop/remove
-ceph daemons.::
+ceph daemons::
 
   $ gnt-node add --readd
 

--- a/lib/storage/bdev.py
+++ b/lib/storage/bdev.py
@@ -903,8 +903,8 @@ class RADOSBlockDevice(base.BlockDev):
     rbd_name = unique_id[1]
 
     # Provision a new rbd volume (Image) inside the RADOS cluster.
-    cmd = [constants.RBD_CMD, "create", "-p", rbd_pool,
-           rbd_name, "--size", "%s" % size]
+    cmd = cls.MakeRbdCmd(params, ["create", "-p", rbd_pool, rbd_name,
+                                  "--size", str(size)])
     result = utils.RunCmd(cmd)
     if result.failed:
       base.ThrowError("rbd creation failed (%s): %s",
@@ -928,7 +928,8 @@ class RADOSBlockDevice(base.BlockDev):
     self.Shutdown()
 
     # Remove the actual Volume (Image) from the RADOS cluster.
-    cmd = [constants.RBD_CMD, "rm", "-p", rbd_pool, rbd_name]
+    cmd = self.__class__.MakeRbdCmd(self.params, ["rm", "-p", rbd_pool,
+                                                  rbd_name])
     result = utils.RunCmd(cmd)
     if result.failed:
       base.ThrowError("Can't remove Volume from cluster with rbd rm: %s - %s",
@@ -968,6 +969,16 @@ class RADOSBlockDevice(base.BlockDev):
 
     return True
 
+  @classmethod
+  def MakeRbdCmd(cls, params, cmd):
+    """Add user id option to rbd command if configured.
+
+    """
+    if params.get(constants.RBD_USER_ID, ""):
+      r_cmd.extend(["--id", str(params[constants.RBD_USER_ID])])
+
+    return [constants.RBD_CMD] + cmd
+
   def _MapVolumeToBlockdev(self, unique_id):
     """Maps existing rbd volumes to block devices.
 
@@ -987,7 +998,7 @@ class RADOSBlockDevice(base.BlockDev):
       return rbd_dev
 
     # The mapping doesn't exist. Create it.
-    map_cmd = [constants.RBD_CMD, "map", "-p", pool, name]
+    map_cmd = self.__class__.MakeRbdCmd(self.params, ["map", "-p", pool, name])
     result = utils.RunCmd(map_cmd)
     if result.failed:
       base.ThrowError("rbd map failed (%s): %s",
@@ -1017,12 +1028,7 @@ class RADOSBlockDevice(base.BlockDev):
     try:
       # Newer versions of the rbd tool support json output formatting. Use it
       # if available.
-      showmap_cmd = [
-        constants.RBD_CMD,
-        "showmapped",
-        "--format",
-        "json"
-        ]
+      showmap_cmd = cls.MakeRbdCmd({}, ["showmapped", "--format", "json"])
       result = utils.RunCmd(showmap_cmd)
       if result.failed:
         logging.error("rbd JSON output formatting returned error (%s): %s,"
@@ -1034,7 +1040,7 @@ class RADOSBlockDevice(base.BlockDev):
     except RbdShowmappedJsonError:
       # For older versions of rbd, we have to parse the plain / text output
       # manually.
-      showmap_cmd = [constants.RBD_CMD, "showmapped", "-p", pool]
+      showmap_cmd = cls.MakeRbdCmd({}, ["showmapped", "-p", pool])
       result = utils.RunCmd(showmap_cmd)
       if result.failed:
         base.ThrowError("rbd showmapped failed (%s): %s",
@@ -1176,7 +1182,8 @@ class RADOSBlockDevice(base.BlockDev):
 
     if rbd_dev:
       # The mapping exists. Unmap the rbd device.
-      unmap_cmd = [constants.RBD_CMD, "unmap", "%s" % rbd_dev]
+      unmap_cmd = self.__class__.MakeRbdCmd(self.params, ["unmap",
+                                                          str(rbd_dev)])
       result = utils.RunCmd(unmap_cmd)
       if result.failed:
         base.ThrowError("rbd unmap failed (%s): %s",
@@ -1220,8 +1227,9 @@ class RADOSBlockDevice(base.BlockDev):
     new_size = self.size + amount
 
     # Resize the rbd volume (Image) inside the RADOS cluster.
-    cmd = [constants.RBD_CMD, "resize", "-p", rbd_pool,
-           rbd_name, "--size", "%s" % new_size]
+    cmd = self.__class__.MakeRbdCmd(self.params, ["resize", "-p", rbd_pool,
+                                                  rbd_name, "--size",
+                                                  "%s" % new_size])
     result = utils.RunCmd(cmd)
     if result.failed:
       base.ThrowError("rbd resize failed (%s): %s",
@@ -1256,16 +1264,16 @@ class RADOSBlockDevice(base.BlockDev):
     self._UnmapVolumeFromBlockdev(self.unique_id)
 
     # Remove the actual Volume (Image) from the RADOS cluster.
-    cmd = [constants.RBD_CMD, "rm", "-p", rbd_pool, rbd_name]
+    cmd = self.__class__.MakeRbdCmd(self.params, ["rm", "-p", rbd_pool,
+                                                  rbd_name])
     result = utils.RunCmd(cmd)
     if result.failed:
       base.ThrowError("Can't remove Volume from cluster with rbd rm: %s - %s",
                       result.fail_reason, result.output)
 
     # We use "-" for importing from stdin
-    return [constants.RBD_CMD, "import",
-            "-p", rbd_pool,
-            "-", rbd_name]
+    return self.__class__.MakeRbdCmd(self.params, ["import", "-p", rbd_pool,
+                                                   "-", rbd_name])
 
   def Export(self):
     """Builds the shell command for exporting data from device.
@@ -1281,9 +1289,8 @@ class RADOSBlockDevice(base.BlockDev):
     rbd_name = self.unique_id[1]
 
     # We use "-" for exporting to stdout.
-    return [constants.RBD_CMD, "export",
-            "-p", rbd_pool,
-            rbd_name, "-"]
+    return self.__class__.MakeRbdCmd(self.params, ["export", "-p", rbd_pool,
+                                                   rbd_name, "-"])
 
   def GetUserspaceAccessUri(self, hypervisor):
     """Generate KVM userspace URIs to be used as `-drive file` settings.
@@ -1292,7 +1299,10 @@ class RADOSBlockDevice(base.BlockDev):
 
     """
     if hypervisor == constants.HT_KVM:
-      return "rbd:" + self.rbd_pool + "/" + self.rbd_name
+      uri = "rbd:" + self.rbd_pool + "/" + self.rbd_name
+      if self.params.get(constants.RBD_USER_ID, ""):
+        uri += ":id=%s" % self.params[constants.RBD_USER_ID]
+      return uri
     else:
       base.ThrowError("Hypervisor %s doesn't support RBD userspace access" %
                       hypervisor)

--- a/man/gnt-cluster.rst
+++ b/man/gnt-cluster.rst
@@ -503,6 +503,10 @@ access
     Attempts to use this feature without rbd support compiled in KVM
     result in a "no such file or directory" error messages.
 
+user-id
+    The user id is used by ceph to determine the keyring to use for
+    authentication. By default the admin keyring is used.
+
 .. _deadlocks: http://tracker.ceph.com/issues/3076
 
 The option ``--maintain-node-health`` allows one to enable/disable

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -2303,6 +2303,9 @@ ldpPlanAhead = "c-plan-ahead"
 ldpPool :: String
 ldpPool = "pool"
 
+ldpUserId :: String
+ldpUserId = "user-id"
+
 ldpProtocol :: String
 ldpProtocol = "protocol"
 
@@ -2330,7 +2333,8 @@ diskLdTypes =
    (ldpDelayTarget, VTypeInt),
    (ldpMaxRate, VTypeInt),
    (ldpMinRate, VTypeInt),
-   (ldpPool, VTypeString)]
+   (ldpPool, VTypeString),
+   (ldpUserId, VTypeString)]
 
 diskLdParameters :: FrozenSet String
 diskLdParameters = ConstantUtils.mkSet (Map.keys diskLdTypes)
@@ -2391,6 +2395,9 @@ lvStripes = "stripes"
 rbdAccess :: String
 rbdAccess = "access"
 
+rbdUserId :: String
+rbdUserId = "user-id"
+
 rbdPool :: String
 rbdPool = "pool"
 
@@ -2413,6 +2420,7 @@ diskDtTypes =
                 (drbdMinRate, VTypeInt),
                 (lvStripes, VTypeInt),
                 (rbdAccess, VTypeString),
+                (rbdUserId, VTypeString),
                 (rbdPool, VTypeString),
                 (glusterHost, VTypeString),
                 (glusterVolume, VTypeString),
@@ -4229,6 +4237,9 @@ defaultPlanAhead = 20
 defaultRbdPool :: String
 defaultRbdPool = "rbd"
 
+defaultRbdUserId :: String
+defaultRbdUserId = ""
+
 diskLdDefaults :: Map DiskTemplate (Map String PyValueEx)
 diskLdDefaults =
   Map.fromList
@@ -4255,11 +4266,13 @@ diskLdDefaults =
   , (DTPlain, Map.fromList [(ldpStripes, PyValueEx lvmStripecount)])
   , (DTRbd, Map.fromList
             [ (ldpPool, PyValueEx defaultRbdPool)
+            , (ldpUserId, PyValueEx defaultRbdUserId)
             , (ldpAccess, PyValueEx diskKernelspace)
             ])
   , (DTSharedFile, Map.empty)
   , (DTGluster, Map.fromList
                 [ (rbdAccess, PyValueEx diskKernelspace)
+                , (rbdUserId, PyValueEx defaultRbdUserId)
                 , (glusterHost, PyValueEx glusterHostDefault)
                 , (glusterVolume, PyValueEx glusterVolumeDefault)
                 , (glusterPort, PyValueEx glusterPortDefault)
@@ -4290,16 +4303,19 @@ diskDtDefaults =
                    ])
   , (DTExt,        Map.fromList
                    [ (rbdAccess, PyValueEx diskKernelspace)
+                   , (rbdUserId, PyValueEx defaultRbdUserId)
                    ])
   , (DTFile,       Map.empty)
   , (DTPlain,      Map.fromList [(lvStripes, PyValueEx lvmStripecount)])
   , (DTRbd,        Map.fromList
                    [ (rbdPool, PyValueEx defaultRbdPool)
                    , (rbdAccess, PyValueEx diskKernelspace)
+                   , (rbdUserId, PyValueEx defaultRbdUserId)
                    ])
   , (DTSharedFile, Map.empty)
   , (DTGluster, Map.fromList
                 [ (rbdAccess, PyValueEx diskKernelspace)
+                , (rbdUserId, PyValueEx defaultRbdUserId)
                 , (glusterHost, PyValueEx glusterHostDefault)
                 , (glusterVolume, PyValueEx glusterVolumeDefault)
                 , (glusterPort, PyValueEx glusterPortDefault)

--- a/test/py/cmdlib/cluster_unittest.py
+++ b/test/py/cmdlib/cluster_unittest.py
@@ -459,7 +459,8 @@ class TestLUClusterSetParams(CmdlibTestCase):
 
   def testValidDiskparams(self):
     diskparams = {constants.DT_RBD: {constants.RBD_POOL: "mock_pool",
-                                     constants.RBD_ACCESS: "kernelspace"}}
+                                     constants.RBD_ACCESS: "kernelspace",
+                                     constants.RBD_USER_ID: "mock_user"}}
     op = opcodes.OpClusterSetParams(diskparams=diskparams)
     self.ExecOpCode(op)
     self.assertEqual(diskparams[constants.DT_RBD],


### PR DESCRIPTION
The user id is used by ceph to determine the keyring to use for
authentication. By default the admin keyring is used, which may
not be desirable. Example usage:

$ gnt-cluster modify -D rbd:user-id=foobar

Originally in b7a0ddeb82e24a1d401ee0eb52f2c00f4c656990 and
aa50df98af5c938c0f38bafd31532bc2d7e36e46 but those changes went missing
in some failed merge I suppose.

Signed-off-by: Oleander Reis <oleander.reis@hostserver.de>