### PR TITLE
QA Suite: fix missing 'None' defaults of HVParams when alternating through possible values

### DIFF
--- a/qa/qa_cluster.py
+++ b/qa/qa_cluster.py
@@ -171,7 +171,13 @@ def PrepareHvParameterSets():
 
   for param, values in toggle_value_params.items():
     list_values = list(values)
-    list_values.remove(hv_params[param])
+    if hv_params[param] in list_values:
+      # some HVParams accept 'None' as valid value which is never part
+      # of the list of allowed values, hence we need this check
+      #
+      # if the current value of the HVParam is part of the list of
+      # allowed values, remove it to avoid unnecessary test cycles
+      list_values.remove(hv_params[param])
     assembled_tests[param] = {
       "values": list_values,
       "reset_value": hv_params[param],


### PR DESCRIPTION
Commit c0ad0f3f5 (#1624) introduced alternating HV parameters to the QA suite. However, it broke on parameters like 'usb_mouse' which have a configured set of allowed values but also allow being set to 'None' (the latter is not part of the configured defaults in the Constants.hs file).

This simple fix allows the QA suite to deal with HV parameters whose current values are not part of the list of allowed values.

I guess the 'correct' way to fix this would be to add 'None' to the list of possible values where applicable. That would require a rather large change to the codebase. Currently the validation for 'None' values is implemented [here](https://github.com/ganeti/ganeti/blob/c0ad0f3f52acb2027e3d726a4dc2348dccba155a/lib/hypervisor/hv_base.py#L157) and e.g. [here](https://github.com/ganeti/ganeti/blob/c0ad0f3f52acb2027e3d726a4dc2348dccba155a/lib/hypervisor/hv_kvm/__init__.py#L555-L556).

@saschalucas this actually breaks the QA suite for KVM atm. I think (hope) we can proceed with other PRs once this fix has been accepted.