### PR TITLE
hotplug: set disk parameters

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -2298,6 +2298,14 @@ class KVMHypervisor(hv_base.BaseHypervisor):
           # after QEMU 4.0. auto-read-only first appeared in 3.1, but 4.0
           # changed its behavior in a way that breaks hotplugging. See #1547.
           cmd += ",auto-read-only=off"
+        # When hot plugging a disk, parameters should match the current runtime.
+        # I.e. for live migration, the cache mode is critical.
+        if up_hvp[constants.HV_DISK_CACHE] != constants.HT_CACHE_DEFAULT:
+          cmd += ",cache=%s" % up_hvp[constants.HV_DISK_CACHE]
+        if up_hvp[constants.HV_KVM_DISK_AIO] == constants.HT_KVM_AIO_NATIVE:
+          cmd += ",aio=%s" % up_hvp[constants.HV_KVM_DISK_AIO]
+        if up_hvp[constants.HV_DISK_DISCARD] != constants.HT_DISCARD_DEFAULT:
+          cmd += ",discard=%s" % up_hvp[constants.HV_DISK_DISCARD]
         self._CallMonitorCommand(instance.name, cmd)
 
       # This must be done indirectly due to the fact that we pass the drive's


### PR DESCRIPTION
When hot plugging a disk, paramters should match the current runtime. I.e. for live migration the cache mode is [critical](https://github.com/ganeti/ganeti/blob/74b82e754387e84913b7df372c7f27884a5656ee/lib/hypervisor/hv_kvm/__init__.py#L1206-L1217). Other parameters like aio, discard and unimplemented I/O (throtteling groups)[#1274] etc. are also relevant, but uncritical.

The documetation of HMP `drive_add` is unclear. It seems, that it supports the same parameters like -drive command line option???

Current cache settings can be checked by:
* HMP: `info block -n`
* QMP: `{ "execute": "query-named-block-nodes" }`

I was not able to check for aio and discard. So I must assume, that the HMP/`drive_add` correctly accepts this parameters.

This closes #1559