### PR TITLE
Legacy Tekram dc390 scsi emulation support

### DIFF
--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -2812,11 +2812,15 @@ htScsiControllerVirtio = "virtio-scsi-pci"
 htScsiControllerMegasas :: String
 htScsiControllerMegasas = "megasas"
 
+htScsiControllerTekram :: String
+htScsiControllerTekram = "dc390"
+
 htKvmValidScsiControllerTypes :: FrozenSet String
 htKvmValidScsiControllerTypes =
   ConstantUtils.mkSet [htScsiControllerLsi,
                        htScsiControllerVirtio,
-                       htScsiControllerMegasas]
+                       htScsiControllerMegasas,
+                       htScsiControllerTekram]
 
 htCacheDefault :: String
 htCacheDefault = "default"


### PR DESCRIPTION
Would it be possible to also allow the configuration of the old 'dc390' cards in the official ganeti releases? I've got a bunch of very old freebsd (3.x, 4.x) instances which I've been supporting via ganeti for quite some time, but some of the more recent changes have broken my ability to continue as-is.

Adding this ability to configure things with the "dc390" card is needed since the new QEMU scsi config since 2.16 hasn't been able to be configured via hv/kvm_extra alone like in the older style.