### PR TITLE
doc: Remove duplicate index entry

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -119,7 +119,6 @@ Draft designs
    design-hotplug.rst
    design-internal-shutdown.rst
    design-kvmd.rst
-   design-location.rst
    design-linuxha.rst
    design-location.rst
    design-lu-generated-jobs.rst


### PR DESCRIPTION
This PR fixes HTML documentation generation with recent versions of Sphinx.

Edit: rebased on #1602.