### PR TITLE
Improve Ganeti QA runtime/logging

### DIFF
--- a/qa/ganeti-qa.py
+++ b/qa/ganeti-qa.py
@@ -841,9 +841,6 @@ def RunInstanceTests():
                                     templ)
             qa_cluster.AssertClusterHvParameterModify(
               param, test_data["reset_value"])
-          else:
-            RunInstanceTestsInner(create_fun, inodes, supported_conversions,
-                                  templ)
         else:
           test_desc = "Iterating through hypervisor parameter values"
           ReportTestSkip(test_desc, "instance-iterate-hvparams")

--- a/qa/qa_cluster.py
+++ b/qa/qa_cluster.py
@@ -153,11 +153,14 @@ def PrepareHvParameterSets():
       "use_localtime",
     ]
 
+    # in general, we toggle through all values known to Ganeti, except:
+    # we cannot use all available disk_types because some require
+    # special backing devices/files (e.g. pflash, mtd)
     toggle_value_params = {
       "disk_aio": constants.HT_KVM_VALID_AIO_TYPES,
       "disk_cache": constants.HT_VALID_CACHE_TYPES,
-      "disk_type": constants.HT_KVM_VALID_DISK_TYPES,
       "usb_mouse": constants.HT_KVM_VALID_MOUSE_TYPES,
+      "disk_type": ["ide", "paravirtual"],
     }
 
   assembled_tests = {}

--- a/qa/qa_cluster.py
+++ b/qa/qa_cluster.py
@@ -181,9 +181,13 @@ def PrepareHvParameterSets():
       # if the current value of the HVParam is part of the list of
       # allowed values, remove it to avoid unnecessary test cycles
       list_values.remove(hv_params[param])
+    if hv_params[param] is None:
+      reset_value = ""
+    else:
+      reset_value = hv_params[param]
     assembled_tests[param] = {
       "values": list_values,
-      "reset_value": hv_params[param],
+      "reset_value": reset_value,
     }
 
   return assembled_tests


### PR DESCRIPTION
This PR addresses recent problems with the QA suite:
* it improves where #1626 and #1624 left:
  * it is not in all cases desirable to iterate through all defined values of a hypervisor parameter (e.g. KVM's `disk_type`)
  * there was an unnecessary step added to the test loop
  * the instance tests that are run for each hypervisor parameter have been reduced to a useful minimum which saves several hours of QA runtime
  * fix resetting the hypervisor parameter to its default, when the default was `None`
* it creates a separate log file ($log_path/qa-profile.log) which only stores the test names and their duration to ease analyzing of the QA suite's performance
