### PR TITLE
move-instance: fix crash in Python 3

### DIFF
--- a/tools/move-instance
+++ b/tools/move-instance
@@ -938,7 +938,9 @@ def _CheckAllocatorOptions(parser, options):
       bool(options.dest_primary_node or options.dest_secondary_node)):
     parser.error("Destination node and iallocator options exclude each other")
 
-  if not options.iallocator and (options.opportunistic_tries > 0):
+  if (not options.iallocator and
+      options.opportunistic_tries is not None and
+      options.opportunistic_tries > 0):
     parser.error("Opportunistic instance creation can only be used with an"
                  " iallocator")
 


### PR DESCRIPTION
Any move-instance call without --opportunistic-tries currently crashes with this:

```
  File "/usr/lib/ganeti/tools/move-instance", line 1132, in <module>
    main()
  File "/usr/share/ganeti/3.0/ganeti/rapi/client.py", line 274, in wrapper
    return fn(*args, **kwargs)
  File "/usr/lib/ganeti/tools/move-instance", line 1069, in main
    CheckOptions(parser, options, args)
  File "/usr/lib/ganeti/tools/move-instance", line 1007, in CheckOptions
    _CheckAllocatorOptions(parser, options)
  File "/usr/lib/ganeti/tools/move-instance", line 941, in _CheckAllocatorOptions
    if not options.iallocator and (options.opportunistic_tries > 0):
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

It is said this was a problem related to the 2to3 migration, but I haven't investigated fully.

See: #1696

/cc @rbott 