### PR TITLE
Qemu-Guest-Agent (QGA): use implicit PCI slot

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -1648,15 +1648,13 @@ class KVMHypervisor(hv_base.BaseHypervisor):
 
     # Add guest agent socket
     if hvp[constants.HV_USE_GUEST_AGENT]:
-      qga_addr = utils.GetFreeSlot(bus_slots[_PCI_BUS], reserve=True)
-      qga_pci_info = "bus=%s,addr=%s" % (_PCI_BUS, hex(qga_addr))
       qga_path = self._InstanceQemuGuestAgentMonitor(instance.name)
       logging.info("KVM: Guest Agent available at %s", qga_path)
       # The 'qga0' identified can change, but the 'org.qemu.guest_agent.0'
       # string is the default expected by the Guest Agent.
       kvm_cmd.extend([
         "-chardev", "socket,path=%s,server,nowait,id=qga0" % qga_path,
-        "-device", "virtio-serial,id=qga0,%s" % qga_pci_info,
+        "-device", "virtio-serial,id=qga0",
         "-device", "virtserialport,chardev=qga0,name=org.qemu.guest_agent.0",
         ])
 


### PR DESCRIPTION
According to `doc/design-hotplug.rst`, explicit PCI slot management via KVM runtime is for Disks and NICs only (see also comment on `update_hvinfo()`). Current PCI slot assignment is calculated from KVM runtime, not live query. This way, misuse of PCI slots, like QGA, are not detected. While QMP `query-pci` would cover virtio-blk-pci and virtio-net-pci, it does not cover the SCSI disk case. Keeping the fix simple, let QGA use an implicit Qemu managed PCI slot (like spice agent virtio-serial).

This fixes #1620