### PR TITLE
SocketOperation: return the number of chars written

### DIFF
--- a/lib/http/__init__.py
+++ b/lib/http/__init__.py
@@ -421,7 +421,7 @@ def SocketOperation(sock, op, arg1, timeout):
             # Use sendall to avoid partial writes that could cause desync with
             # our caller, as len(data) != len(arg1) in the general case
             sock.sendall(data)
-            return len(data)
+            return len(arg1)
           return sock.send(arg1)
 
         elif op == SOCKOP_RECV:


### PR DESCRIPTION
Callers deal with strings, so it's the number of chars we should return
rather than the number of bytes.

Note that this is only relevant if we pass non-ascii information over
HTTP.