### PR TITLE
Adjust for Pyparsing 3.0.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -38,7 +38,7 @@ Before installing, please verify that you have the following programs:
 - `Python OpenSSL bindings <https://www.pyopenssl.org/>`_
 - `simplejson Python module <https://simplejson.readthedocs.io/>`_
 - `pyparsing Python module <https://pyparsing-docs.readthedocs.io/>`_, version
-  1.4.6 or above
+  1.5.7 or above
 - `pyinotify Python module <https://github.com/seb-m/pyinotify>`_
 - `PycURL Python module <http://pycurl.io/>`_
 - `socat <http://www.dest-unreach.org/socat/>`_, see :ref:`note

--- a/lib/qlang.py
+++ b/lib/qlang.py
@@ -221,7 +221,7 @@ def BuildFilterParser():
                glob_cond ^ not_glob_cond)
 
   # Associativity operators
-  filter_expr = pyp.operatorPrecedence(condition, [
+  filter_expr = pyp.infixNotation(condition, [
     (pyp.Keyword("not").suppress(), 1, pyp.opAssoc.RIGHT,
      lambda toks: [[OP_NOT, toks[0][0]]]),
     (pyp.Keyword("and").suppress(), 2, pyp.opAssoc.LEFT,


### PR DESCRIPTION
`operatorPrecedence` was renamed to `infixNotation` in pyparsing 1.5.7 (from 2012) and finally removed in 3.x.

Please also backport to 3.0.