### PR TITLE
fix KVM's HotplugSupported() method 

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -2151,8 +2151,9 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     @raise errors.HypervisorError: in one of the previous cases
 
     """
+
     try:
-      version = self.qmp.version
+      version = self.qmp.GetVersion()
     except errors.HypervisorError:
       raise errors.HotplugError("Instance is probably down")
 

--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -702,6 +702,18 @@ class QmpConnection(MonitorSocket):
     if "netdev_add" not in self.supported_commands:
       _raise("netdev_add qmp command is not supported")
 
+
+  @_ensure_connection
+  def GetVersion(self):
+    """Return the QMP/qemu version field
+
+    Accessing the version attribute directly might result in an error
+    since the socket might not be yet connected. This getter method
+    uses the @_ensure_connection decorator to work around this problem.
+    """
+    return self.version
+
+
   @_ensure_connection
   def HasDynamicAutoReadOnly(self):
     """Check if QEMU uses dynamic auto-read-only for block devices


### PR DESCRIPTION
HotplugSupported() tries to access the `version` property of the QMP instance. However, it only exists _after_ a QMP connection has been established, which is not the case when this method is the first interaction with the QMP socket.

I could reproduce the error with issuing the following on a freshly started instance:
```
gnt-instance modify --net -1:add --hotplug test-instance.example.org
```

Usually QMP functions are accessed through methods of the QmpConnection class which always use the decorator `@_ensure_connection` which takes care of opening the QMP socket if not yet done. This simple fix makes sure HotplugSupported() always has a working QMP connection available.