### PR TITLE
hscan should save corrected fixdata

### DIFF
--- a/src/Ganeti/HTools/Program/Hscan.hs
+++ b/src/Ganeti/HTools/Program/Hscan.hs
@@ -144,7 +144,7 @@ writeDataInner nlen name opts cdata fixdata = do
   hFlush stdout
   when (isJust shownodes) .
        putStr $ Cluster.printNodes nl (fromJust shownodes)
-  writeFile (oname <.> "data") (serializeCluster cdata)
+  writeFile (oname <.> "data") (serializeCluster fixdata)
   return True
 
 -- | Main function.


### PR DESCRIPTION
When [this PR](https://github.com/ganeti/ganeti/pull/34) was merged back in 2017, hscan was updated to look at the new data and present it to stdout, however the change was never applied to the saved copy (LOCAL.data) of the information.

When this incorrect data is reloaded through hbal, under some conditions the invalid memory information can cause it to silently stop considering otherwise viable instance moves.

Correcting hscan to actually save the fixed data for external use, instead of saving the unmodified copy keeps things working as expected.