### PR TITLE
KVM: improved migration caps handling

### DIFF
--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -716,7 +716,7 @@ class QmpConnection(MonitorSocket):
     self.Execute("migrate-set-parameters", arguments)
 
   @_ensure_connection
-  def SetMigrationCapabilities(self, capabilities):
+  def SetMigrationCapabilities(self, capabilities, state):
     """Configure live migration capabilities
 
     """
@@ -727,7 +727,7 @@ class QmpConnection(MonitorSocket):
     for capability in capabilities:
       arguments["capabilities"].append({
         "capability": capability,
-        "state": True
+        "state": state,
       })
 
     self.Execute("migrate-set-capabilities", arguments)


### PR DESCRIPTION
NOTE: this is untested, I would appreciate if anyone using migration caps (@saschalucas, @rbott, @atta) could help here.

Currently we set KVM migration capabilities only on the source instance
and leave them set even if migration fails. This leads to two problems:

 - There are a number of features (e.g. postcopy-ram) where the
   capability needs to be set on both, source and destination instance

 - If a migration breaks because of a capability mismatch, the
   capability remains set causing all future migration attempts to fail
   as well (see Debian bug #969028 [1])

Fix both issues by setting all capabilities on both sides of the
migration and clearing all capabilities on the surviving side when the
migration is over.

[1] https://bugs.debian.org/969028