### PR TITLE
Use `AmbientCapabilities` unit file setting instead of `Capabilities`

### DIFF
--- a/doc/examples/systemd/ganeti-metad.service.in
+++ b/doc/examples/systemd/ganeti-metad.service.in
@@ -13,7 +13,7 @@ EnvironmentFile = -@LOCALSTATEDIR@/lib/ganeti/ganeti-metad.onetime.conf
 ExecStart = @SBINDIR@/ganeti-metad -f $METAD_ARGS $ONETIME_ARGS
 Restart = on-failure
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-Capabilities=cap_net_bind_service+=ep
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 # ganeti-metad is started on-demand by noded, so there must be no Install
 # section.


### PR DESCRIPTION
The `Capabilities` unit file setting has been removed since systemd v230(it is ignored for backwards compatibility).
Instead, use `AmbientCapabilities` and `CapabilityBoundingSet`.

Tested with:

- Debian 9 Stretch or later
- Ubuntu 16.04 Xenial or later
- Red Hat Eneterprise Linux 7 or later

Error messages:

```
# Ubuntu 16.04 Xenial
# Red Hat Eneterprise Linux 7
Feb 02 07:51:31 node01 systemd[1]: [/lib/systemd/system/ganeti-metad.service:14] Failed to parse capabilities, ignoring: cap_net_bind_service+=ep

# Debian 9 Stretch or later
# Ubuntu 18.04 Bionic or later
# Red Hat Eneterprise Linux 8
Feb 02 08:01:21 node01 systemd[1]: /lib/systemd/system/ganeti-metad.service:14: Support for option Capabilities= has been removed and it is ignored
```
