### PR TITLE
Warn users that changing DRBD parameters does not affect running instances

### DIFF
--- a/lib/cmdlib/cluster/__init__.py
+++ b/lib/cmdlib/cluster/__init__.py
@@ -1272,6 +1272,16 @@ class LUClusterSetParams(LogicalUnit):
     self._CheckDrbdHelper(vm_capable_node_uuids,
                           drbd_enabled, drbd_gets_enabled)
 
+    if (self.op.diskparams is not None and
+            constants.DT_DRBD8 in self.op.diskparams):
+      self.LogWarning("Changing DRBD parameters only affects devices created "
+                      "in the future, not existing ones")
+      self.LogWarning("You need to shutdown and start (not reboot!) existing "
+                      "instances to adopt the changes")
+      self.LogWarning("Alternatively you can swap the secondary node by "
+                      "running `gnt-instance replace-disks --new-secondary "
+                      "$instance`")
+
     # validate params changes
     if self.op.beparams:
       objects.UpgradeBeParams(self.op.beparams)


### PR DESCRIPTION
When a user changes DRBD parameters (e.g. sync-related parameters) they will be only used in future DRBD setups and not applied to currently existing ones. This only adds a warning. A better solution would be to have `activate-disks` apply changed parameters where possible and either add this information to the warning message or remove it and run activate-disks automatically for all existing devices.

Partially fixes #781
