### PR TITLE
GHC 9 compatibility fixes

### DIFF
--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -63,14 +63,14 @@ library
     , unix                          >= 2.5.1.0
     , utf8-string                   >= 0.3.7
 
-    , attoparsec                    >= 0.10.1.1   && < 0.14
-    , base64-bytestring             >= 1.0.0.1    && < 1.2
+    , attoparsec                    >= 0.10.1.1   && < 0.15
+    , base64-bytestring             >= 1.0.0.1    && < 1.3
     , case-insensitive              >= 0.4.0.1    && < 1.3
     , curl                          >= 1.3.7      && < 1.4
     , hinotify                      >= 0.3.2      && < 0.5
     , hslogger                      >= 1.1.4      && < 1.4
     , json                          >= 0.5        && < 1.0
-    , lens                          >= 3.10       && < 5.0
+    , lens                          >= 3.10       && < 6.0
     , lifted-base                   >= 0.2.0.3    && < 0.3
     , monad-control                 >= 0.3.1.3    && < 1.1
     , parallel                      >= 3.2.0.2    && < 3.3

--- a/src/Ganeti/THH.hs
+++ b/src/Ganeti/THH.hs
@@ -884,7 +884,7 @@ genLoadOpCode opdefs fn = do
                   ) $ zip mexps opdefs
       defmatch = Match WildP (NormalB fails) []
       cst = NoBindS $ CaseE (VarE opid) $ mpats++[defmatch]
-      body = DoE [st, cst]
+      body = mkDoE [st, cst]
   -- include "OP_ID" to the list of used keys
   bodyAndOpId <- [| $(return body)
                     <* tell (mkUsedKeys . S.singleton . T.pack $ opidKey) |]
@@ -1541,7 +1541,7 @@ loadExcConstructor inname sname fields = do
                 [x] -> BindS (ListP [VarP x])
                 _   -> BindS (TupP (map VarP f_names))
       cval = appCons name $ map VarE f_names
-  return $ DoE [binds read_args, NoBindS (AppE (VarE 'return) cval)]
+  return $ mkDoE [binds read_args, NoBindS (AppE (VarE 'return) cval)]
 
 {-| Generates the loadException function.
 

--- a/src/Ganeti/THH/Compat.hs
+++ b/src/Ganeti/THH/Compat.hs
@@ -40,9 +40,11 @@ module Ganeti.THH.Compat
   , extractDataDConstructors
   , myNotStrict
   , nonUnaryTupE
+  , mkDoE
   ) where
 
 import Language.Haskell.TH
+import Language.Haskell.TH.Syntax
 
 -- | Convert Names to DerivClauses
 --
@@ -61,7 +63,11 @@ derivesFromNames names = map ConT names
 --
 -- Handle TH 2.11 and 2.12 changes in a transparent manner using the pre-2.11
 -- API.
+#if MIN_VERSION_template_haskell(2,17,0)
+gntDataD :: Cxt -> Name -> [TyVarBndr ()] -> [Con] -> [Name] -> Dec
+#else
 gntDataD :: Cxt -> Name -> [TyVarBndr] -> [Con] -> [Name] -> Dec
+#endif
 gntDataD x y z a b =
 #if MIN_VERSION_template_haskell(2,12,0)
     DataD x y z Nothing a $ derivesFromNames b
@@ -113,4 +119,13 @@ nonUnaryTupE :: [Exp] -> Exp
 nonUnaryTupE es = TupE $ map Just es
 #else
 nonUnaryTupE es = TupE $ es
+#endif
+
+-- | DoE is now qualified with an optional ModName
+mkDoE :: [Stmt] -> Exp
+mkDoE s =
+#if MIN_VERSION_template_haskell(2,17,0)
+    DoE Nothing s
+#else
+    DoE s
 #endif


### PR DESCRIPTION
This PR addresses some (not all) compatibility issues with GHC 9, as found in Debian. The TH changes are relatively simple, and the version bumps are straightforward. Note that Ganeti currently _does not_ build with Lens 5, I'm still investigating this and will open a separate PR.