### PR TITLE
QA: fix SSH multiplexing setup

### DIFF
--- a/qa/ganeti-qa.py
+++ b/qa/ganeti-qa.py
@@ -1178,12 +1178,11 @@ def main():
 
   qa_config.Load(config_file)
 
-  primary = qa_config.GetMasterNode().primary
-  qa_utils.StartMultiplexer(primary)
-  print("SSH command for primary node: %s" %
-        utils.ShellQuoteArgs(qa_utils.GetSSHCommand(primary, "")))
-  print("SSH command for other nodes: %s" %
-        utils.ShellQuoteArgs(qa_utils.GetSSHCommand("NODE", "")))
+  for node in qa_config.GetAllNodes():
+    qa_utils.StartMultiplexer(node.primary)
+    print("SSH command for node %s: %s" % (node.primary,
+          utils.ShellQuoteArgs(qa_utils.GetSSHCommand(node.primary, ""))))
+
   try:
     RunQa()
   finally:

--- a/qa/qa_config.py
+++ b/qa/qa_config.py
@@ -60,6 +60,8 @@ _QA_PATCH_ORDER_FILE = "order"
 #: QA configuration (L{_QaConfig})
 _config = None
 
+MULTIPLEXERS = {}
+
 
 class _QaInstance(object):
   __slots__ = [

--- a/qa/qa_utils.py
+++ b/qa/qa_utils.py
@@ -66,8 +66,6 @@ from qa import qa_error
 from qa_logging import FormatInfo
 
 
-_MULTIPLEXERS = {}
-
 #: Unique ID per QA run
 _RUN_UUID = utils.NewUUID()
 
@@ -309,8 +307,8 @@ def GetSSHCommand(node, cmd, strict=True, opts=None, tty=False,
   args.append("-oForwardAgent=%s" % ("yes" if forward_agent else "no", ))
   if opts:
     args.extend(opts)
-  if node in _MULTIPLEXERS and use_multiplexer:
-    spath = _MULTIPLEXERS[node][0]
+  if node in qa_config.MULTIPLEXERS and use_multiplexer:
+    spath = qa_config.MULTIPLEXERS[node][0]
     args.append("-oControlPath=%s" % spath)
     args.append("-oControlMaster=no")
 
@@ -366,7 +364,7 @@ def StartMultiplexer(node):
   @param node: the node for which to open the multiplexer
 
   """
-  if node in _MULTIPLEXERS:
+  if node in qa_config.MULTIPLEXERS:
     return
 
   # Note: yes, we only need mktemp, since we'll remove the file anyway
@@ -375,15 +373,15 @@ def StartMultiplexer(node):
   opts = ["-N", "-oControlPath=%s" % sname, "-oControlMaster=yes"]
   print("Created socket at %s" % sname)
   child = StartLocalCommand(GetSSHCommand(node, None, opts=opts))
-  _MULTIPLEXERS[node] = (sname, child)
+  qa_config.MULTIPLEXERS[node] = (sname, child)
 
 
 def CloseMultiplexers():
   """Closes all current multiplexers and cleans up.
 
   """
-  for node in list(_MULTIPLEXERS):
-    (sname, child) = _MULTIPLEXERS.pop(node)
+  for node in list(qa_config.MULTIPLEXERS):
+    (sname, child) = qa_config.MULTIPLEXERS.pop(node)
     utils.KillProcess(child.pid, timeout=10, waitpid=True)
     utils.RemoveFile(sname)
 


### PR DESCRIPTION
[SSH multiplexing](https://blog.scottlowe.org/2015/12/11/using-ssh-multiplexing/) was broken in the QA suite, because the code only used to set up a multiplexing connection to the first node, not for all nodes.

Addtionally, there was a bug that let to the multiplexer not being used in certain scenarios. Multplexed connections are stored in the `qua_utils._MULTIPLEXERS` dictionary. However, since the `qa_utils` module gets imported in two different flavors at the same time (as the entire module but also selected functions directly like `AssertCommand()`). Only one instance had the `_MULTIPLEXERS`  dict populated - SSH calls with e.g. `AssertCommand()` in the callstack would not be able to use the multiplexed connections.
This is fixed bei moving the `_MULTIPLEXERS` dictionary over to the `qa_config` module which only has one instance throughout the entire QA.

This speeds up the QA on a multi-node cluster by a few minutes (depending on the actual QA setup).

