### PR TITLE
PyYAML 6.0 compatibility

### DIFF
--- a/qa/qa_utils.py
+++ b/qa/qa_utils.py
@@ -450,7 +450,7 @@ def GetObjectInfo(infocmd):
   master = qa_config.GetMasterNode()
   cmdline = utils.ShellQuoteArgs(infocmd)
   info_out = GetCommandOutput(master.primary, cmdline)
-  return yaml.load(info_out)
+  return yaml.load(info_out, Loader=yaml.FullLoader)
 
 
 def UploadFile(node, src):

--- a/qa/qa_utils.py
+++ b/qa/qa_utils.py
@@ -450,7 +450,7 @@ def GetObjectInfo(infocmd):
   master = qa_config.GetMasterNode()
   cmdline = utils.ShellQuoteArgs(infocmd)
   info_out = GetCommandOutput(master.primary, cmdline)
-  return yaml.load(info_out, Loader=yaml.FullLoader)
+  return yaml.load(info_out, Loader=yaml.SafeLoader)
 
 
 def UploadFile(node, src):

--- a/test/py/ganeti.cli_unittest.py
+++ b/test/py/ganeti.cli_unittest.py
@@ -1142,14 +1142,14 @@ class TestFormatPolicyInfo(unittest.TestCase):
     self.assertTrue(constants.IPOLICY_DTS in parsed)
     parsed[constants.IPOLICY_DTS] = yaml.load("[%s]" %
                                               parsed[constants.IPOLICY_DTS],
-                                              Loader=yaml.FullLoader)
+                                              Loader=yaml.SafeLoader)
 
   @staticmethod
   def _PrintAndParsePolicy(custom, effective, iscluster):
     formatted = cli.FormatPolicyInfo(custom, effective, iscluster)
     buf = StringIO()
     cli._SerializeGenericInfo(buf, formatted, 0)
-    return yaml.load(buf.getvalue(), Loader=yaml.FullLoader)
+    return yaml.load(buf.getvalue(), Loader=yaml.SafeLoader)
 
   def _PrintAndCheckParsed(self, policy):
     parsed = self._PrintAndParsePolicy(policy, NotImplemented, True)

--- a/test/py/ganeti.cli_unittest.py
+++ b/test/py/ganeti.cli_unittest.py
@@ -1141,14 +1141,15 @@ class TestFormatPolicyInfo(unittest.TestCase):
           self._RenameDictItem(minmax, key, keyparts[0])
     self.assertTrue(constants.IPOLICY_DTS in parsed)
     parsed[constants.IPOLICY_DTS] = yaml.load("[%s]" %
-                                              parsed[constants.IPOLICY_DTS])
+                                              parsed[constants.IPOLICY_DTS],
+                                              Loader=yaml.FullLoader)
 
   @staticmethod
   def _PrintAndParsePolicy(custom, effective, iscluster):
     formatted = cli.FormatPolicyInfo(custom, effective, iscluster)
     buf = StringIO()
     cli._SerializeGenericInfo(buf, formatted, 0)
-    return yaml.load(buf.getvalue())
+    return yaml.load(buf.getvalue(), Loader=yaml.FullLoader)
 
   def _PrintAndCheckParsed(self, policy):
     parsed = self._PrintAndParsePolicy(policy, NotImplemented, True)


### PR DESCRIPTION
PyYAML 6.0 and later requires an explicit `Loader` argument.  The first commit in this PR adds a `Loader` that preserves previous behavior, while the second commit switches to `SafeLoader` for good measure (mainly to prevent cargo-culting a poor example).

I suppose this should be backported to 3.0 (will there be a 3.0.3?).