### PR TITLE
Replace calls to deprecated threading methods

### DIFF
--- a/lib/config/__init__.py
+++ b/lib/config/__init__.py
@@ -87,7 +87,7 @@ def GetWConfdContext(ec_id, livelock):
 
   """
   if ec_id is None:
-    return (threading.current_thread().getName(),
+    return (threading.current_thread().name,
             livelock.GetPath(), os.getpid())
   else:
     return (ec_id,

--- a/lib/http/client.py
+++ b/lib/http/client.py
@@ -294,7 +294,7 @@ class _PendingRequestMonitor(object):
     result = []
 
     if self._pending_fn:
-      owner_name = self._owner.getName()
+      owner_name = self._owner.name
 
       for client in self._pending_fn():
         req = client.GetCurrentRequest()
@@ -380,7 +380,7 @@ def ProcessRequests(requests, lock_monitor_cb=None, _curl=pycurl.Curl,
   assert len(curl_to_client) == len(requests)
 
   if lock_monitor_cb:
-    monitor = _PendingRequestMonitor(threading.currentThread(),
+    monitor = _PendingRequestMonitor(threading.current_thread(),
                                      curl_to_client.values)
     lock_monitor_cb(monitor)
   else:

--- a/lib/locking.py
+++ b/lib/locking.py
@@ -210,8 +210,8 @@ class SingleNotifyPipeCondition(_BaseCondition):
   This condition class uses pipes and poll, internally, to be able to wait for
   notification with a timeout, without resorting to polling. It is almost
   compatible with Python's threading.Condition, with the following differences:
-    - notifyAll can only be called once, and no wait can happen after that
-    - notify is not supported, only notifyAll
+    - notify_all can only be called once, and no wait can happen after that
+    - notify is not supported, only notify_all
 
   """
 
@@ -281,7 +281,7 @@ class SingleNotifyPipeCondition(_BaseCondition):
       if self._nwaiters == 0:
         self._Cleanup()
 
-  def notifyAll(self): # pylint: disable=C0103
+  def notify_all(self):
     """Close the writing side of the pipe to notify all waiters.
 
     """
@@ -298,7 +298,7 @@ class PipeCondition(_BaseCondition):
 
   This condition class uses pipes and poll, internally, to be able to wait for
   notification with a timeout, without resorting to polling. It is almost
-  compatible with Python's threading.Condition, but only supports notifyAll and
+  compatible with Python's threading.Condition, but only supports notify_all and
   non-recursive locks. As an additional features it's able to report whether
   there are any waiting threads.
 
@@ -338,7 +338,7 @@ class PipeCondition(_BaseCondition):
       self._check_owned()
       self._waiters.remove(threading.current_thread())
 
-  def notifyAll(self): # pylint: disable=C0103
+  def notify_all(self):
     """Notify all currently waiting threads.
 
     """

--- a/lib/locking.py
+++ b/lib/locking.py
@@ -331,19 +331,19 @@ class PipeCondition(_BaseCondition):
     # notifying while we're waiting.
     cond = self._single_condition
 
-    self._waiters.add(threading.currentThread())
+    self._waiters.add(threading.current_thread())
     try:
       cond.wait(timeout)
     finally:
       self._check_owned()
-      self._waiters.remove(threading.currentThread())
+      self._waiters.remove(threading.current_thread())
 
   def notifyAll(self): # pylint: disable=C0103
     """Notify all currently waiting threads.
 
     """
     self._check_owned()
-    self._single_condition.notifyAll()
+    self._single_condition.notify_all()
     self._single_condition = self._single_condition_class(self._lock)
 
   def get_waiting(self):
@@ -487,7 +487,7 @@ class SharedLock(object):
 
         if owner:
           assert not self.__deleted
-          owner_names = [i.getName() for i in owner]
+          owner_names = [i.name for i in owner]
 
       # Pending acquires are wanted
       if query.LQ_PENDING in requested:
@@ -502,7 +502,7 @@ class SharedLock(object):
               pendmode = _EXCLUSIVE_TEXT
 
             # List of names will be sorted in L{query._GetLockPending}
