### PR TITLE
Added 'custom_osparams' to the rapi I_FIELDS.

### DIFF
--- a/lib/rapi/rlib2.py
+++ b/lib/rapi/rlib2.py
@@ -91,6 +91,7 @@ I_FIELDS = ["name", "admin_state", "os",
             "beparams", "hvparams",
             "oper_state", "oper_ram", "oper_vcpus", "status",
             "custom_hvparams", "custom_beparams", "custom_nicparams",
+            "custom_osparams",
             ] + _COMMON_FIELDS
 
 N_FIELDS = ["name", "offline", "master_candidate", "drained",


### PR DESCRIPTION
We developed a number of clients that need access to the custom_osparams field via the Ganeti remote API.