### PR TITLE
Workaround for NIC hotplugging with chrooted qemu and QA suite fix for ACPI/hotplugging

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -2291,12 +2291,14 @@ class KVMHypervisor(hv_base.BaseHypervisor):
       self.qmp.HotAddDisk(device, kvm_devid, uri, drive_add_fn)
     elif dev_type == constants.HOTPLUG_TARGET_NIC:
       kvmpath = instance.hvparams[constants.HV_KVM_PATH]
+      is_chrooted = instance.hvparams[constants.HV_KVM_USE_CHROOT]
       kvmhelp = self._GetKVMOutput(kvmpath, self._KVMOPT_HELP)
       devlist = self._GetKVMOutput(kvmpath, self._KVMOPT_DEVICELIST)
       features, _, _ = self._GetNetworkDeviceFeatures(up_hvp, devlist, kvmhelp)
       (tap, tapfds, vhostfds) = OpenTap(features=features)
       self._ConfigureNIC(instance, seq, device, tap)
-      self.qmp.HotAddNic(device, kvm_devid, tapfds, vhostfds, features)
+      self.qmp.HotAddNic(device, kvm_devid, tapfds, vhostfds, features,
+                         is_chrooted)
       utils.WriteFile(self._InstanceNICFile(instance.name, seq), data=tap)
 
     self._VerifyHotplugCommand(instance, kvm_devid, True)

--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -465,7 +465,8 @@ class QmpConnection(MonitorSocket):
     return ret
 
   @_ensure_connection
-  def HotAddNic(self, nic, devid, tapfds=None, vhostfds=None, features=None):
+  def HotAddNic(self, nic, devid, tapfds=None, vhostfds=None, features=None,
+                is_chrooted=False):
     """Hot-add a NIC
 
     First pass the tapfds, then netdev_add and then device_add
@@ -492,6 +493,7 @@ class QmpConnection(MonitorSocket):
       "id": devid,
       "fds": ":".join(fdnames),
     }
+
     if enable_vhost:
       fdnames = []
       for i, fd in enumerate(vhostfds):
@@ -509,6 +511,11 @@ class QmpConnection(MonitorSocket):
       "netdev": devid,
       "mac": nic.mac,
     }
+    if is_chrooted:
+      # do not try to load a rom file when we are running qemu chrooted
+      arguments.update({
+        "romfile": "",
+      })
     # Note that hvinfo that _GenerateDeviceHVInfo() creates
     # should include *only* the driver, id, bus, and addr keys
     arguments.update(self._filter_hvinfo(nic.hvinfo))


### PR DESCRIPTION
This PR addresses two problems:

* hotplugging does not work when ACPI is disabled - as this might be the case during the QA runs (e.g. due to alternating through hvparams), the QA suite now only runs hotplug tests when ACPI is enabled for the guest
* while fixing the above I stumbled on another problem: when QEMU runs chrooted, one can not hotplug a NIC because qemu tries to load a PXE rom file which is not present in the chroot (`failed to find romfile "$depends_on_the_driver.rom"` error message). When chrooting is enabled, QMPs `device_add` will now be instructed to not load a rom file from disk

I guess the latter is more of a workaround. Either Ganeti should setup the chroot environment correctly (e.g. provide required rom files inside the chroot) or have the actual hotplug command fail early with a note that hotplugging nics is not possible while running qemu in a chroot. OTOH I am not sure how relevant PXE roms are when NICs are hot-added to already running systems.