### PR TITLE
don't expose RAPI to public w/o password

### DIFF
--- a/doc/examples/ganeti.default
+++ b/doc/examples/ganeti.default
@@ -1,6 +1,6 @@
 # Default arguments for Ganeti daemons
 NODED_ARGS=""
-RAPI_ARGS=""
+RAPI_ARGS="-b 127.0.0.1 --require-authentication"
 CONFD_ARGS=""
 MOND_ARGS=""
 WCONFD_ARGS=""


### PR DESCRIPTION
This binds the RAPI port to localhost and requires always authentication, so that no information can be leaked by default. This is what [Debian packaging does](https://salsa.debian.org/ganeti-team/ganeti/-/blob/master/debian/rules#L111-112).

Signed-off-by: Sascha Lucas <sascha_lucas@web.de>