### PR TITLE
Fix building against GHC 9 / Lens 5

### DIFF
--- a/src/Ganeti/Network.hs
+++ b/src/Ganeti/Network.hs
@@ -87,11 +87,11 @@ data PoolPart = PoolInstances | PoolExt
 addressPoolIso :: Iso' AddressPool BA.BitArray
 addressPoolIso = iso apReservations AddressPool
 
-poolLens :: PoolPart -> Lens' Network (Maybe AddressPool)
+--poolLens :: PoolPart -> Lens' Network (Maybe AddressPool)
 poolLens PoolInstances = networkReservationsL
 poolLens PoolExt = networkExtReservationsL
 
-poolArrayLens :: PoolPart -> Lens' Network (Maybe BA.BitArray)
+--poolArrayLens :: PoolPart -> Lens' Network (Maybe BA.BitArray)
 poolArrayLens part = poolLens part . mapping addressPoolIso
 
 netIpv4NumHosts :: Network -> Integer

--- a/src/Ganeti/Utils/MultiMap.hs
+++ b/src/Ganeti/Utils/MultiMap.hs
@@ -91,7 +91,7 @@ multiMap :: (Ord k, Ord v) => M.Map k (S.Set v) -> MultiMap k v
 multiMap = MultiMap . M.filter (not . S.null)
 
 -- | A 'Lens' that allows to access a set under a given key in a multi-map.
-multiMapL :: (Ord k, Ord v) => k -> Lens' (MultiMap k v) (S.Set v)
+--multiMapL :: (Ord k, Ord v) => k -> Lens' (MultiMap k v) (S.Set v)
 multiMapL k f = fmap MultiMap
                  . at k (fmap (mfilter (not . S.null) . Just)
                          . f . fromMaybe S.empty)

--- a/test/hs/Test/Ganeti/Objects.hs
+++ b/test/hs/Test/Ganeti/Objects.hs
@@ -93,7 +93,13 @@ instance Arbitrary (Container DataCollectorConfig) where
 instance Arbitrary BS.ByteString where
   arbitrary = genPrintableByteString
 
+instance Arbitrary a => Arbitrary (Private a) where
+  arbitrary = Private <$> arbitrary
+
 $(genArbitrary ''PartialNDParams)
+
+instance Arbitrary (Container J.JSValue) where
+  arbitrary = return $ GenericContainer Map.empty
 
 instance Arbitrary Node where
   arbitrary = Node <$> genFQDN <*> genFQDN <*> genFQDN
@@ -297,10 +303,6 @@ genDisk = genDiskWithChildren 3
 -- validation rules.
 $(genArbitrary ''PartialISpecParams)
 
--- | FIXME: This generates completely random data, without normal
--- validation rules.
-$(genArbitrary ''PartialIPolicy)
-
 $(genArbitrary ''FilledISpecParams)
 $(genArbitrary ''MinMaxISpecs)
 $(genArbitrary ''FilledIPolicy)
@@ -308,6 +310,10 @@ $(genArbitrary ''IpFamily)
 $(genArbitrary ''FilledNDParams)
 $(genArbitrary ''FilledNicParams)
 $(genArbitrary ''FilledBeParams)
+
+-- | FIXME: This generates completely random data, without normal
+-- validation rules.
+$(genArbitrary ''PartialIPolicy)
 
 -- | No real arbitrary instance for 'ClusterHvParams' yet.
 instance Arbitrary ClusterHvParams where
@@ -331,17 +337,11 @@ instance Arbitrary OsParams where
 instance Arbitrary Objects.ClusterOsParamsPrivate where
   arbitrary = (GenericContainer . Map.fromList) <$> arbitrary
 
-instance Arbitrary a => Arbitrary (Private a) where
-  arbitrary = Private <$> arbitrary
-
 instance Arbitrary ClusterOsParams where
   arbitrary = (GenericContainer . Map.fromList) <$> arbitrary
 
 instance Arbitrary ClusterBeParams where
   arbitrary = (GenericContainer . Map.fromList) <$> arbitrary
-
-instance Arbitrary IAllocatorParams where
-  arbitrary = return $ GenericContainer Map.empty
 
 $(genArbitrary ''Cluster)
 

--- a/test/hs/Test/Ganeti/Query/Language.hs
+++ b/test/hs/Test/Ganeti/Query/Language.hs
@@ -59,6 +59,9 @@ import Ganeti.Query.Language
 instance Arbitrary (Filter FilterField) where
   arbitrary = genFilter
 
+instance Arbitrary FilterRegex where
+  arbitrary = genName >>= mkRegex -- a name should be a good regex
+
 -- | Custom 'Filter' generator (top-level), which enforces a
 -- (sane) limit on the depth of the generated filters.
 genFilter :: Gen (Filter FilterField)
@@ -96,9 +99,6 @@ $(genArbitrary ''QueryTypeOp)
 $(genArbitrary ''QueryTypeLuxi)
 
 $(genArbitrary ''ItemType)
-
-instance Arbitrary FilterRegex where
-  arbitrary = genName >>= mkRegex -- a name should be a good regex
 
 $(genArbitrary ''ResultStatus)
 


### PR DESCRIPTION
It looks like something in the GHC 9 / Lens 5 combination yields unexpected results when using view on Lens', with GHC complaining that it's passed a Lens' instead of a Getting (which should still be compatible).  Commenting out the signatures of Ganeti.Network.poolLens, Ganeti.Network.poolArrayLens and Ganeti.Utils.MultiMap.multiMapL makes Ganeti build again, so I'd keep this ugly hack until we figure out what's actually wrong.