### PR TITLE
lib/runtime: improve not-master error

### DIFF
--- a/lib/runtime.py
+++ b/lib/runtime.py
@@ -286,8 +286,11 @@ def GetClient():
 
     master, myself = ssconf.GetMasterAndMyself(ss=ss)
     if master != myself:
-      raise errors.OpPrereqError("This is not the master node, please connect"
-                                 " to node '%s' and rerun the command" %
-                                 master, errors.ECODE_INVAL)
+      # print our own name to aid debugging, esp. re FQDN
+      # common error is: hostname != hostname.domain.tld
+      raise errors.OpPrereqError("This node, '%s', is not the master node,
+                                 " please connect to node '%s' and rerun "
+                                 " the command" %
+                                 % (myself, master), errors.ECODE_INVAL)
     raise
   return client


### PR DESCRIPTION
For unclear reasons, there was an environment where the master was running, but the clients did not believe it was the master.

kernel.hostname returned the unqualified hostname, as expected, but the master check was looking for the FQDN.

Improve the error message as a start on making it easier to debug.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>