### PR TITLE
switch setting spice password to decorator

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -2050,13 +2050,7 @@ class KVMHypervisor(hv_base.BaseHypervisor):
         raise errors.HypervisorError("Failed to open SPICE password file %s: %s"
                                      % (spice_password_file, err))
 
-      qmp = QmpConnection(self._InstanceQmpMonitor(instance.name))
-      qmp.connect()
-      arguments = {
-          "protocol": "spice",
-          "password": spice_pwd,
-      }
-      qmp.Execute("set_password", arguments)
+      self.qmp.SetSpicePassword(spice_pwd)
 
     for filename in temp_files:
       utils.RemoveFile(filename)

--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -768,6 +768,18 @@ class QmpConnection(MonitorSocket):
 
     return self.Execute("query-migrate")
 
+  @_ensure_connection
+  def SetSpicePassword(self, spice_pwd):
+    """Set Spice password of an instance
+
+    """
+    arguments = {
+      "protocol": "spice",
+      "password": spice_pwd,
+    }
+
+    self.Execute("set_password", arguments)
+
   def _GetFd(self, fd, fdname):
     """Wrapper around the getfd qmp command
 


### PR DESCRIPTION
It has been reported (and verified), that setting a spice password is broken (see #1535):

Setting the spice password via a self managed QMP connection will block further QMP commands. The instance stays paused, because it will not receive the "cont" command.

Instead of going back to HMP, switch the spice password setting to use the @_with_qmp decorator.