### PR TITLE
drop distutils

### DIFF
--- a/test/py/ganeti.utils.x509_unittest.py
+++ b/test/py/ganeti.utils.x509_unittest.py
@@ -34,9 +34,9 @@ import os
 import tempfile
 import unittest
 import shutil
-import OpenSSL
-import distutils.version
 import string
+import OpenSSL
+import packaging.version
 
 from ganeti import constants
 from ganeti import utils
@@ -78,10 +78,11 @@ class TestGetX509CertValidity(testutils.GanetiTestCase):
   def setUp(self):
     testutils.GanetiTestCase.setUp(self)
 
-    pyopenssl_version = distutils.version.LooseVersion(OpenSSL.__version__)
+    pyopenssl_version = packaging.version.parse(OpenSSL.__version__)
+    minimal_pyopenssl_version = packaging.version.parse("0.7")
 
-    # Test whether we have pyOpenSSL 0.7 or above
-    self.pyopenssl0_7 = (pyopenssl_version >= "0.7")
+    # Test whether we have pyOpenSSL in desired_pyopenssl_version (0.7) or above
+    self.pyopenssl0_7 = pyopenssl_version >= minimal_pyopenssl_version
 
     if not self.pyopenssl0_7:
       warnings.warn("This test requires pyOpenSSL 0.7 or above to"


### PR DESCRIPTION
This PR removes distutils because it is deprecated and will be removed in 3.12.
See #1710

distutils was only used to check if the pyopenssl is greater than 0.7 in test/py/ganeti.utils.x509_unittest.py. 
version.parse from packaging is now used for the version comparison.