### PR TITLE
KVM: repeat QMP shutdown request every 10 seconds

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -2432,20 +2432,6 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     else:
       return "pc"
 
-  def _WaitForInstanceToShutdown(self, timeout, name):
-    """Wait for QEMU to shut down within a given timeout
-
-    """
-    tick = 1
-    while tick <= timeout:
-      _, _, alive = self._InstancePidAlive(name)
-      if not alive:
-        logging.info("KVM: instance %s finished shutdown after %d seconds"
-                     % (name, tick))
-        break
-      tick += 1
-      time.sleep(1)
-
   @_with_qmp
   def _StopInstance(self, instance, force=False, name=None, timeout=None):
     """Stop an instance.
@@ -2466,8 +2452,6 @@ class KVMHypervisor(hv_base.BaseHypervisor):
         utils.KillProcess(pid)
       else:
         self.qmp.Powerdown()
-        if timeout is not None:
-          self._WaitForInstanceToShutdown(timeout, name)
 
     self._ClearUserShutdown(instance.name)
 


### PR DESCRIPTION
When instances start and stop in short order (which happens e.g. during the QA suite tests) the guest usually is not yet able to receive ACPI shutdown events, hence triggering the 120 second shutdown timeout. This expands the QA runtime from a few hours to sometimes > 12 hours.

Ganeti now signals the KVM guest to shut down every 10 seconds until the shutdown timeout has been reached. This avoids the aforementioned scenario (or any other case where the guest might miss the shutdown event). According to some tests, this does not affect guests in negative ways, but it surely needs some in-depth testing.

I will update this PR as soon as I have tested several different guest systems. 
