### PR TITLE
KVM: work around dynamic auto-ro for disk hotplug

### DIFF
--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -703,6 +703,23 @@ class QmpConnection(MonitorSocket):
       _raise("netdev_add qmp command is not supported")
 
   @_ensure_connection
+  def HasDynamicAutoReadOnly(self):
+    """Check if QEMU uses dynamic auto-read-only for block devices
+
+    Use QMP schema introspection (QEMU 2.5+) to check for the
+    dynamic-auto-read-only feature.
+    """
+    schema = self.Execute("query-qmp-schema")
+
+    # QEMU 4.0 did not have a feature flag, but has dynamic auto-read-only
+    # support.
+    if self.version[:2] == (4, 0):
+      return True
+
+    return any([x for x in schema
+                if "dynamic-auto-read-only" in x.get("features",[])])
+
+  @_ensure_connection
   def SetMigrationParameters(self, max_bandwidth, downtime_limit):
     """Configute live migration parameters
 


### PR DESCRIPTION
QEMU 4.0 introduced dynamic auto-read-only for file-backed drives.
Citing the relevant commit:
```
  commit 23dece19da41724349809873923e20a48b619cb7
  Author: Kevin Wolf <kwolf@redhat.com>
  Date:   Fri Mar 1 22:15:11 2019 +0100

    file-posix: Make auto-read-only dynamic

    Until now, with auto-read-only=on we tried to open the file read-write
    first and if that failed, read-only was tried. This is actually not good
    enough for libvirt, which gives QEMU SELinux permissions for read-write
    only as soon as it actually intends to write to the image. So we need to
    be able to switch between read-only and read-write at runtime.

    This patch makes auto-read-only dynamic, i.e. the file is opened
    read-only as long as no user of the node has requested write
    permissions, but it is automatically reopened read-write as soon as the
    first writer is attached. Conversely, if the last writer goes away, the
    file is reopened read-only again.

    bs->read_only is no longer set for auto-read-only=on files even if the
    file descriptor is opened read-only because it will be transparently
    upgraded as soon as a writer is attached. This changes the output of
    qemu-iotests 232.
```
This causes a couple of issues with disk hotplugging. For a start,
dynamic auto-ro requires two file descriptors in the drive's fdset, one
for read-only and one for read-write access. This is trivial to
implement, but it turns out that even with that our combination of
HMP/drive_add and QMP/device_add still doesn't work and throws a "Could
not reopen file" error.

Switching from HMP/drive_add to QMP/blockdev-add fixes things, but needs
careful testing and is a rather invasive change. To unbreak disk
hotplugging until then, it is probably wiser to just disable
auto-read-only completely for hot-added disks. Unfortunately, we cannot
blindly add a ",auto-read-only=off" flag to all drive_add commands, as
this would break QEMU versions before 3.1 where the option didn't exist.
Luckily, QEMU 4.1 added a feature flag for dynamic auto-read-only, so
let's use that instead and only disable auto-read-only in versions where
it is dynamic.

Note that this leaves QEMU 4.0 still broken, as it has dynamic
auto-read-only but no feature flag. To cover this case, we explicitly
check against the 4.0 version.

This fixes #1547.