### PR TITLE
impexpd: verify remote socket against actual host name

### DIFF
--- a/lib/impexpd/__init__.py
+++ b/lib/impexpd/__init__.py
@@ -225,8 +225,30 @@ class CommandBuilder(object):
       # For socat versions >= 1.7.3, we need to also specify
       # openssl-commonname, otherwise server certificate verification will
       # fail.
+      x509_cert_cn = host
+      # we were previously hardcoding constants.X509_CERT_CN here, but
+      # that's always ganeti.example.com while the other end generates
+      # an actual cert that matches the hostname. unfortunately here
+      # we are typically given an IP address, so let's try to find a
+      # real hostname for the certificate check
+      if host and netutils.IPAddress.IsValid(host):
+        # this looks like an IP address, override based on the reverse
+        # DNS
+        try:
+          x509_cert_cn, _, _ = socket.gethostbyaddr(host)
+          logging.warning("overriden IP address %s to reverse hostname %s",
+                          host,
+                          x509_cert_cn)
+        except OSError as e:
+          logging.error(
+            "failed to resolve IP address %s, reverting to default %s: %s",
+            host,
+            constants.X509_CERT_CN,
+            e,
+          )
+          x509_cert_cn = constants.X509_CERT_CN
       if self._GetSocatVersion() >= (1, 7, 3):
-        addr2 += ["openssl-commonname=%s" % constants.X509_CERT_CN]
+        addr2 += ["openssl-commonname=%s" % x509_cert_cn]
 
     else:
       raise errors.GenericError("Invalid mode '%s'" % self._mode)

--- a/test/py/legacy/ganeti.impexpd_unittest.py
+++ b/test/py/legacy/ganeti.impexpd_unittest.py
@@ -44,7 +44,7 @@ from ganeti import errors
 from ganeti import impexpd
 
 import testutils
