### PR TITLE
Replace google.com/test.com by rfc 2606 domain example.com

### DIFF
--- a/doc/walkthrough.rst
+++ b/doc/walkthrough.rst
@@ -61,7 +61,7 @@ Since this proceeded correctly, let's add the other two nodes::
   on the target machine (node2) with the ones of the current one
   and grant full intra-cluster ssh root access to/from it
 
-  Unable to verify hostkey of host xen-devi-5.fra.corp.google.com:
+  Unable to verify hostkey of host xen-devi-5.fra.corp.example.com:
   f7:…. Do you want to accept it?
   y/[n]/?: %y%
   Mon Oct 26 02:11:53 2009  Authentication to node2 via public key failed, trying password

--- a/test/py/cmdlib/cluster_unittest.py
+++ b/test/py/cmdlib/cluster_unittest.py
@@ -2362,7 +2362,7 @@ class TestLUClusterVerifyGroupHooksCallBack(TestLUClusterVerifyGroupMethods):
 class TestLUClusterVerifyDisks(CmdlibTestCase):
 
   def testVerifyDisks(self):
-    self.cfg.AddNewInstance(uuid="tst1.inst.corp.google.com",
+    self.cfg.AddNewInstance(uuid="tst1.inst.corp.example.com",
                             disk_template=constants.DT_PLAIN)
     op = opcodes.OpClusterVerifyDisks()
     result = self.ExecOpCode(op)
@@ -2370,9 +2370,9 @@ class TestLUClusterVerifyDisks(CmdlibTestCase):
     self.assertEqual(1, len(result["jobs"]))
 
   def testVerifyDisksExt(self):
-    self.cfg.AddNewInstance(uuid="tst1.inst.corp.google.com",
+    self.cfg.AddNewInstance(uuid="tst1.inst.corp.example.com",
                             disk_template=constants.DT_EXT)
-    self.cfg.AddNewInstance(uuid="tst2.inst.corp.google.com",
+    self.cfg.AddNewInstance(uuid="tst2.inst.corp.example.com",
                             disk_template=constants.DT_EXT)
     op = opcodes.OpClusterVerifyDisks()
     result = self.ExecOpCode(op)
@@ -2380,9 +2380,9 @@ class TestLUClusterVerifyDisks(CmdlibTestCase):
     self.assertEqual(0, len(result["jobs"]))
 
   def testVerifyDisksMixed(self):
-    self.cfg.AddNewInstance(uuid="tst1.inst.corp.google.com",
+    self.cfg.AddNewInstance(uuid="tst1.inst.corp.example.com",
                             disk_template=constants.DT_EXT)
-    self.cfg.AddNewInstance(uuid="tst2.inst.corp.google.com",
+    self.cfg.AddNewInstance(uuid="tst2.inst.corp.example.com",
                             disk_template=constants.DT_PLAIN)
     op = opcodes.OpClusterVerifyDisks()
     result = self.ExecOpCode(op)

--- a/test/py/ganeti.backend_unittest.py
+++ b/test/py/ganeti.backend_unittest.py
@@ -169,7 +169,7 @@ class TestNodeVerify(testutils.GanetiTestCase):
 
   def testVerifyNodeNetTestMissingSelf(self):
     my_name = netutils.Hostname.GetSysName()
-    local_data = ([('n1.test.com', "any", "any")], [my_name])
+    local_data = ([('n1.example.com', "any", "any")], [my_name])
     result = backend.VerifyNode({constants.NV_NODENETTEST: local_data},
                                 None, {})
 
@@ -193,7 +193,7 @@ class TestNodeVerify(testutils.GanetiTestCase):
                     "NodeNetTest failed")
 
   def testVerifyNodeNetSkipTest(self):
-    local_data = ([('n1.test.com', "any", "any")], [])
+    local_data = ([('n1.example.com', "any", "any")], [])
     result = backend.VerifyNode({constants.NV_NODENETTEST: local_data},
                                 None, {})
     self.assertTrue(constants.NV_NODENETTEST in result,

--- a/test/py/ganeti.rapi.resources_unittest.py
+++ b/test/py/ganeti.rapi.resources_unittest.py
@@ -62,14 +62,14 @@ class MapperTests(unittest.TestCase):
     self._TestFailingUri("/instances")
     self._TestUri("/version", (rlib2.R_version, [], {}))
 
-    self._TestUri("/2/instances/www.test.com",
+    self._TestUri("/2/instances/www.example.com",
                   (rlib2.R_2_instances_name,
-                   ["www.test.com"],
+                   ["www.example.com"],
                    {}))
 
-    self._TestUri("/2/instances/www.test.com/tags?f=5&f=6&alt=html",
+    self._TestUri("/2/instances/www.example.com/tags?f=5&f=6&alt=html",
                   (rlib2.R_2_instances_name_tags,
-                   ["www.test.com"],
+                   ["www.example.com"],
                    {"alt": ["html"],
                     "f": ["5", "6"],
                    }))


### PR DESCRIPTION
as users do not have control over google.com or test.com zone it is better to use one of the dedicated example domains.