### PR TITLE
Do not override disk_cache settings for RBD disks

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -1173,7 +1173,8 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     # Cache mode
     disk_cache = up_hvp[constants.HV_DISK_CACHE]
     for cfdev, link_name, uri in kvm_disks:
-      if cfdev.dev_type in constants.DTS_EXT_MIRROR:
+      if (cfdev.dev_type in constants.DTS_EXT_MIRROR
+          and cfdev.dev_type != constants.DT_RBD):
         if disk_cache != "none":
           # TODO: make this a hard error, instead of a silent overwrite
           logging.warning("KVM: overriding disk_cache setting '%s' with 'none'"


### PR DESCRIPTION
Currently disk_cache settings other than none will be overridden to
none. RBD is considered safe and well behaved when it comes to
live migration and other cache sensitive issues.

Fixes #822.

Signed-off-by: Oleander Reis <oleander.reis@hostserver.de>