### PR TITLE
backport: hotplug: set disk parameters

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -2294,6 +2294,14 @@ class KVMHypervisor(hv_base.BaseHypervisor):
           # after QEMU 4.0. auto-read-only first appeared in 3.1, but 4.0
           # changed its behavior in a way that breaks hotplugging. See #1547.
           cmd += ",auto-read-only=off"
+        # When hot plugging a disk, parameters should match the current runtime.
+        # I.e. for live migration, the cache mode is critical.
+        if up_hvp[constants.HV_DISK_CACHE] != constants.HT_CACHE_DEFAULT:
+          cmd += ",cache=%s" % up_hvp[constants.HV_DISK_CACHE]
+        if up_hvp[constants.HV_KVM_DISK_AIO] == constants.HT_KVM_AIO_NATIVE:
+          cmd += ",aio=%s" % up_hvp[constants.HV_KVM_DISK_AIO]
+        if up_hvp[constants.HV_DISK_DISCARD] != constants.HT_DISCARD_DEFAULT:
+          cmd += ",discard=%s" % up_hvp[constants.HV_DISK_DISCARD]
         self._CallMonitorCommand(instance.name, cmd)
 
       # This must be done indirectly due to the fact that we pass the drive's


### PR DESCRIPTION
This is a cherry-pick from commit 44386707e188236fd0c99ced94c1136771914ef4 (see PR #1561). If we intend to ship working hot plug in 3.0 (#1558), we should also set correct disk/cache parameters.

When hot plugging a disk, paramters should match the current runtime. I.e. for live migration the cache mode is critical. Other parameters like aio, discard and unimplemented I/O throtteling groups etc. are also relevant, but uncritical. The documetation of HMP drive_add is unclear. It seems, that it supports the same parameters like -drive command line option???

Current cache settings can be checked by:
  * HMP: info block -n
  * QMP: { "execute": "query-named-block-nodes" }

I was not able to check for aio and discard. So I must assume, that the HMP/drive_add correctly accepts this parameters.