### PR TITLE
Fix docs by removing sphinx pre-1.3 support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -646,7 +646,6 @@ docinput = \
 	doc/cluster-keys-replacement.rst \
 	doc/cluster-merge.rst \
 	doc/conf.py \
-	doc/css/style.css \
 	doc/design-2.0.rst \
 	doc/design-2.1.rst \
 	doc/design-2.2.rst \
@@ -1172,11 +1171,6 @@ doc/html/index.html: ENABLE_MANPAGES =
 doc/man-html/index.html: ENABLE_MANPAGES = 1
 doc/man-html/index.html: doc/manpages-enabled.rst $(mandocrst)
 
-if HAS_SPHINX_PRE13
-        SPHINX_HTML_THEME=default
-else
-        SPHINX_HTML_THEME=classic
-endif
 # Note: we use here an order-only prerequisite, as the contents of
 # _constants.py are not actually influencing the html build output: it
 # has to exist in order for the sphinx module to be loaded
@@ -1185,7 +1179,7 @@ endif
 doc/html/index.html doc/man-html/index.html: $(docinput) doc/conf.py \
 	configure.ac $(RUN_IN_TEMPDIR) lib/build/sphinx_ext.py \
 	lib/build/shell_example_lexer.py lib/ht.py \
-	doc/css/style.css lib/rapi/connector.py lib/rapi/rlib2.py \
+	lib/rapi/connector.py lib/rapi/rlib2.py \
 	autotools/sphinx-wrapper | $(built_python_sources)
 	@test -n "$(SPHINX)" || \
 	    { echo 'sphinx-build' not found during configure; exit 1; }
@@ -1204,7 +1198,6 @@ endif
 	dir=$(dir $@) && \
 	@mkdir_p@ $$dir && \
 	PYTHONPATH=. ENABLE_MANPAGES=$(ENABLE_MANPAGES) COPY_DOC=1 \
-        HTML_THEME=$(SPHINX_HTML_THEME) \
 	$(RUN_IN_TEMPDIR) autotools/sphinx-wrapper $(SPHINX) -q -W -b html \
 		-d . \
 		-D version="$(VERSION_MAJOR).$(VERSION_MINOR)" \

--- a/configure.ac
+++ b/configure.ac
@@ -537,9 +537,6 @@ else
   fi
 fi
 AM_CONDITIONAL([HAS_SPHINX], [test -n "$SPHINX"])
-AM_CONDITIONAL([HAS_SPHINX_PRE13],
- [test -n "$SPHINX" && echo "$sphinxver" | grep -q -E \
-  '^Sphinx([[[:space:]]]+|\(sphinx-build[[1-9]]?\)|v)*[[1-9]]\.[[0-2]]\.'])
 
 AC_ARG_ENABLE([manpages-in-doc],
   [AS_HELP_STRING([--enable-manpages-in-doc],

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -114,7 +114,7 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = os.getenv("HTML_THEME")
+html_theme = "classic"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -143,9 +143,7 @@ html_theme = os.getenv("HTML_THEME")
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["css"]
-
-html_style = "style.css"
+html_static_path = []
 
 # If not "", a "Last updated on:" timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/doc/css/style.css
+++ b/doc/css/style.css
@@ -1,5 +1,0 @@
-@import url(default.css);
-
-a {
-  text-decoration: underline;
-}


### PR DESCRIPTION
Currently building documentation is broken (missing style sheet), because `doc/css/style.css` includes default.css:

https://github.com/ganeti/ganeti/blob/f3f033a62c15f63cbc091be9924a2a370c874a39/doc/css/style.css#L1

instead of classic.css, which is the sphinx theme for >=1.3. The commit 268953c4c introduced differentiation between sphinx pre-1.3 and later, but missed `doc/css/style.css`.

This removes the differentiation between sphinx pre-1.3 and later, because the oldest shinx version currently in use is from Ubuntu Xenial (1.3)[1]. This means, switching to classic theme only. To not further hardcode the name of the theme (include statement), remove also the custom style (underlining links):

https://github.com/ganeti/ganeti/blob/f3f033a62c15f63cbc091be9924a2a370c874a39/doc/css/style.css#L3-L4

Mostly a revert of commit 268953c4c and dbee5c92.

[1] see footer of https://saschalucas.github.io/docs/docs/ganeti/2.16/html/search.html

This PR is against stable-2.16 in order to build docs there too. Later it will be merged into master.