### PR TITLE
kvm_qmp_timeout hypervisor parameter

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -178,7 +178,7 @@ def _with_qmp(fn):
         raise(RuntimeError("QMP decorator could not find"
                            " a valid ganeti instance object"))
       filename = self._InstanceQmpMonitor(instance.name)# pylint: disable=W0212
-      self.qmp = QmpConnection(filename)
+      self.qmp = QmpConnection(filename, instance.hvparams[constants.HV_KVM_QMP_TIMEOUT])
     return fn(self, *args, **kwargs)
   return wrapper
 
@@ -595,6 +595,7 @@ class KVMHypervisor(hv_base.BaseHypervisor):
        constants.QEMU_PCI_SLOTS,
        None, None),
     constants.HV_VNET_HDR: hv_base.NO_CHECK,
+    constants.HV_KVM_QMP_TIMEOUT: hv_base.OPT_NONNEGATIVE_INT_CHECK,
     }
 
   _VIRTIO = "virtio"
@@ -1101,7 +1102,7 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     times = 0
 
     try:
-      qmp = QmpConnection(self._InstanceQmpMonitor(instance_name))
+      qmp = QmpConnection(self._InstanceQmpMonitor(instance_name), hvparams[constants.HV_KVM_QMP_TIMEOUT])
       qmp.connect()
       vcpus = len(qmp.Execute("query-cpus"))
       # Will fail if ballooning is not enabled, but we can then just resort to

--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -128,9 +128,8 @@ class QmpMessage(object):
 
 
 class MonitorSocket(object):
-  _SOCKET_TIMEOUT = 5
 
-  def __init__(self, monitor_filename):
+  def __init__(self, monitor_filename, monitor_timeout):
     """Instantiates the MonitorSocket object.
 
     @type monitor_filename: string
@@ -139,6 +138,7 @@ class MonitorSocket(object):
 
     """
     self.monitor_filename = monitor_filename
+    self._SOCKET_TIMEOUT = monitor_timeout
     self._connected = False
 
   def _check_socket(self):
@@ -258,8 +258,8 @@ class QmpConnection(MonitorSocket):
     "driver", "id", "bus", "addr", "channel", "scsi-id", "lun"
     ]
 
-  def __init__(self, monitor_filename):
-    super(QmpConnection, self).__init__(monitor_filename)
+  def __init__(self, monitor_filename, monitor_timeout):
+    super(QmpConnection, self).__init__(monitor_filename, monitor_timeout)
     self._buf = b""
     self.supported_commands = None
 

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -944,6 +944,13 @@ virtio\_net\_queues
 
     It is set to ``1`` by default.
 
+kvm\_qmp\_timeout
+    Valid for the KVM hypervisor.
+
+    Sets the QMP socket timeout value.
+
+    It is set to ``5`` by default.
+
 startup\_timeout
     Valid for the LXC hypervisor.
 

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -1711,6 +1711,9 @@ hvKvmScsiControllerType = "scsi_controller_type"
 hvKvmPciReservations :: String
 hvKvmPciReservations = "kvm_pci_reservations"
 
+hvKvmQmpTimeout :: String
+hvKvmQmpTimeout = "kvm_qmp_timeout"
+
 hvKvmSpiceAudioCompr :: String
 hvKvmSpiceAudioCompr = "spice_playback_compression"
 
@@ -1926,6 +1929,7 @@ hvsParameterTypes = Map.fromList
   , (hvKvmDiskAio,                      VTypeString)
   , (hvKvmScsiControllerType,           VTypeString)
   , (hvKvmPciReservations,              VTypeInt)
+  , (hvKvmQmpTimeout,                   VTypeInt)
   , (hvKvmSpiceAudioCompr,              VTypeBool)
   , (hvKvmSpiceBind,                    VTypeString)
   , (hvKvmSpiceIpVersion,               VTypeInt)
@@ -4114,6 +4118,7 @@ hvcDefaults =
           , (hvVncPasswordFile,                 PyValueEx "")
           , (hvKvmScsiControllerType,           PyValueEx htScsiControllerLsi)
           , (hvKvmPciReservations,         PyValueEx qemuDefaultPciReservations)
+          , (hvKvmQmpTimeout,                   PyValueEx (5 :: Int))
           , (hvKvmSpiceBind,                    PyValueEx "")
           , (hvKvmSpiceIpVersion,           PyValueEx ifaceNoIpVersionSpecified)
           , (hvKvmSpicePasswordFile,            PyValueEx "")


### PR DESCRIPTION
This change makes the kvm hypervisor QMP timeout a settable hypervisor parameter. The default timeout remains the preconfigured 5 seconds, but can now be easily extended for edge cases that create QMP timeouts regularly.