### PR TITLE
Allow to run QA suite's instance tests with alternating HV parameters

### DIFF
--- a/qa/qa-sample.json
+++ b/qa/qa-sample.json
@@ -240,6 +240,7 @@
     "instance-list": true,
     "instance-migrate": true,
     "instance-modify": true,
+    "instance-iterate-hvparams": true,
     "instance-modify-primary": true,
     "instance-modify-disks": false,
     "instance-reboot": true,


### PR DESCRIPTION
The QA suite currently does not test different values to hypervisor parameters (e.g. `use_chroot`, `use_guest_agent` etc.). This PR implements automatic cycling through values of boolean parameters and parameters which values are known to Ganeti (e.g. `disk_cache`).

It does not cover parameters which accept custom values and it also does not cover parameters which need to be set along with others (e.g. `security_model` and `security_domain`). However, this could be implemented on top of this patch later on. 

The hvparam tests have their own switch in the QA suite configuration as they run **all** enabled instance tests (e.g. create/migrate/hotplugging etc.) **for each hypervisor parameter**, which is very time consuming. If they are disabled the QA suite will fall back to the old behaviour and only run instance tests with the default parameters.

Currently, only KVM HV parameters are used, but it is also possible to add checks for Xen/LXC parameters.

@saschalucas This patch correctly uncovers the bug you are trying to fix in #1622. Once this patch gets merged, I can have the QA suite verify if our PR fixes the problem without any sideeffects.