### PR TITLE
Fix lvcreate for newer lvm versions (#1586)

### DIFF
--- a/lib/storage/bdev.py
+++ b/lib/storage/bdev.py
@@ -215,7 +215,10 @@ class LogicalVolume(base.BlockDev):
     # create an optimally-striped volume; in that case, we want to try
     # with N, N-1, ..., 2, and finally 1 (non-stripped) number of
     # stripes
-    cmd = ["lvcreate", "-L%dm" % size, "-n%s" % lv_name]
+    # When run non-interactively, newer LVM versions will fail (unless
+    # `--yes` is specified) when an existing filesystem signature is
+    # encountered while creating a new LV. Using `-Wn` disables this check.
+    cmd = ["lvcreate", "-Wn", "-L%dm" % size, "-n%s" % lv_name]
     for stripes_arg in range(stripes, 0, -1):
       result = utils.RunCmd(cmd + ["-i%d" % stripes_arg] + [vg_name] + pvlist)
       if not result.failed:


### PR DESCRIPTION
This backports #1586 into stable-3.0 for the upcoming 3.0.2 release.