### PR TITLE
Drop testing against bullseye, add bookworm instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [bullseye, focal, jammy, debian-testing]
+        os: [bookworm, focal, jammy, debian-testing]
     container:
       image: ganeti/ci:${{ matrix.os }}-py3
       options: "--init"


### PR DESCRIPTION
The ci-images have been updated to provide Debian Bookworm as stable environment while the `debian-testing` image has moved on to Trixie. This commit updates the Github Actions workflow accordingly.