### PR TITLE
Disable the start rate limiting for the ganeti-common.service

### DIFF
--- a/doc/examples/systemd/ganeti-common.service.in
+++ b/doc/examples/systemd/ganeti-common.service.in
@@ -4,3 +4,5 @@ Description = Ganeti one-off setup
 [Service]
 Type = oneshot
 ExecStart = @PKGLIBDIR@/ensure-dirs
+# Disable the start rate limiting
+StartLimitBurst = 0


### PR DESCRIPTION
The ganeti-common.service is executed by multiple ganeti service units.
When multiple ganeti service units grouped by ganeti.target are started in a short period of time, some executions of ganeti-common.service will fail due to the unit start rate limiting setting.


Tested with:

- Debian 9 Stretch or later
- Ubuntu 16.04 Xenial or later
- Red Hat Enterprise Linux 7 or later

Error message: `start request repeated too quickly for ganeti-common.service`

```
# journalctl -u ganeti-common.service
...
Jan 25 11:00:39 node01.example.org systemd[1]: Starting Ganeti one-off setup...
Jan 25 11:00:40 node01.example.org systemd[1]: Started Ganeti one-off setup.
Jan 25 11:00:40 node01.example.org systemd[1]: Starting Ganeti one-off setup...
Jan 25 11:00:40 node01.example.org systemd[1]: Started Ganeti one-off setup.
Jan 25 11:00:40 node01.example.org systemd[1]: Starting Ganeti one-off setup...
Jan 25 11:00:40 node01.example.org systemd[1]: Started Ganeti one-off setup.
Jan 25 11:00:40 node01.example.org systemd[1]: Starting Ganeti one-off setup...
Jan 25 11:00:41 node01.example.org systemd[1]: Started Ganeti one-off setup.
Jan 25 11:00:41 node01.example.org systemd[1]: Starting Ganeti one-off setup...
Jan 25 11:00:41 node01.example.org systemd[1]: Started Ganeti one-off setup.
Jan 25 11:00:41 node01.example.org systemd[1]: start request repeated too quickly for ganeti-common.service
Jan 25 11:00:41 node01.example.org systemd[1]: Failed to start Ganeti one-off setup.
Jan 25 11:00:41 node01.example.org systemd[1]: Unit ganeti-common.service entered failed state.
Jan 25 11:00:41 node01.example.org systemd[1]: ganeti-common.service failed.
Jan 25 11:00:41 node01.example.org systemd[1]: start request repeated too quickly for ganeti-common.service
Jan 25 11:00:41 node01.example.org systemd[1]: Failed to start Ganeti one-off setup.
Jan 25 11:00:41 node01.example.org systemd[1]: ganeti-common.service failed.
Jan 25 11:00:41 node01.example.org systemd[1]: start request repeated too quickly for ganeti-common.service
Jan 25 11:00:41 node01.example.org systemd[1]: Failed to start Ganeti one-off setup.
Jan 25 11:00:41 node01.example.org systemd[1]: ganeti-common.service failed.
```
