### PR TITLE
Add rapi support for --ssl-chain

### DIFF
--- a/lib/http/__init__.py
+++ b/lib/http/__init__.py
@@ -557,7 +557,7 @@ class HttpSslParams(object):
   """Data class for SSL key and certificate.
 
   """
-  def __init__(self, ssl_key_path, ssl_cert_path):
+  def __init__(self, ssl_key_path, ssl_cert_path, ssl_chain_path=None):
     """Initializes this class.
 
     @type ssl_key_path: string
@@ -570,12 +570,16 @@ class HttpSslParams(object):
     self.ssl_key_pem = utils.ReadFile(ssl_key_path)
     self.ssl_cert_pem = utils.ReadFile(ssl_cert_path)
     self.ssl_cert_path = ssl_cert_path
+    self.ssl_chain_path = ssl_chain_path
 
   def GetCertificateDigest(self):
     return utils.GetCertificateDigest(cert_filename=self.ssl_cert_path)
 
   def GetCertificateFilename(self):
     return self.ssl_cert_path
+
+  def GetChain(self):
+      return self.ssl_chain_path
 
   def GetKey(self):
     return OpenSSL.crypto.load_privatekey(OpenSSL.crypto.FILETYPE_PEM,
@@ -624,9 +628,13 @@ class HttpBase(object):
 
     self._ssl_key = ssl_params.GetKey()
     self._ssl_cert = ssl_params.GetCertificate()
+    self._ssl_chain = ssl_params.GetChain()
 
     ctx = OpenSSL.SSL.Context(OpenSSL.SSL.SSLv23_METHOD)
     ctx.set_options(OpenSSL.SSL.OP_NO_SSLv2)
+
+    if self._ssl_chain:
+        ctx.use_certificate_chain_file(self._ssl_chain)
 
     ciphers = self.GetSslCiphers()
     logging.debug("Setting SSL cipher string %s", ciphers)

--- a/lib/server/rapi.py
+++ b/lib/server/rapi.py
@@ -330,7 +330,8 @@ def CheckRapi(options, args):
   # Read SSL certificate (this is a little hackish to read the cert as root)
   if options.ssl:
     options.ssl_params = http.HttpSslParams(ssl_key_path=options.ssl_key,
-                                            ssl_cert_path=options.ssl_cert)
+                                            ssl_cert_path=options.ssl_cert,
+                                            ssl_chain_path=options.ssl_chain)
   else:
     options.ssl_params = None
 
@@ -387,6 +388,9 @@ def Main():
                     default=20, type="int",
                     help="Number of simultaneous connections accepted"
                     " by ganeti-rapi")
+  parser.add_option("--ssl-chain", dest="ssl_chain",
+                    help="SSL Certificate chain path",
+                    default=None, type="string")
 
   daemon.GenericMain(constants.RAPI, parser, CheckRapi, PrepRapi, ExecRapi,
                      default_ssl_cert=pathutils.RAPI_CERT_FILE,

--- a/man/ganeti-rapi.rst
+++ b/man/ganeti-rapi.rst
@@ -11,7 +11,7 @@ Synopsis
 
 | **ganeti-rapi** [-d] [-f] [-p *PORT*] [-b *ADDRESS*] [-i *INTERFACE*]
 | [\--max-clients *CLIENTS*] [\--no-ssl] [-K *SSL_KEY_FILE*]
-| [-C *SSL_CERT_FILE*] | [\--require-authentication]
+| [-C *SSL_CERT_FILE*] | [\--require-authentication] [\--ssl-chain *SSL_CHAIN_FILE*]
 
 DESCRIPTION
 -----------
@@ -23,6 +23,9 @@ It is automatically started on the master node, and by default it
 uses SSL encryption. This can be disabled by passing the
 ``--no-ssl`` option, or alternatively the certificate used can be
 changed via the ``-C`` option and the key via the ``-K`` option.
+If your certificate chain involves intermediate certificates that
+the server needs to present that chain file can be privided with
+``--ssl-chain``.
 
 The daemon will listen to the "ganeti-rapi" TCP port, as listed in the
 system services database, or if not defined, to port 5080 by default.


### PR DESCRIPTION
This is so rapi can be used with modern Let's Encrypt certificates.
