### PR TITLE
add rename function to networks

### DIFF
--- a/lib/client/gnt_network.py
+++ b/lib/client/gnt_network.py
@@ -322,6 +322,21 @@ def RemoveNetwork(opts, args):
   SubmitOrSend(op, opts)
 
 
+def RenameNetwork(opts, args):
+  """Rename a network.
+
+  @param opts: the command line options selected by the user
+  @type args: list
+  @param args: a list of length 2, [old_name, new_name]
+  @rtype: int
+  @return: the desired exit code
+
+  """
+  network_name, new_name = args
+  op = opcodes.OpNetworkRename(network_name=network_name, new_name=new_name)
+  SubmitOrSend(op, opts)
+
+
 commands = {
   "add": (
     AddNetwork, ARGS_ONE_NETWORK,
@@ -368,6 +383,10 @@ commands = {
     [FORCE_OPT, DRY_RUN_OPT] + SUBMIT_OPTS + [PRIORITY_OPT],
     "[--dry-run] <network>",
     "Remove an (empty) network from the cluster"),
+  "rename": (
+    RenameNetwork, [ArgGroup(min=2, max=2)],
+    [DRY_RUN_OPT] + SUBMIT_OPTS + [PRIORITY_OPT],
+    "[--dry-run] <old-name> <new-name>", "Rename a network"),
   "list-tags": (
     ListTags, ARGS_ONE_NETWORK, [],
     "<network>", "List the tags of the given network"),

--- a/lib/cmdlib/__init__.py
+++ b/lib/cmdlib/__init__.py
@@ -120,6 +120,7 @@ from ganeti.cmdlib.tags import \
 from ganeti.cmdlib.network import \
   LUNetworkAdd, \
   LUNetworkRemove, \
+  LUNetworkRename, \
   LUNetworkSetParams, \
   LUNetworkConnect, \
   LUNetworkDisconnect

--- a/man/gnt-network.rst
+++ b/man/gnt-network.rst
@@ -135,6 +135,16 @@ LIST-FIELDS
 
 List available fields for networks.
 
+RENAME
+~~~~~~
+
+| **rename** [\--submit] [\--print-jobid] {*oldname*} {*newname*}
+
+Renames a given network from *oldname* to *newname*.
+
+See **ganeti**\(7) for a description of ``--submit`` and other common
+options.
+
 INFO
 ~~~~
 

--- a/src/Ganeti/Hs2Py/OpDoc.hs
+++ b/src/Ganeti/Hs2Py/OpDoc.hs
@@ -482,6 +482,10 @@ opNetworkRemove =
   "Remove an existing network from the cluster.\n\
 \     Must not be connected to any nodegroup."
 
+opNetworkRename :: String
+opNetworkRename =
+  "Rename a network in the cluster."
+
 opNetworkSetParams :: String
 opNetworkSetParams =
   "Modify Network's parameters except for IPv4 subnet"

--- a/src/Ganeti/OpCodes.hs
+++ b/src/Ganeti/OpCodes.hs
@@ -945,6 +945,13 @@ $(genOpCode "OpCode"
      , pForce
      ],
      "network_name")
+  , ("OpNetworkRename",
+     [t| NonEmptyString |],
+     OpDoc.opNetworkRename,
+     [ pNetworkName
+     , withDoc "New network name" pNewName
+     ],
+     [])
   , ("OpNetworkSetParams",
      [t| () |],
      OpDoc.opNetworkSetParams,


### PR DESCRIPTION
Currently it is not possible to rename a network, besides removing and
recreate it with the new name. In order to remove a network, it must not
contain instances and is not connected to any node group. During
removing/recreating the network information like network address/mask,
gateway, link, vlan etc. must be saved externally. With this change
networks can be renamed like most other Ganeti config objects.