### PR TITLE
GHC 8.10 + Stackage 18.10 compatibility

### DIFF
--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -64,7 +64,7 @@ library
     , utf8-string                   >= 0.3.7
 
     , attoparsec                    >= 0.10.1.1   && < 0.14
-    , base64-bytestring             >= 1.0.0.1    && < 1.1
+    , base64-bytestring             >= 1.0.0.1    && < 1.2
     , case-insensitive              >= 0.4.0.1    && < 1.3
     , curl                          >= 1.3.7      && < 1.4
     , hinotify                      >= 0.3.2      && < 0.5
@@ -95,7 +95,7 @@ library
   if flag(htest)
     build-depends:
         HUnit                         >= 1.2.4.2    && < 1.7
-      , QuickCheck                    >= 2.8        && < 2.14
+      , QuickCheck                    >= 2.8        && < 2.15
       , test-framework                >= 0.6        && < 0.9
       , test-framework-hunit          >= 0.2.7      && < 0.4
       , test-framework-quickcheck2    >= 0.2.12.1   && < 0.4

--- a/src/Ganeti/THH/Compat.hs
+++ b/src/Ganeti/THH/Compat.hs
@@ -6,7 +6,7 @@
 
 {-
 
-Copyright (C) 2018 Ganeti Project Contributors.
+Copyright (C) 2018, 2021 Ganeti Project Contributors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,7 @@ module Ganeti.THH.Compat
   , gntDataD
   , extractDataDConstructors
   , myNotStrict
+  , nonUnaryTupE
   ) where
 
 import Language.Haskell.TH
@@ -103,4 +104,13 @@ myNotStrict :: Bang
 myNotStrict = Bang NoSourceUnpackedness NoSourceStrictness
 #else
 myNotStrict = NotStrict
+#endif
+
+-- | TupE changed from '[Exp] -> Exp' to '[Maybe Exp] -> Exp'.
+-- Provide the old signature for compatibility.
+nonUnaryTupE :: [Exp] -> Exp
+#if MIN_VERSION_template_haskell(2,16,0)
+nonUnaryTupE es = TupE $ map Just es
+#else
+nonUnaryTupE es = TupE $ es
 #endif

--- a/src/Ganeti/THH/Types.hs
+++ b/src/Ganeti/THH/Types.hs
@@ -49,6 +49,7 @@ import Control.Arrow (first)
 import Control.Monad (liftM, replicateM)
 import Language.Haskell.TH
 import qualified Text.JSON as J
+import Ganeti.THH.Compat (nonUnaryTupE)
 
 -- | This fills the gap between @()@ and @(,)@, providing a wrapper for
 -- 1-element tuples. It's needed for RPC, where arguments for a function are
@@ -123,4 +124,4 @@ curryN n = do
   f <- newName "f"
   ps <- replicateM n (newName "x")
   return $ LamE (VarP f : map VarP ps)
-             (AppE (VarE f) (TupE $ map VarE ps))
+             (AppE (VarE f) (nonUnaryTupE $ map VarE ps))


### PR DESCRIPTION
This PR adjusts for a [`TupE` type change in GHC 8.10](https://gitlab.haskell.org/ghc/ghc/-/wikis/Migration/8.10#tupeunboxedtupe-changes), and bumps library requirements to match those on Stackage 18.10 which is what my distribution follows.

Note: I'm not a haskeller; I simply searched the web for approaches to the `TupE` type change and everywhere I looked had this exact same snippet.