### PR TITLE
kvm: get known instances from runtime and not PID files

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -1130,7 +1130,8 @@ class KVMHypervisor(hv_base.BaseHypervisor):
 
     """
     data = []
-    for name in os.listdir(self._PIDS_DIR):
+    for entry in os.listdir(self._CONF_DIR):
+      name, _ = os.path.splitext(entry)
       try:
         info = self.GetInstanceInfo(name)
       except errors.HypervisorError:


### PR DESCRIPTION
KVM's `GetAllInstancesInfo` enumerates all "known" instances using their
PID files. This should be fine as long as we care about live instances,
but it gets more complicated in reality because `GetAllInstancesInfo` also
tries to gather information about user-down instances which are no
longer alive.

Up until QEMU 3.1 this worked reliably because QEMU would leave the
pidfile behind after exiting. Since a user-down instance was not cleaned
up by Ganeti itself, its pidfile was left behind and `GetAllInstancesInfo`
would find it and detect that it was shutdown by the user.

However, as of QEMU 3.1 the pidfile is removed by QEMU itself on exit
(see QEMU commit 90a84d131c "Delete PID file on exit"), and as a result
user-down instances are now omitted from the loop and reported as
ERROR_down by the master.

Fix this by using the KVM runtime files rather than the PID files to
enumerate all "known" instances. In theory this should be safe:
excluding QEMU, Ganeti manages the PID and runtime files using the same
lifecycle.

This fixes #1440.