-            pending.append((pendmode, [i.getName()
+            pending.append((pendmode, [i.name
                                        for i in cond.get_waiting()]))
       else:
         pending = None
@@ -522,13 +522,13 @@ class SharedLock(object):
     """Is the current thread sharing the lock at this time?
 
     """
-    return threading.currentThread() in self.__shr
+    return threading.current_thread() in self.__shr
 
   def __is_exclusive(self):
     """Is the current thread holding the lock exclusively at this time?
 
     """
-    return threading.currentThread() == self.__exc
+    return threading.current_thread() == self.__exc
 
   def __is_owned(self, shared=-1):
     """Is the current thread somehow owning the lock at this time?
@@ -598,9 +598,9 @@ class SharedLock(object):
 
     """
     if shared:
-      self.__shr.add(threading.currentThread())
+      self.__shr.add(threading.current_thread())
     else:
-      self.__exc = threading.currentThread()
+      self.__exc = threading.current_thread()
 
   def __can_acquire(self, shared):
     """Determine whether lock can be acquired.
@@ -791,7 +791,7 @@ class SharedLock(object):
               prioqueue.insert(0, cond)
 
             # Notify
-            cond.notifyAll()
+            cond.notify_all()
 
       assert not self.__is_exclusive()
       assert self.__is_sharer()
@@ -817,7 +817,7 @@ class SharedLock(object):
         self.__exc = None
         notify = True
       else:
-        self.__shr.remove(threading.currentThread())
+        self.__shr.remove(threading.current_thread())
         notify = not self.__shr
 
       # Notify topmost condition in queue if there are no owners left (for
@@ -834,7 +834,7 @@ class SharedLock(object):
     (priority, prioqueue) = self.__find_first_pending_queue()
     if prioqueue:
       cond = prioqueue[0]
-      cond.notifyAll()
+      cond.notify_all()
       if cond.shared:
         # Prevent further shared acquires from sneaking in while waiters are
         # notified
@@ -890,7 +890,7 @@ class SharedLock(object):
         # Notify all acquires. They'll throw an error.
         for (_, prioqueue) in self.__pending:
           for cond in prioqueue:
-            cond.notifyAll()
+            cond.notify_all()
 
         assert self.__deleted
 

--- a/test/py/ganeti.http_unittest.py
+++ b/test/py/ganeti.http_unittest.py
@@ -679,7 +679,7 @@ class TestProcessRequests(unittest.TestCase):
                                          default=("localhost/version%s" %
                                                   handle.opts["__port__"]))),
               None,
-              [threading.currentThread().getName()], None)
+              [threading.current_thread().name], None)
              for handle in handles[idx:]]
           self.assertEqual(sorted(lock_info), sorted(expected))
 

--- a/test/py/ganeti.utils.log_unittest.py
+++ b/test/py/ganeti.utils.log_unittest.py
@@ -257,7 +257,7 @@ class TestSetupToolLogging(unittest.TestCase):
             ])
 
   def testThreadName(self):
-    thread_name = threading.currentThread().getName()
+    thread_name = threading.current_thread().name
 
     for enable_threadname in [False, True]:
       logger = logging.Logger("TestLogger")

--- a/test/py/ganeti.workerpool_unittest.py
+++ b/test/py/ganeti.workerpool_unittest.py
@@ -93,7 +93,7 @@ class ChecksumBaseWorker(workerpool.BaseWorker):
 
     # This assertion needs to be checked before updating the checksum. A
     # failing assertion will then cause the result to be wrong.
-    assert self.getName() == ("%s/%s" % (self._worker_id, name))
+    assert self.name == ("%s/%s" % (self._worker_id, name))
 
     ctx.lock.acquire()
     try:

--- a/tools/move-instance
+++ b/tools/move-instance
@@ -430,8 +430,8 @@ class MoveRuntime(object):
 
     self.lock.acquire()
     try:
-      self.source_to_dest.notifyAll()
-      self.dest_to_source.notifyAll()
+      self.source_to_dest.notify_all()
+      self.dest_to_source.notify_all()
     finally:
       self.lock.release()
 
@@ -567,7 +567,7 @@ class MoveDestExecutor(object):
     mrt.dest_to_source.acquire()
     try:
       mrt.dest_impinfo = impinfo
-      mrt.dest_to_source.notifyAll()
+      mrt.dest_to_source.notify_all()
     finally:
       mrt.dest_to_source.release()
 
@@ -726,7 +726,7 @@ class MoveSourceExecutor(object):
     try:
       mrt.src_instinfo = instinfo
       mrt.src_expinfo = expinfo
-      mrt.source_to_dest.notifyAll()
+      mrt.source_to_dest.notify_all()
     finally:
       mrt.source_to_dest.release()
 
@@ -855,7 +855,7 @@ class MoveSourceWorker(workerpool.BaseWorker):
       mrt = MoveRuntime(move)
 
       logging.debug("Starting destination thread")
-      dest_thread = threading.Thread(name="DestFor%s" % self.getName(),
+      dest_thread = threading.Thread(name="DestFor%s" % self.name,
                                      target=mrt.HandleErrors,
                                      args=("dest", MoveDestExecutor,
                                            rapi_factory.GetDestClient(),


### PR DESCRIPTION
Python 3.10 has deprecated a bunch of camelCase threading methods in favor of snake_case methods and getter/setter attributes. The new methods/attributes have existed since Python 2.6, so switching does not break backward compatibility.

This is part of #1687.