### PR TITLE
KVM: use qemu monitor to set spice password instead of QMP

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -2050,13 +2050,8 @@ class KVMHypervisor(hv_base.BaseHypervisor):
         raise errors.HypervisorError("Failed to open SPICE password file %s: %s"
                                      % (spice_password_file, err))
 
-      qmp = QmpConnection(self._InstanceQmpMonitor(instance.name))
-      qmp.connect()
-      arguments = {
-          "protocol": "spice",
-          "password": spice_pwd,
-      }
-      qmp.Execute("set_password", arguments)
+      change_cmd = "set_password spice %s" % spice_pwd
+      self._CallMonitorCommand(instance.name, change_cmd)
 
     for filename in temp_files:
       utils.RemoveFile(filename)


### PR DESCRIPTION
Before this patch ganeti used the more modern QEMU Machine protocol to set
the spice password for an instance upon startup. This is in contrast to the
method used when setting a VNC password, which employs qemu monitor to
the same effect.

However, it appears that this implementation is currently broken. Instances
with a set spice password will fail to start due to QMP timeout.

Why this is the case is not clear to me. Either QMP is not ready to serve requests
for the instance at the time the message is sent out by ganeti, or the timing of
the QMP request is such during the VM startup process that the password-setting
command cannot be executed.

This patch changes the method used to set a spice password for the instance
to match the one used for VNC (i.e. via qemu monitor), enabling instances
with password-protected spice servers to start without manual user intervention.