### PR TITLE
Fix flaky GetCmdline() tests in Github Action containers

### DIFF
--- a/test/py/ganeti.utils.process_unittest.py
+++ b/test/py/ganeti.utils.process_unittest.py
@@ -751,6 +751,12 @@ class GetCmdline(unittest.TestCase):
     sample_cmd = "sleep 20; true"
     child = subprocess.Popen(sample_cmd, shell=True)
     pid = child.pid
+    # this is somewhat silly, but apparently sometimes the cmdline has not
+    # yet been set and the call to GetProcCmdline() will return an emptry
+    # string. This problem has surfaced recently and especially on Docker
+    # containers used for testing via Github Actions (could not reproduce
+    # locally)
+    time.sleep(1)
     cmdline = utils.GetProcCmdline(pid)
     # As the popen will quote and pass on the sample_cmd, it should be returned
     # by the function as an element in the list of arguments


### PR DESCRIPTION
The test for utils.GetCmdline() sometimes returns an error because the process started by `subprocess.popen()` does not _yet_ return a valid command line via `/proc/$pid/cmdline` (just an empty string).

This does only seem to happen in containers running in the Github Actions environment as I was not able to reproduce this anywhere else. The "fix" is to wait for one second so things can settle.