### PR TITLE
htest: use printable unicode ByteStrings

### DIFF
--- a/test/hs/Test/Ganeti/Objects.hs
+++ b/test/hs/Test/Ganeti/Objects.hs
@@ -91,7 +91,7 @@ instance Arbitrary (Container DataCollectorConfig) where
       fromContainer = Map.fromList $ zip names configs }
 
 instance Arbitrary BS.ByteString where
-  arbitrary = fmap UTF8.fromString arbitrary
+  arbitrary = genPrintableByteString
 
 $(genArbitrary ''PartialNDParams)
 

--- a/test/hs/Test/Ganeti/TestCommon.hs
+++ b/test/hs/Test/Ganeti/TestCommon.hs
@@ -56,6 +56,7 @@ module Test.Ganeti.TestCommon
   , genPrintableAsciiChar
   , genPrintableAsciiString
   , genPrintableAsciiStringNE
+  , genPrintableByteString
   , genName
   , genFQDN
   , genUUID
@@ -101,6 +102,11 @@ import Data.List
 import qualified Data.Map as M
 import Data.Text (pack)
 import Data.Word
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.UTF8 as UTF8
+#if !MIN_VERSION_QuickCheck(2,10,0)
+import Data.Char (isPrint)
+#endif
 import qualified Data.Set as Set
 import System.Directory (getTemporaryDirectory, removeFile)
 import System.Environment (getEnv)
@@ -266,6 +272,14 @@ genPrintableAsciiStringNE :: Gen NonEmptyString
 genPrintableAsciiStringNE = do
   n <- choose (1, 40)
   vectorOf n genPrintableAsciiChar >>= mkNonEmpty
+
+-- | Generates a printable Unicode ByteString
+genPrintableByteString :: Gen BS.ByteString
+#if MIN_VERSION_QuickCheck(2, 10, 0)
+genPrintableByteString = fmap (UTF8.fromString . getPrintableString) arbitrary
+#else
+genPrintableByteString = fmap UTF8.fromString $ listOf (arbitrary `suchThat` isPrint)
+#endif
 
 -- | Generates a single name component.
 genName :: Gen String


### PR DESCRIPTION
For most of the config values, our test suite uses the generic String generator and decodes its output to a ByteString assuming UTF-8 encoding. The String arbitrary instance generates random unicode codepoints, avoiding only surrogate pairs. Unfortunately, as demonstrated in #1506, it also generates "non-characters"[1] that are usually rejected when found in a UTF-8 string, such as U+FFFE:

```Haskell
GHCi, version 8.8.3: https://www.haskell.org/ghc/  :? for help
Prelude> import qualified Data.ByteString.UTF8 as UTF8
Prelude UTF8> UTF8.toString $ UTF8.fromString "\65534"
"\65533"
```

Note how U+FFFE was replaced by the replacement character U+FFFD (�). This behavior breaks the serialization/deserialization tests, causing intermitent build failures.

Our expectations about config objects are that they should be serializable into JSON, and thus should contain valid Unicode text. We take extra care to encode arbitrary binary data, such as the gnt-network bitarrays, exactly because our config file is not a binary data store.

To this end, I believe it makes sense to restrict ByteString generation to printable Unicode strings. Do this using the modifiers introduced in QuickCheck 2.10.

This fixes #1506.

[1] https://en.wikipedia.org/wiki/Universal_Character_Set_characters#Non-characters