### PR TITLE
HTTP/TLS implementation: fix OpenSSL exceptions during portprobing

### DIFF
--- a/lib/http/__init__.py
+++ b/lib/http/__init__.py
@@ -79,6 +79,8 @@ HTTP_APP_OCTET_STREAM = "application/octet-stream"
 HTTP_APP_JSON = "application/json"
 
 _SSL_UNEXPECTED_EOF = "Unexpected EOF"
+_SSL_SHUTDOWN_DURING_INIT = ('SSL routines', 'SSL_shutdown',
+                             'shutdown while in init')
 
 # Socket operations
 (SOCKOP_SEND,
@@ -484,6 +486,11 @@ def SocketOperation(sock, op, arg1, timeout):
         raise socket.error(err.args)
 
       except OpenSSL.SSL.Error as err:
+        if err.args[0] == [_SSL_SHUTDOWN_DURING_INIT]:
+          host, port = sock.getpeername()
+          logging.warning("OpenSSL: unexpected shutdown while in init from"
+                          " %s:%d" % (host, port))
+          break
         raise socket.error(err.args)
 
     except socket.error as err:


### PR DESCRIPTION
During a `gnt-cluster verify` run, Ganeti runs the method `VerifyNodeNetTest()` from each node. This method checks if all other noded are reachable from all nodes by using the `netutils.TcpPing()` method which simply opens and closes a socket.

This triggers an OpenSSL exception in the HTTP/TLS implementation of Ganeti because no successful TLS handshake happens:
```
Traceback (most recent call last):
  File "/usr/share/ganeti/3.1/ganeti/http/__init__.py", line 433, in SocketOperation
    return sock.shutdown()
  File "/usr/lib/python3/dist-packages/OpenSSL/SSL.py", line 1914, in shutdown
    self._raise_ssl_error(self._ssl, result)
  File "/usr/lib/python3/dist-packages/OpenSSL/SSL.py", line 1566, in _raise_ssl_error
    _raise_current_error()
  File "/usr/lib/python3/dist-packages/OpenSSL/_util.py", line 57, in exception_from_error_queue
    raise exception_type(errors)
OpenSSL.SSL.Error: [('SSL routines', 'SSL_shutdown', 'shutdown while in init')]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/ganeti/3.1/ganeti/http/__init__.py", line 529, in ShutdownConnection
    SocketOperation(sock, SOCKOP_SHUTDOWN, socket.SHUT_RDWR,
  File "/usr/share/ganeti/3.1/ganeti/http/__init__.py", line 487, in SocketOperation
    raise socket.error(err.args)
OSError: ([('SSL routines', 'SSL_shutdown', 'shutdown while in init')],)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/ganeti/3.1/ganeti/http/server.py", line 618, in _IncomingConnection
    self.request_executor(self, self.handler, connection, client_addr)
  File "/usr/share/ganeti/3.1/ganeti/server/noded.py", line 156, in __init__
    http.server.HttpServerRequestExecutor.__init__(self, *args, **kwargs)
  File "/usr/share/ganeti/3.1/ganeti/http/server.py", line 444, in __init__
    http.ShutdownConnection(sock, self.CLOSE_TIMEOUT, self.WRITE_TIMEOUT,
  File "/usr/share/ganeti/3.1/ganeti/http/__init__.py", line 536, in ShutdownConnection
    raise HttpError("Error while shutting down connection: %s" % err)
ganeti.http.HttpError: Error while shutting down connection: ([('SSL routines', 'SSL_shutdown', 'shutdown while in init')],)
```

This commit detects this specific error and replaces the stacked exceptions with a simple error message which makes reading the log much easier:
```
ganeti-noded pid=40276 server:418 DEBUG Connection from 192.168.122.23:34765
ganeti-noded pid=40276 server:428 DEBUG Unexpected EOF from 192.168.122.23:34765
ganeti-noded pid=40276 __init__:490 ERROR OpenSSL: unexpected shutdown while in init
ganeti-noded pid=40276 server:449 DEBUG Disconnected 192.168.122.23:34765
ganeti-noded pid=40276 server:620 DEBUG Request from 192.168.122.23:34765 executed in: 0.0269 [setup: 0.0019] [workers: 1]
```

Is the loglevel ERROR here OK? Should it rather be WARNING or DEBUG?