### PR TITLE
optimize verify-disks (DrbdNeedsActivation)

### DIFF
--- a/lib/backend.py
+++ b/lib/backend.py
@@ -5603,8 +5603,11 @@ def DrbdNeedsActivation(disks):
   """
   faulty_disks = []
 
+  is_plain_disk = compat.any([_CheckForPlainDisk(d) for d in disks])
+  lvs_cache = bdev.LogicalVolume.GetLvGlobalInfo() if is_plain_disk else None
+
   for disk in disks:
-    rd = _RecursiveFindBD(disk)
+    rd = _RecursiveFindBD(disk, lvs_cache=lvs_cache)
     if rd is None:
       faulty_disks.append(disk)
       continue


### PR DESCRIPTION
The `ganeti-watcher` runs via cron every 5 minutes to also verify DRBD disks. On larger clusters with DRBD instances (i.e. 150+ instances) the disk verification takes a long time (>1.5 minutes) and therefore reduces the window, where other jobs can run to <3.5 minutes (<66%).  This is very annoying. Ganeti checks every node in a group one after one, if there are DRBD disks which needs activation. It therefore calls node RPC `drbd_needs_activation`, which results in the backend function `DrbdNeedsActivation`. It can be observed in `noded.log` that for every disk on a node (primary or secondary) one `lvs` call is executed. That is because `_RecursiveFindBD` is called for every disk on a node, without supplying a `lvs_cache`.

Adding a `lvs_cache` speeds things dramatically up. On test cluster with 192 DRBD instances a run of `ganeti-watcher` took **1m52s** before and **0m3.5s** after this fix.

I have successfully tested DRBD repair of individual degraded disks and a node reboot.

This obsoletes #1562.