### PR TITLE
limit postcopy migration bandwidth

### DIFF
--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -710,10 +710,11 @@ class QmpConnection(MonitorSocket):
 
     arguments = {
       "max-bandwidth": max_bandwidth,
-      # TODO: available since qemu 3.0
-      #"max-postcopy-bandwidth": max_bandwidth,
       "downtime-limit": downtime_limit,
     }
+
+    if self.version >= (3, 0, 0):
+      arguments["max-postcopy-bandwidth"] = max_bandwidth
 
     self.Execute("migrate-set-parameters", arguments)
 


### PR DESCRIPTION
Since qemu-3.0 the max-postcopy-bandwidth[1] can be limited, too (like normal migration bandwidth). If unset, bandwidth is unlimited. If the link gets saturated, there is a risk of DRBD disconnects ("PingAck did not arrive in time") and possibly split brain disks.

[1] https://www.qemu.org/docs/master/interop/qemu-qmp-ref.html