### PR TITLE
kvm: support multiple devices for boot order preference

### DIFF
--- a/lib/hypervisor/hv_base.py
+++ b/lib/hypervisor/hv_base.py
@@ -167,6 +167,21 @@ def ParamInSet(required, my_set):
   err = ("The value must be one of: %s" % utils.CommaJoin(my_set))
   return (required, fn, err, None, None)
 
+def AllParamsInSet(required, my_set):
+  """Builds parameter checker for set membership for collection of items.
+  @type required: boolean
+  @param required: whether this is a required parameter
+  @type my_set: tuple, list or set
+  @param my_set: allowed values set
+  """
+  def fn(x):
+    for item in x.split(','):
+      if item not in my_set:
+        return False
+    return True
+
+  err = ("Each value must be one of: %s" % utils.CommaJoin(my_set))
+  return (required, fn, err, None, None)
 
 def GenerateTapName():
   """Generate a TAP network interface name for a NIC.

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -2888,6 +2888,15 @@ htKvmValidBoTypes :: FrozenSet String
 htKvmValidBoTypes =
   ConstantUtils.mkSet [htBoCdrom, htBoDisk, htBoFloppy, htBoNetwork]
 
+
+htKvmBoLetterMapping :: Map String String
+htKvmBoLetterMapping =
+  Map.fromList
+  [(htBoCdrom, "d"),
+   (htBoDisk, "c"),
+   (htBoFloppy, "a"),
+   (htBoNetwork, "n")]
+
 -- * SPICE lossless image compression options
 
 htKvmSpiceLosslessImgComprAutoGlz :: String


### PR DESCRIPTION
This patch adds multiple device support for the boot_order
setting. Valid values are still disk, cdrom, network and floppy,
but the user can now supply a comma-separated list of those instead
of a single value only.

Additionally, this patch will now use the newer
'-boot order=drives' syntax for the qemu command line,
instead of the deprecated '-boot drives'.