### PR TITLE
backport: kvm: get known instances from runtime and not PID files

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -1110,7 +1110,8 @@ class KVMHypervisor(hv_base.BaseHypervisor):
 
     """
     data = []
-    for name in os.listdir(self._PIDS_DIR):
+    for entry in os.listdir(self._CONF_DIR):
+      name, _ = os.path.splitext(entry)
       try:
         info = self.GetInstanceInfo(name)
       except errors.HypervisorError:


### PR DESCRIPTION
@apoikos fixed #1440 in stable-3.0 (commit 459fdb7415832caa3926c8ddd2e4cbafe49b399b), which also affects Ganeti-2.16 on Buster (qemu-3.1). According to our new development model we can now cherry-pick bug fixes to older releases. So I'm asking here, to backport userdown fix into stable-2.16.

I have verified, that this fixes userdown in Buster:
```
# Cluster=10.255.255.5 Ganeti=https://github.com/saschalucas/ganeti:backports/stable-2.16/userdown OS=debian-buster

root@master:~# gnt-instance list -o name,nic.ip/0,status
Instance NicIP/0      Status
test.vm  10.255.255.6 running

root@master:~# ssh 10.255.255.6 shutdown -h now
root@10.255.255.6's password: 

root@master:~# gnt-instance list -o name,nic.ip/0,status
Instance NicIP/0      Status
test.vm  10.255.255.6 USER_down
```

