### PR TITLE
fix building docs on Debian Bullseye

### DIFF
--- a/lib/build/shell_example_lexer.py
+++ b/lib/build/shell_example_lexer.py
@@ -79,4 +79,4 @@ class ShellExampleLexer(RegexLexer):
 
 
 def setup(app):
-  app.add_lexer("shell-example", ShellExampleLexer())
+  app.add_lexer("shell-example", ShellExampleLexer)

--- a/lib/build/sphinx_ext.py
+++ b/lib/build/sphinx_ext.py
@@ -360,7 +360,7 @@ def _ManPageNodeClass(*args, **kwargs):
 
   # Force custom title
   kwargs["refexplicit"] = True
-  kwargs["refdomain"] = None
+  kwargs["refdomain"] = "std"
 
   return sphinx.addnodes.pending_xref(*args, **kwargs)
 


### PR DESCRIPTION
When building docs with man pages (`--enable-manpages-in-doc`) the following issues exists:

* Sphinx refdomain=None no longer works. In a previous fix (commit 388c0b6653028b82edb8ea4b0d769ce71122f5be, by @cilq ) refdomain=None was introduced. However this emits a deprecation warning on pre Debian Bullseye (i.e. Ubuntu Focal) and no longer works on Bullseye. Fix this by setting refdomain=std:
```
  RemovedInSphinx20Warning: Invalid pendig_xref node detected. :doc: reference should have refdomain=std attribute.
```
* On Bullseye an other deprecation warning is emitted and no longer works the old way. Fixing this as suggested in the warning:
```
  RemovedInSphinx40Warning: app.add_lexer() API changed; Please give lexer class instead of instance
```
