### PR TITLE
Replace pep8 with pycodestyle

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2141,7 +2141,7 @@ standalone_python_modules = \
 	lib/rapi/client.py \
 	tools/ganeti-listrunner
 
-pep8_python_code = \
+pycodestyle_python_code = \
 	ganeti \
 	ganeti/http/server.py \
 	$(dist_sbin_SCRIPTS) \
@@ -2688,6 +2688,7 @@ hs-shell: test/hs/hpc-htools test/hs/hpc-mon-collector $(HS_BUILT_TEST_HELPERS)
 hs-check: hs-tests hs-shell
 
 # E111: indentation is not a multiple of four
+# E114: indentation is not a multiple of four (comment)
 # E121: continuation line indentation is not a multiple of four
 #       (since our indent level is not 4)
 # E125: continuation line does not distinguish itself from next logical line
@@ -2701,7 +2702,7 @@ hs-check: hs-tests hs-shell
 # instead of silencing it
 # E261: at least two spaces before inline comment
 # E501: line too long (80 characters)
-PEP8_IGNORE = E111,E121,E123,E125,E127,E261,E501
+PEP8_IGNORE = E111,E114,E121,E123,E125,E127,E261,E501
 
 # For excluding pep8 expects filenames only, not whole paths
 PEP8_EXCLUDE = $(subst $(space),$(comma),$(strip $(notdir $(built_python_sources))))
@@ -2730,8 +2731,8 @@ LINT_OPTS_ALL = $(LINT_OPTS) \
 LINT_OPTS_ALL += --extension-pkg-whitelist=pycurl
 
 LINT_TARGETS = pylint pylint-qa pylint-test
-if HAS_PEP8
-LINT_TARGETS += pep8
+if HAS_PYCODESTYLE
+LINT_TARGETS += pycodestyle
 endif
 if HAS_HLINT
 LINT_TARGETS += hlint
@@ -2758,11 +2759,16 @@ pylint-test: $(GENERATED_FILES)
 		PYTHONPATH=.:./test/py $(PYLINT) $(LINT_OPTS_ALL) \
 		--rcfile=pylintrc-test  $(python_test_support) $(python_test_utils)
 
-.PHONY: pep8
-pep8: $(GENERATED_FILES)
-	@test -n "$(PEP8)" || { echo 'pep8' not found during configure; exit 1; }
-	$(PEP8) --ignore='$(PEP8_IGNORE)' --exclude='$(PEP8_EXCLUDE)' \
-	  --repeat $(pep8_python_code)
+.PHONY: pycodestyle
+pycodestyle: $(GENERATED_FILES)
+	@test -n "$(PYCODESTYLE)" || { echo 'pycodestyle' not found during configure; exit 1; }
+	$(PYCODESTYLE) --ignore='$(PEP8_IGNORE)' --exclude='$(PEP8_EXCLUDE)' \
+	--repeat $(pycodestyle_python_code)
+
+pycodestyle-stats: $(GENERATED_FILES)
+	@test -n "$(PYCODESTYLE)" || { echo 'pycodestyle' not found during configure; exit 1; }
+	$(PYCODESTYLE) --ignore='$(PEP8_IGNORE)' --exclude='$(PEP8_EXCLUDE)' \
+	--repeat --statistics $(pycodestyle_python_code)
 
 HLINT_EXCLUDES = src/Ganeti/THH.hs test/hs/hpc-htools.hs
 .PHONY: hlint

--- a/configure.ac
+++ b/configure.ac
@@ -588,14 +588,14 @@ then
   fi
 fi
 
-# Check for pep8
-AC_ARG_VAR(PEP8, [pep8 path])
-AC_PATH_PROG(PEP8, [pep8], [])
-if test -z "$PEP8"
+# Check for pycodestyle, formerly pep8
+AC_ARG_VAR(PYCODESTYLE, [pycodestyle path])
+AC_PATH_PROG(PYCODESTYLE, [pycodestyle], [])
+if test -z "$PYCODESTYLE"
 then
-  AC_MSG_WARN([pep8 not found, checking code will not be complete])
+  AC_MSG_WARN([pycodestyle not found, checking code will not be complete])
 fi
