### PR TITLE
automatic postcopy-ram live migration

### DIFF
--- a/lib/cmdlib/instance_migration.py
+++ b/lib/cmdlib/instance_migration.py
@@ -953,7 +953,10 @@ class TLMigrateInstance(Tasklet):
         raise errors.OpExecError("Could not migrate instance %s: %s" %
                                  (self.instance.name, msg))
 
-      if result.payload.status != constants.HV_MIGRATION_ACTIVE:
+      if ms.postcopy_status == constants.HV_KVM_MIGRATION_POSTCOPY_ACTIVE:
+        self.feedback_fn("* memory transfer has switched to postcopy")
+
+      if ms.status not in constants.HV_KVM_MIGRATION_ACTIVE_STATUSES:
         self.feedback_fn("* memory transfer complete")
         break
 

--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -710,6 +710,8 @@ class QmpConnection(MonitorSocket):
 
     arguments = {
       "max-bandwidth": max_bandwidth,
+      # TODO: available since qemu 3.0
+      #"max-postcopy-bandwidth": max_bandwidth,
       "downtime-limit": downtime_limit,
     }
 
@@ -759,6 +761,14 @@ class QmpConnection(MonitorSocket):
     }
 
     self.Execute("migrate", arguments)
+
+  @_ensure_connection
+  def StartPostcopyMigration(self):
+    """ Start postcopy-ram migration
+
+    """
+
+    self.Execute("migrate-start-postcopy")
 
   @_ensure_connection
   def GetMigrationStatus(self):

--- a/lib/objects.py
+++ b/lib/objects.py
@@ -2317,6 +2317,8 @@ class MigrationStatus(ConfigObject):
     "status",
     "transferred_ram",
     "total_ram",
+    # to signal, if migration has switched to postcopy
+    "postcopy_status",
     ]
 
 

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -886,10 +886,18 @@ migration\_caps
 
     Enable specific migration capabilities by providing a ":" separated
     list of supported capabilities. QEMU version 1.7.0 defines
-    x-rdma-pin-all, auto-converge, zero-blocks, and xbzrle. Please note
-    that while a combination of xbzrle and auto-converge might speed up
-    the migration process significantly, the first may cause BSOD on
-    Windows8r2 instances running on drbd.
+    x-rdma-pin-all, auto-converge, zero-blocks, and xbzrle.
+
+    QEMU version 2.5 defines x-postcopy-ram and 2.6 renames this to
+    postcopy-ram. If x-postcopy-ram or postcopy-ram are enabled, Ganeti will
+    automatically move a migration to postcopy mode after a dirty_sync_count
+    of 2. Other than normal live migration, that can recover from dying
+    destination node, it is not possible to recover from dying source node
+    during active postcopy migration.
+
+    Please note that while a combination of xbzrle and auto-converge
+    might speed up the migration process significantly, the first may
+    cause BSOD on Windows8r2 instances running on drbd.
 
 kvm\_path
     Valid for the KVM hypervisor.

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -2001,9 +2001,17 @@ hvMigrationFailedStatuses =
 
 -- | KVM-specific statuses
 --
--- FIXME: this constant seems unnecessary
+hvKvmMigrationPostcopyActive :: String
+hvKvmMigrationPostcopyActive = "postcopy-active"
+
 hvKvmMigrationValidStatuses :: FrozenSet String
-hvKvmMigrationValidStatuses = hvMigrationValidStatuses
+hvKvmMigrationValidStatuses =
+  ConstantUtils.union hvMigrationValidStatuses
+                      (ConstantUtils.mkSet [hvKvmMigrationPostcopyActive])
+
+hvKvmMigrationActiveStatuses :: FrozenSet String
+hvKvmMigrationActiveStatuses =
+  ConstantUtils.mkSet [hvMigrationActive, hvKvmMigrationPostcopyActive]
 
 -- | Node info keys
 hvNodeinfoKeyVersion :: String


### PR DESCRIPTION
This implements automatic postcopy-ram live migration for the KVM hypervisor. Basically it is a cherry-pick from commit 041ed56d9 adopted to today's code. Credit goes to the original author @calumcalder.

It extends the migration status by `dirty_sync_count`, which is the number of times that dirty ram was synchronized (since qemu-2.1). If the migration capability `postcopy-ram` is set and `dirty_sync_count >=2`, live migration automatically switches to postcopy-ram migration.  In the future the existing HV parameter `migration_mode` can be extended by something like postcopy-live to let users better control live migrations.

Special Thanks to @cilq for his help on this PR.
