### PR TITLE
KVM: shift `info` queries from human monitor to QMP

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -16,10 +16,7 @@ Before installing, please verify that you have the following programs:
 
 - `Xen Hypervisor <http://www.xen.org/>`_, version 3.0 or above, if
   running on Xen
-- `KVM Hypervisor <http://www.linux-kvm.org>`_, version 72 or above, if
-  running on KVM. In order to use advanced features, such as live
-  migration, virtio, etc, an even newer version is recommended (qemu-kvm
-  versions 0.11.X and above have shown good behavior).
+- `KVM Hypervisor <http://www.linux-kvm.org>`_, version 2.12 or above
 - `DRBD <http://www.drbd.org/>`_, kernel module and userspace utils,
   version 8.0.7 or above, up to 8.4.x.
 - `RBD <http://ceph.newdream.net/>`_, kernel modules

--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -772,6 +772,14 @@ class QmpConnection(MonitorSocket):
     self.Execute("migrate-start-postcopy")
 
   @_ensure_connection
+  def GetCpuInformation(self):
+    """ Retrieve CPU/thread information
+        uses the query-cpus-fast which does not interrupt the guest
+    """
+
+    return self.Execute("query-cpus-fast")
+
+  @_ensure_connection
   def GetMigrationStatus(self):
     """Retrieve the current migration status
 


### PR DESCRIPTION
This PR partially addresses #1542 in moving the `info cpus` and `info version` human monitor requests over to QMP. Moreover, it uses `query-cpus-fast` instead of `query-cpus`, because the latter interrupts/stalls the VM for a brief moment (according to the QEMU/QMP documentation)

However, `query-cpus-fast` is only available since QEMU 2.12, bumping the minimum required QEMU version to this level. Debian Stretch comes with 2.8 but is out-of-scope due to Python/GHC versions anyways. Debian Buster is fine (QEMU 3.1). CentOS 7 comes with 2.12, should be also fine.

We could resort to compatibility code (e.g. use `query-cpus` on older QEMU versions) but I do not think this is required/helpful.

I checked the `info version` part against the QA suite (needs the `instance-device-hotplug` test enabled) and did manual testing on a QA cluster for the CPU masking feature.