### PR TITLE
make python tests compatible with roman 3.2+

### DIFF
--- a/test/py/ganeti.compat_unittest.py
+++ b/test/py/ganeti.compat_unittest.py
@@ -84,7 +84,8 @@ class TestTryToRoman(testutils.GanetiTestCase):
   def testAFewIntegers(self):
     # This test only works is the roman module is installed
     if compat.roman is not None:
-      self.assertEqual(compat.TryToRoman(0), 0)
+      # starting with roman 3.2 single-digit 0 now converts to 'N' instead of 0
+      self.assertIn(compat.TryToRoman(0), [0, 'N'])
       self.assertEqual(compat.TryToRoman(1), "I")
       self.assertEqual(compat.TryToRoman(4), "IV")
       self.assertEqual(compat.TryToRoman(5), "V")


### PR DESCRIPTION
Ganeti 2.1.3 added the following feature:

> Now with ancient latin support. Try it passing the ``--roman`` option to
> ``gnt-instance info``, ``gnt-cluster info`` or ``gnt-node list``
> (requires the python-roman module to be installed, in order to work).

..which was again partially removed with 2.4.0 beta1:
> - Removed support for roman numbers from ``gnt-node list`` and
>  ``gnt-instance list``.

Tests are currently breaking on Ubuntu Jammy (upcoming LTS release) as it the roman Python library has changed its behavior with version 3.2 and now formats a single digit `0` as 'N', rather than `0` (the following is taken from the roman module [changelog](https://pypi.org/project/roman/)):

> Added support for 0 -> N (see https://en.wikipedia.org/wiki/Roman_numerals#Zero)

I am really not sure what this `--roman` support is all about and frankly it looks more like an Aprils fool, which makes it tempting to remove this altogether from the codebase. Maybe someone can enlighten me here (CC @iustin? :-) ).

Anyways, this PR simply broadens the test for `0` a bit by accepting both `0` and 'N' as valid outcome. As the library is only used for output formatting and never for any input parsing, this seems to be the least-effort solution.

