### PR TITLE
KVM: handle migrate-set-capabilities with qemu upgrades

### DIFF
--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -774,6 +774,13 @@ class QmpConnection(MonitorSocket):
       "capabilities": []
     }
     for capability in capabilities:
+      # Fix the old capability names
+      # TODO: how do we verify that the new name is supported?
+      # Fixes "error executing the migrate-set-capabilities command:
+      # Parameter 'capability' does not accept value 'x-rdma-pin-all'"
+      if capability == 'x-rdma-pin-all':
+        capability = 'rdma-pin-all'
+      # Setup the caps.
       arguments["capabilities"].append({
         "capability": capability,
         "state": state,


### PR DESCRIPTION
Newer version of QEMU only support the string `rdma-pin-all`, not the older `x-rdma-pin-all`. The migration works fine if the string is just updated during a migration.

The error preventing migration is:
```
Failed to accept instance: kvm: error executing the
migrate-set-capabilities command: Parameter 'capability' does not accept
value 'x-rdma-pin-all' (GenericError):
````