### PR TITLE
force usage of TLSv1.2 in rapi client

### DIFF
--- a/lib/rapi/client.py
+++ b/lib/rapi/client.py
@@ -475,6 +475,7 @@ class GanetiRapiClient(object): # pylint: disable=R0904
     curl.setopt(pycurl.USERAGENT, self.USER_AGENT)
     curl.setopt(pycurl.SSL_VERIFYHOST, 0)
     curl.setopt(pycurl.SSL_VERIFYPEER, False)
+    curl.setopt(pycurl.SSLVERSION, pycurl.SSLVERSION_TLSv1_2 | pycurl.SSLVERSION_MAX_TLSv1_2)
     curl.setopt(pycurl.HTTPHEADER, [
       "Accept: %s" % HTTP_APP_JSON,
       "Content-type: %s" % HTTP_APP_JSON,


### PR DESCRIPTION
Ganeti version: 3.0.1-1~bpo10+1
OS: Debian Buster

If you're installing a newer curl version (e.g. 7.74.0-1.2~bpo10+1 from Buster backports), the rapi client will try to connect to the rapi daemon using TLSv1.3, which isn't supported by the current HTTP server implementation.

In the future (if pyopenssl 20.0.1 is available on e.g. Debian), adding support for TLSv1.3 within the HTTP server might be good. Something like:
```python
diff --git a/lib/http/__init__.py b/lib/http/__init__.py
index 0ed127046..c1a67e720 100644
--- a/lib/http/__init__.py
+++ b/lib/http/__init__.py
@@ -625,7 +625,7 @@ class HttpBase(object):
     self._ssl_key = ssl_params.GetKey()
     self._ssl_cert = ssl_params.GetCertificate()
 
-    ctx = OpenSSL.SSL.Context(OpenSSL.SSL.SSLv23_METHOD)
+    ctx = OpenSSL.SSL.Context(OpenSSL.SSL.TLS_SERVER_METHOD)
     ctx.set_options(OpenSSL.SSL.OP_NO_SSLv2)
 
     ciphers = self.GetSslCiphers()
```