### PR TITLE
Add KVM parameter to toggle QEMU's debug-threads=on|off feature

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -535,6 +535,7 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     constants.HV_KVM_SPICE_USE_TLS: hv_base.NO_CHECK,
     constants.HV_KVM_SPICE_TLS_CIPHERS: hv_base.NO_CHECK,
     constants.HV_KVM_SPICE_USE_VDAGENT: hv_base.NO_CHECK,
+    constants.HV_KVM_DEBUG_THREADS: hv_base.NO_CHECK,
     constants.HV_KVM_FLOPPY_IMAGE_PATH: hv_base.OPT_FILE_CHECK,
     constants.HV_CDROM_IMAGE_PATH: hv_base.OPT_FILE_OR_URL_CHECK,
     constants.HV_KVM_CDROM2_IMAGE_PATH: hv_base.OPT_FILE_OR_URL_CHECK,
@@ -738,7 +739,7 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     while arg_list:
       arg = arg_list.pop(0)
       if arg == "-name":
-        instance = arg_list.pop(0)
+        instance = arg_list.pop(0).split(",")[0]
       elif arg == "-m":
         memory = int(arg_list.pop(0))
       elif arg == "-smp":
@@ -1330,8 +1331,11 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     pidfile = self._InstancePidFile(instance.name)
     kvm = hvp[constants.HV_KVM_PATH]
     kvm_cmd = [kvm]
-    # used just by the vnc server, if enabled
-    kvm_cmd.extend(["-name", instance.name])
+    if hvp[constants.HV_KVM_DEBUG_THREADS]:
+      name_parameter = "%s,debug-threads=on" % (instance.name)
+    else:
+      name_parameter = "%s,debug-threads=off" % (instance.name)
+    kvm_cmd.extend(["-name", name_parameter])
     kvm_cmd.extend(["-m", instance.beparams[constants.BE_MAXMEM]])
 
     smp_list = ["%s" % instance.beparams[constants.BE_VCPUS]]

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -513,6 +513,14 @@ spice\_use\_vdagent
 
     Enables or disables passing mouse events via SPICE vdagent.
 
+debug\_threads
+    Valid for the KVM hypervisor.
+
+    Enables or disables the debug_threads option for QEMU. Enabling this
+    will give the threads of a QEMU process more meaningful names (e.g.
+    for observation using the `top` tool). This setting does not imply
+    performance penalties.
+
 cpu\_type
     Valid for the KVM hypervisor.
 

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -1740,6 +1740,9 @@ hvKvmSpiceUseVdagent = "spice_use_vdagent"
 hvKvmSpiceZlibGlzImgCompr :: String
 hvKvmSpiceZlibGlzImgCompr = "spice_zlib_glz_wan_compression"
 
+hvKvmDebugThreads :: String
+hvKvmDebugThreads = "debug_threads"
+
 hvKvmUseChroot :: String
 hvKvmUseChroot = "use_chroot"
 
@@ -1930,6 +1933,7 @@ hvsParameterTypes = Map.fromList
   , (hvKvmSpiceUseTls,                  VTypeBool)
   , (hvKvmSpiceUseVdagent,              VTypeBool)
   , (hvKvmSpiceZlibGlzImgCompr,         VTypeString)
+  , (hvKvmDebugThreads,                 VTypeBool)
   , (hvKvmUseChroot,                    VTypeBool)
   , (hvKvmUserShutdown,                 VTypeBool)
   , (hvLxcDevices,                      VTypeString)
@@ -4109,6 +4113,7 @@ hvcDefaults =
           , (hvKvmSpiceUseTls,                  PyValueEx False)
           , (hvKvmSpiceTlsCiphers,              PyValueEx opensslCiphers)
           , (hvKvmSpiceUseVdagent,              PyValueEx True)
+          , (hvKvmDebugThreads,                 PyValueEx False)
           , (hvKvmFloppyImagePath,              PyValueEx "")
           , (hvCdromImagePath,                  PyValueEx "")
           , (hvKvmCdrom2ImagePath,              PyValueEx "")


### PR DESCRIPTION
This PR adds support for the `debug-threads` sub-parameter of the `qemu -name` parameter, according to #1526. This sub-parameter has been introduced in QEMU 2.0 and hence should not impose a problem on our currently supported platforms.

Albeit containing the phrase "debug", this change does not imply performance penalties. It will make QEMU name its threads in a more meaningful way, making it easier to debug. You can observe this e.g. with `top` (using the `H` key to view threads instead of tasks).

I have labeled this change for Ganeti 3.1, as it introduces new KVM instance parameters. It defaults to "false/off", which should reflect the current behaviour.