### PR TITLE
optimize move-instance: do not wait for DRBD sync

### DIFF
--- a/tools/move-instance
+++ b/tools/move-instance
@@ -690,7 +690,8 @@ class MoveDestExecutor(object):
                              osparams=objects.FillDict(inst_osparams,
                                                        override_osparams),
                              opportunistic_locking=is_attempt_opportunistic,
-                             tags=instance["tags"]
+                             tags=instance["tags"],
+                             wait_for_sync=False,
                              )
 
 


### PR DESCRIPTION
This is debatable and a change from the default in create-instance, but I think it makes sense. We're already creating a copy of the VM in move-instance, if `keep_source_instance` is set, of course, but also *while* the migration is happening, in any case. So we shouldn't worry too much about the lack of DRBD consistency during the move.

Otherwise this takes twice the time it could normally take, as the move needs to wait for the entire disk to sync. In my tests, it turns a 17 minutes migration into a ~7 minutes migration, improving performance by a twofold.

Naturally, this could also be made configurable, but I am not sure we want to exactly copy all of the instance creation parameters here, and this one particularly feels like a default that could be improved.

Just like `keep_source_instance` used to be hardcoded, let's start with a hardcoded value and switch it to configurable if people actually need to.

Closes: #1702