### PR TITLE
Add devcontainer for developing Ganeti

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "name": "Ganeti Dev Container",
+    "image": "ganeti/ci:jammy-py3",
+
+    "customizations":{
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.debugpy",
+                "ms-python.vscode-pylance",
+                "ms-python.isort",
+
+                "haskell.haskell"
+            ]
+        }
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,9 +9,14 @@
                 "ms-python.debugpy",
                 "ms-python.vscode-pylance",
                 "ms-python.isort",
+                "ms-python.pylint",
 
                 "haskell.haskell"
-            ]
+            ],
+            "settings": {
+                "python.linting.enabled": true,
+                "python.linting.pylintEnabled": true
+            }
         }
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Ganeti Dev Container",
-    "image": "ganeti/ci:jammy-py3",
+    "image": "ganeti/ci:bookworm-py3",
 
     "customizations":{
         "vscode": {

--- a/Makefile.am
+++ b/Makefile.am
@@ -283,7 +283,8 @@ DIRCHECK_EXCLUDE = \
 	doc/html/_* \
 	doc/man-html/_* \
 	tools/shebang \
-	autom4te.cache
+	autom4te.cache \
+	.devcontainer
 
 # some helper vars
 COVERAGE_DIR = doc/coverage


### PR DESCRIPTION
This PR adds a basic devcontainer config.
With the [Devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) standard, a dev environment can easily be created in the vscode editor or gh codespaces.

So you can develop and test within the donatiner without having to install any Haskell stuff on your own host. 
The ci-image from jammy is used as base image.