### PR TITLE
RAPI: Correctly return HTTP 400 on request parse error

### DIFF
--- a/lib/http/server.py
+++ b/lib/http/server.py
@@ -158,8 +158,7 @@ class _HttpServerToClientMessageWriter(http.HttpMessageWriter):
     # message-body, [...]"
 
     return (http.HttpMessageWriter.HasMessageBody(self) and
-            (request_method is not None and
-             request_method != http.HTTP_HEAD) and
+            request_method != http.HTTP_HEAD and
             response_code >= http.HTTP_OK and
             response_code not in (http.HTTP_NO_CONTENT,
                                   http.HTTP_NOT_MODIFIED))
@@ -314,6 +313,8 @@ class HttpResponder(object):
         _HandleServerRequestInner(self._handler, request_msg, req_msg_reader)
     except http.HttpException as err:
       self._SetError(self.responses, self._handler, response_msg, err)
+      request_msg = http.HttpMessage()
+      req_msg_reader = None
     else:
       # Only wait for client to close if we didn't have any exception.
       force_close = False


### PR DESCRIPTION
This re-implements the fix by @nicolasavru in #1373 as there has been no response in a while. This PR has passed a QA run and seems to introduce no problems.