-
+import unittest.mock
 
 class CmdBuilderConfig(objects.ConfigObject):
   __slots__ = [
@@ -112,13 +112,20 @@ class TestCommandBuilder(unittest.TestCase):
           else:
             self.assertFalse(magic_cmd)
 
-        for host in ["localhost", "198.51.100.4", "192.0.2.99"]:
+        testcases = [
+          { "target": "localhost", "expected_hostname": "localhost" },
+          { "target": "198.51.100.4", "expected_hostname": "my.ganeti.org" },
+        ]
+
+        for host in testcases:
+          socket_patcher = unittest.mock.patch("socket.gethostbyaddr", return_value=(host["expected_hostname"], [], []))
+          socket_patcher.start()
           for port in [0, 1, 1234, 7856, 45452]:
             for cmd_prefix in [None, "PrefixCommandGoesHere|",
                                "dd if=/dev/hda bs=1048576 |"]:
               for cmd_suffix in [None, "< /some/file/name",
                                  "| dd of=/dev/null"]:
-                opts = CmdBuilderConfig(host=host, port=port, compress=compress,
+                opts = CmdBuilderConfig(host=host["target"], port=port, compress=compress,
                                         cmd_prefix=cmd_prefix,
                                         cmd_suffix=cmd_suffix)
 
@@ -145,15 +152,16 @@ class TestCommandBuilder(unittest.TestCase):
                   self.assertTrue(("OPENSSL-LISTEN:%s" % port) in ssl_addr)
                 elif mode == constants.IEM_EXPORT:
                   ssl_addr = socat_cmd[-1].split(",")
-                  self.assertTrue(("OPENSSL:%s:%s" % (host, port)) in ssl_addr)
+                  self.assertTrue(("OPENSSL:%s:%s" % (host["target"], port)) in ssl_addr)
                   if impexpd.CommandBuilder._GetSocatVersion() >= (1, 7, 3):
                     self.assertTrue("openssl-commonname=%s" %
-                                 constants.X509_CERT_CN in ssl_addr)
+                                 host["expected_hostname"] in ssl_addr)
                   else:
                     self.assertTrue("openssl-commonname=%s" %
                                  constants.X509_CERT_CN not in ssl_addr)
 
                 self.assertTrue("verify=1" in ssl_addr)
+          socket_patcher.stop()
 
   @testutils.RequiresIPv6()
   def testIPv6(self):
@@ -194,8 +202,6 @@ class TestCommandBuilder(unittest.TestCase):
 
   def testOptionLengthError(self):
     testopts = [
-      CmdBuilderConfig(bind="0.0.0.0" + ("A" * impexpd.SOCAT_OPTION_MAXLEN),
-                       port=1234, ca="/tmp/ca"),
       CmdBuilderConfig(host="localhost", port=1234,
                        ca="/tmp/ca" + ("B" * impexpd.SOCAT_OPTION_MAXLEN)),
       CmdBuilderConfig(host="localhost", port=1234,

--- a/test/py/legacy/ganeti.impexpd_unittest.py
+++ b/test/py/legacy/ganeti.impexpd_unittest.py
@@ -118,16 +118,23 @@ class TestCommandBuilder(unittest.TestCase):
         ]
 
         for host in testcases:
-          socket_patcher = unittest.mock.patch("socket.gethostbyaddr", return_value=(host["expected_hostname"], [], []))
+          socket_patcher = unittest.mock.patch(
+            "socket.gethostbyaddr",
+            return_value=(host["expected_hostname"], [], []),
+          )
           socket_patcher.start()
           for port in [0, 1, 1234, 7856, 45452]:
             for cmd_prefix in [None, "PrefixCommandGoesHere|",
                                "dd if=/dev/hda bs=1048576 |"]:
               for cmd_suffix in [None, "< /some/file/name",
                                  "| dd of=/dev/null"]:
-                opts = CmdBuilderConfig(host=host["target"], port=port, compress=compress,
-                                        cmd_prefix=cmd_prefix,
-                                        cmd_suffix=cmd_suffix)
+                opts = CmdBuilderConfig(
+                  host=host["target"],
+                  port=port,
+                  compress=compress,
+                  cmd_prefix=cmd_prefix,
+                  cmd_suffix=cmd_suffix,
+                )
 
                 builder = impexpd.CommandBuilder(mode, opts, 1, 2, 3)
 
@@ -152,7 +159,9 @@ class TestCommandBuilder(unittest.TestCase):
                   self.assertTrue(("OPENSSL-LISTEN:%s" % port) in ssl_addr)
                 elif mode == constants.IEM_EXPORT:
                   ssl_addr = socat_cmd[-1].split(",")
-                  self.assertTrue(("OPENSSL:%s:%s" % (host["target"], port)) in ssl_addr)
+                  self.assertTrue(
+                    ("OPENSSL:%s:%s" % (host["target"], port)) in ssl_addr
+                  )
                   if impexpd.CommandBuilder._GetSocatVersion() >= (1, 7, 3):
                     self.assertTrue("openssl-commonname=%s" %
                                  host["expected_hostname"] in ssl_addr)

--- a/test/py/legacy/ganeti.impexpd_unittest.py
+++ b/test/py/legacy/ganeti.impexpd_unittest.py
@@ -96,7 +96,11 @@ class TestCommandBuilder(unittest.TestCase):
       for compress in constants.IEC_ALL:
         for magic in [None, 10 * "-", "HelloWorld", "J9plh4nFo2",
                       "24A02A81-2264-4B51-A882-A2AB9D85B420"]:
-          opts = CmdBuilderConfig(magic=magic, compress=compress)
+          opts = CmdBuilderConfig(
+            magic=magic,
+            compress=compress,
+            host="localhost",
+          )
           builder = impexpd.CommandBuilder(mode, opts, 1, 2, 3)
 
           magic_cmd = builder._GetMagicCommand()


### PR DESCRIPTION
In 7bb0351 (impexpd: fix certificate verification with new socat versions, 2017-12-20), a hostname verification was introduced to fix socat's new (and proper) behavior of actually checking the remote hostname during OpenSSL-protected transfers.

The problem, however, is that the hostname used was the default `X509_CERT_CN` constant (`x509CertCn` in Haskell) which is hardcoded to `ganeti.example.com`. In a real-world deployment, it seems like the remote CommonName (CN) of the certificate used by the export daemon is actually the target node name.

In my case, it meant I was getting the following error from socat during transfers:

    Disk 0 failed to send data: Exited with status 1 (recent output: socat: E certificate is valid but its commonName does not match hostname "ganeti.example.com")

At first I thought socat might be doing us some trouble, but no: socat works properly. An example is this:

 1. generate a self-signed certificate:

        openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -nodes -subj '/CN=ganeti.example.com' -days 1

 2. start a socat server:

        socat -ls -d -d  STDIO OPENSSL-LISTEN:8443,reuseaddr,forever,key=key.pem,cert=cert.pem,cafile=cert.pem

 3. connect to it with a client:

        socat -ls -d -d   STDIO  OPENSSL:localhost:8443,openssl-commonname=ganeti.example.com,verify=1,key=key.pem,cert=cert.pem,cafile=cert.pem

... which actually works, which means the `openssl-commonname` argument actually works, and works properly. If it's changed, for example, to `ganeti.example.net`, the above fails with the aforementioned error message.

We fix this by doing a reverse name resolution on the provided IP address. Now, we don't *assume* it's an IP address: this code kicks in only if the impexpd is passed an actual IP address, but in my experience it seems to always be the case (which is probably a separate problem to fix).

This is rather brittle and assumes DNS will not lie, which is quite a stretch. In our environment, however, we have end-to-end DNSSEC so we can trust the DNS. And this beats hardcoding verify=0, which is the other workaround that can be done to fix this issue.

Closes: #1681