### PR TITLE
Fix non-SSL operation for Python daemons

### DIFF
--- a/lib/http/__init__.py
+++ b/lib/http/__init__.py
@@ -415,6 +415,13 @@ def SocketOperation(sock, op, arg1, timeout):
     try:
       try:
         if op == SOCKOP_SEND:
+          # Non-SSL sockets expect bytes
+          if isinstance(sock, socket.socket):
+            data = arg1.encode("utf-8")
+            # Use sendall to avoid partial writes that could cause desync with
+            # our caller, as len(data) != len(arg1) in the general case
+            sock.sendall(data)
+            return len(data)
           return sock.send(arg1)
 
         elif op == SOCKOP_RECV:


### PR DESCRIPTION
`http.SocketOperation` relies on the API uniformity between raw sockets
and OpenSSL.SSL.Connection objects to provide a unified API for SSL and
non-SSL operation. This worked fine in Python 2, but is currently
broken in Python 3: OpenSSL uses a text-based API, while raw sockets
expect bytes.

Fix (or rather work around) this by explicilty encoding data before
sending it out over a raw socket. Since callers are text-based and keep
track of characters rather than bytes, we resort to using
`socket.sendall()` for plain text sockets to avoid char-vs-byte count
mismatch.

This fixes #1508.