-AM_CONDITIONAL([HAS_PEP8], [test -n "$PEP8"])
+AM_CONDITIONAL([HAS_PYCODESTYLE], [test -n "$PYCODESTYLE"])
 
 # Check for python3-coverage
 AC_ARG_VAR(PYCOVERAGE, [python3-coverage path])

--- a/doc/devnotes.rst
+++ b/doc/devnotes.rst
@@ -14,15 +14,18 @@ Most dependencies from :doc:`install-quick`, including ``qemu-img``
 - `Gzip <http://www.gnu.org/software/gzip/>`_
 - `pandoc <http://johnmacfarlane.net/pandoc/>`_
 - `python-epydoc <http://epydoc.sourceforge.net/>`_
+  Note: python-epydoc is not compatible with python3
+  and is only available in Debian <= 10 and Ubuntu <= 18.04.
+  We are looking for a suitable replacement.
 - `python-sphinx <http://sphinx.pocoo.org/>`_
-  (tested with version 1.1.3)
+  (tested with version 3.4.3)
 - `python-mock <http://www.voidspace.org.uk/python/mock/>`_
-  (tested with version 1.0.1)
+  (tested with version 4.0.3)
 - `graphviz <http://www.graphviz.org/>`_
 - the `en_US.UTF-8` locale must be enabled on the system
-- `pylint <http://www.logilab.org/857>`_ and its associated
+- `pylint <https://github.com/PyCQA/pylint>`_ and its associated
   dependencies
-- `pep8 <https://github.com/jcrocholl/pep8/>`_
+- `pycodestyle (formerly pep8) <https://github.com/PyCQA/pycodestyle>`_
 - `PyYAML <http://pyyaml.org/>`_
 
 For older developement (Ganeti < 2.4) ``docbook`` was used instead of
@@ -32,31 +35,25 @@ Note that for pylint, at the current moment the following versions
 must be used::
 
     $ pylint --version
-    pylint 0.26.0,
-    astng 0.24.1, common 0.58.3
+      pylint 2.7.2
+      astroid 2.5.1
 
-The same with pep8, other versions may give you errors::
+The same with pycodestyle, other versions may give you errors::
 
-     $ pep8 --version
-     1.3.3
+    $ pycodestyle --version
+      2.6.0
 
-Both these versions are the ones shipped with Ubuntu 13.04.
+Both these versions are the ones shipped with Debian 11 Bullseye.
 
 To generate unittest coverage reports (``make coverage``), `coverage
 <http://pypi.python.org/pypi/coverage>`_ needs to be installed.
 
 Installation of all dependencies listed here::
 
-     $ apt-get install python-setuptools automake git fakeroot
-     $ apt-get install pandoc python-epydoc graphviz python-sphinx
-     $ apt-get install python-yaml
-     $ cd / && easy_install \
-               logilab-astng==0.24.1 \
-               logilab-common==0.58.3 \
-               pylint==0.26.0 \
-               pep8==1.3.3 \
-               mock==1.0.1 \
-               coverage
+     $ apt install python3-setuptools automake git fakeroot \
+           pandoc graphviz python3-sphinx \
+           python3-yaml python3-coverage python3-mock \
+           pylint pycodestyle
 
 For Haskell development, again all things from the quick install
 document, plus:
@@ -86,7 +83,7 @@ document, plus:
 Under Debian Wheezy or later, these can be installed (on top of the
 required ones from the quick install document) via::
 
-  $ apt-get install libghc-quickcheck2-dev libghc-hunit-dev \
+  $ apt install libghc-quickcheck2-dev libghc-hunit-dev \
         libghc-test-framework-dev \
         libghc-test-framework-quickcheck2-dev \
         libghc-test-framework-hunit-dev \


### PR DESCRIPTION
The pep8 tool changed its name to pycodestyle a few years ago and added more errors. This commit allows one to run 'make pycodestyle' instead of 'make pep8'. 'make pycodestyle' produces many style related errors. Errors will have to be added to PEP8_IGNORE or python source code will have to be altered. I used the 2.6.0 version of pycodestyle that is included in Debian bullseye to test everything. I added E114, which is relevant to comment whitespace, to the PEP8_IGNORE variable. It eliminates\hides 2,540 errors.

I also added a 'make pycodestyle-stats' target to print out code style statistics.

Signed-off-by: Zachary Newell <newellz2@unr.edu>