### PR TITLE
relax VLAN check with VETHs

### DIFF
--- a/tools/net-common.in
+++ b/tools/net-common.in
@@ -76,9 +76,15 @@ function bridge_vlan_add {
   # tap on the VLAN aware bridge will not receive traffic
   if [ -r /proc/net/vlan/config ]; then
     local vlan_interface="$(awk -F '[| ]*' -v vlan="^${VID}$" 'match($2, vlan) { print $1 }' /proc/net/vlan/config)"
+    local lower_devs="$(awk -F '[| ]*' -v vlan="^${VID}$" 'match($2, vlan) { print $3 }' /proc/net/vlan/config)"
     if [ -n "${vlan_interface}" ]; then
-      echo "VLAN ${VID} is in use by interface ${vlan_interface}"
-      exit 1
+      for i in ${lower_devs}; do
+        # allow bridge stacking and vlan overlap for veth devices
+        if [ "$(ip -o link show dev ${i} type veth | wc -l)" -ne 1 ]; then
+          echo "VLAN ${VID} is in use by lower interface ${i}"
+          exit 1
+        fi
+      done
     fi
   fi
 


### PR DESCRIPTION
Normally one can not use identical VLAN on VLAN aware bridge and traditional VLAN interfaces connected to the same lower device. A common workaround is to insert a veth pair between the VLAN aware bridge and traditional VLAN interfaces. This way one can stack VLAN aware bridge and traditional bridges, too. This commit relaxes the VLAN check, to be skipped, if the lower interface is of type `veth`.

This fixes #1533