### PR TITLE
move-instance: allow users to empty out NIC parameters

### DIFF
--- a/tools/move-instance
+++ b/tools/move-instance
@@ -972,6 +972,12 @@ def _CheckInstanceOptions(parser, options, instance_names):
 
     if options.nics:
       options.nics = cli.ParseNicOption(options.nics)
+      # allow user to override instance parameters by hardcoding the
+      # empty string as "ignore this setting" shortcut
+      for nic in options.nics:
+        for k, v in nic.items():
+          if v == "":
+            nic[k] = None
   else:
     # Moving more than one instance
     if compat.any(options.dest_instance_name, options.dest_primary_node,


### PR DESCRIPTION
In #1696, I ended up in a situation where the instance I'm moving had both "network" and "link" parameters. That seems like a natural configuration in our cluster, but something move-instance really doesn't like, as it's passing this verbatim to create-instance which naturally freaks out on the contradictory arguments.

Instead of just crashing, detect empty parameters (`not v` is a shortcut here) and null them out. This will result in those parameters being passed as empty to create-instance, or to be more accurate, not be passed at all.

I've been able to fix the crash in #1696 by passing `--net 0:ip=pool,network=gnt-dal-01,mode=,link=` to move-instance with this patch.

I'm not sure it's the right approach though. I'd much rather *not* have to pass `--net` at all, as I actually want to move multiple instances across clusters, and that seems incompatible with `--net` for some reason I cannot currently fathom (but which is possibly related to this problem).