### PR TITLE
Fix regexps for testing vhost and virtio queues capabilities in kvm

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -615,8 +615,8 @@ class KVMHypervisor(hv_base.BaseHypervisor):
 
   _QMP_RE = re.compile(r"^-qmp\s", re.M)
   _SPICE_RE = re.compile(r"^-spice\s", re.M)
-  _VHOST_RE = re.compile(r"^-net(?:dev)?\stap.*,vhost=on\|off", re.M | re.S)
-  _VIRTIO_NET_QUEUES_RE = re.compile(r"^-net(?:dev)?\stap.*,fds=x:y:...:z", re.M)
+  _VHOST_RE = re.compile(r"^-netdev\stap.*,vhost=on\|off", re.M | re.S)
+  _VIRTIO_NET_QUEUES_RE = re.compile(r"^-netdev\stap.*,fds=x:y:...:z", re.M)
   _ENABLE_KVM_RE = re.compile(r"^-enable-kvm\s", re.M)
   _DISABLE_KVM_RE = re.compile(r"^-disable-kvm\s", re.M)
   _NETDEV_RE = re.compile(r"^-netdev\s", re.M)

--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -615,8 +615,8 @@ class KVMHypervisor(hv_base.BaseHypervisor):
 
   _QMP_RE = re.compile(r"^-qmp\s", re.M)
   _SPICE_RE = re.compile(r"^-spice\s", re.M)
-  _VHOST_RE = re.compile(r"^-net\s.*,vhost=on|off", re.M)
-  _VIRTIO_NET_QUEUES_RE = re.compile(r"^-net(dev)?\s.*,fds=x:y:...:z", re.M)
+  _VHOST_RE = re.compile(r"^-net(?:dev)?\stap.*,vhost=on\|off", re.M | re.S)
+  _VIRTIO_NET_QUEUES_RE = re.compile(r"^-net(?:dev)?\stap.*,fds=x:y:...:z", re.M)
   _ENABLE_KVM_RE = re.compile(r"^-enable-kvm\s", re.M)
   _DISABLE_KVM_RE = re.compile(r"^-disable-kvm\s", re.M)
   _NETDEV_RE = re.compile(r"^-netdev\s", re.M)


### PR DESCRIPTION
Updates #1326

Fix typo in _VHOST_RE that made it match kvm --help output in multiple places (on|off would match on OR off and no literal 'on|off')
Harmonize with _VIRTIO_NET_QUEUES_RE (it's -net or -netdev).

With these changes, we match (-net|-netdev) tap from qemu 2.11 all the way to 4.2.1.

Note: \s could just be ' ' here, and the non-capturing (?:..) isn't strictly necessary, but hey.

Thanks to @saschalucas for feedback.