### PR TITLE
Preserve instance tags in intra-cluster-moves

### DIFF
--- a/tools/move-instance
+++ b/tools/move-instance
@@ -689,7 +689,8 @@ class MoveDestExecutor(object):
                                                        override_hvparams),
                              osparams=objects.FillDict(inst_osparams,
                                                        override_osparams),
-                             opportunistic_locking=is_attempt_opportunistic
+                             opportunistic_locking=is_attempt_opportunistic,
+                             tags=instance["tags"]
                              )
 
 
@@ -709,6 +710,9 @@ class MoveSourceExecutor(object):
     logging.info("Retrieving instance information from source cluster")
     instinfo = self._GetInstanceInfo(src_client, mrt.PollJob,
                                      mrt.move.src_instance_name)
+
+    instinfo["tags"] = self._GetInstanceTags(src_client,
+                                             mrt.move.src_instance_name)
 
     logging.info("Preparing export on source cluster")
     expinfo = self._PrepareExport(src_client, mrt.PollJob,
@@ -769,6 +773,21 @@ class MoveSourceExecutor(object):
     result = poll_job_fn(cl, job_id)
     assert len(result[0].keys()) == 1
     return result[0][list(result[0].keys())[0]]
+
+  @staticmethod
+  def _GetInstanceTags(cl, name):
+    """Retrieves instance tags (as they are not returned by _GetInstanceInfo)
+
+    @type cl: L{rapi.client.GanetiRapiClient}
+    @param cl: RAPI client
+    @type name: string
+    @param name: Instance name
+
+    @return: list of strings
+    """
+
+    return cl.GetInstance(name)["tags"]
+
 
   @staticmethod
   def _PrepareExport(cl, poll_job_fn, name):


### PR DESCRIPTION
Currently the `move-instance` script drops any instance tags that might exist on the source side. With this PR, tags will be always transferred. Currently, all information about the source instance are retrieved with the `GetInstanceInfo()` method - unfortunatly Ganeti clusters do not return instance tags here (can be verified with `gnt-instance info <name>` on the CLI). So we had to add another call to `GetInstance()`.
