### PR TITLE
replace simplejson by the python build-in json module

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -36,7 +36,6 @@ Before installing, please verify that you have the following programs:
 - `ndisc6 <http://www.remlab.net/ndisc6/>`_ (if using IPv6)
 - `Python <http://www.python.org/>`_, version 3.6 or above
 - `Python OpenSSL bindings <https://www.pyopenssl.org/>`_
-- `simplejson Python module <https://simplejson.readthedocs.io/>`_
 - `pyparsing Python module <https://pyparsing-docs.readthedocs.io/>`_, version
   1.5.7 or above
 - `pyinotify Python module <https://github.com/seb-m/pyinotify>`_
@@ -63,7 +62,7 @@ packages, except for RBD, DRBD and Xen::
 
   $ apt-get install lvm2 ssh iproute iputils-arping make m4 \
                     ndisc6 python3 python3-openssl openssl \
-                    python3-pyparsing python3-simplejson python3-bitarray \
+                    python3-pyparsing python3-bitarray \
                     python3-pyinotify python3-pycurl socat fping
 
 Note that the previous instructions don't install optional packages.
@@ -87,7 +86,7 @@ For example::
 On Fedora to install all required packages except RBD, DRBD and Xen::
 
   $ yum install openssh openssh-clients iproute ndisc6 make \
-                pyOpenSSL pyparsing python-simplejson python-inotify \
+                pyOpenSSL pyparsing python-inotify \
                 python-lxm socat fping python-bitarray python-ipaddr
 
 For optional packages use the command::

--- a/configure.ac
+++ b/configure.ac
@@ -898,7 +898,6 @@ m4_define_default([_AM_PYTHON_INTERPRETER_LIST],
                   [python3 python3.8 python3.7 python3.6 python])
 AM_PATH_PYTHON([3.6])
 AC_PYTHON_MODULE(OpenSSL, t)
-AC_PYTHON_MODULE(simplejson, t)
 AC_PYTHON_MODULE(pyparsing, t)
 AC_PYTHON_MODULE(pyinotify, t)
 AC_PYTHON_MODULE(pycurl, t)

--- a/devel/build_chroot
+++ b/devel/build_chroot
@@ -243,7 +243,6 @@ case ${DIST_RELEASE}${VARIANT} in
         hscolour pandoc \
         graphviz qemu-utils \
         python-docutils \
-        python-simplejson \
         python-pyparsing \
         python-pyinotify \
         python-pycurl \
@@ -340,7 +339,7 @@ case ${DIST_RELEASE}${VARIANT} in
       libghc-zlib-dev libghc-psqueue-dev \
       cabal-install \
       python-setuptools python-sphinx python-epydoc graphviz python-pyparsing \
-      python-simplejson python-pycurl python-paramiko \
+      python-pycurl python-paramiko \
       python-bitarray python-ipaddr python-yaml qemu-utils python-coverage pep8 \
       shelltestrunner python-dev openssh-client vim git git-email exuberant-ctags
 
@@ -392,7 +391,7 @@ case ${DIST_RELEASE}${VARIANT} in
       libghc-cabal-dev \
       cabal-install \
       python-setuptools python-sphinx python-epydoc graphviz python-pyparsing \
-      python-simplejson python-pycurl python-pyinotify python-paramiko \
+      python-pycurl python-pyinotify python-paramiko \
       python-bitarray python-ipaddr python-yaml qemu-utils python-coverage pep8 \
       shelltestrunner python-dev pylint openssh-client \
       vim git git-email exuberant-ctags
@@ -426,7 +425,6 @@ case ${DIST_RELEASE}${VARIANT} in
         hlint hscolour pandoc \
         graphviz qemu-utils \
         python-docutils \
-        python-simplejson \
         python-pyparsing \
         python-pyinotify \
         python-pycurl \
@@ -523,7 +521,7 @@ EOF
       cabal-install \
       libpcre3 libpcre3-dev happy hscolour pandoc \
       python-setuptools python-sphinx python-epydoc graphviz python-pyparsing \
-      python-simplejson python-pyinotify python-pycurl python-paramiko \
+      python-pyinotify python-pycurl python-paramiko \
       python-bitarray python-ipaddr python-yaml qemu-utils python-coverage pep8 \
       python-dev pylint openssh-client vim git git-email exuberant-ctags \
       build-essential
@@ -575,7 +573,7 @@ EOF
       cabal-install \
       libghc-base64-bytestring-dev \
       python-setuptools python-sphinx python-epydoc graphviz python-pyparsing \
-      python-simplejson python-pyinotify python-pycurl python-paramiko \
+      python-pyinotify python-pycurl python-paramiko \
       python-bitarray python-ipaddr python-yaml qemu-utils python-coverage pep8 \
       shelltestrunner python-dev pylint openssh-client \
       vim git git-email exuberant-ctags \

--- a/lib/cli_opts.py
+++ b/lib/cli_opts.py
@@ -34,7 +34,7 @@ import re
 
 from optparse import (Option, OptionValueError)
 
-import simplejson
+import json
 
 from ganeti import utils
 from ganeti import errors
@@ -474,7 +474,7 @@ def check_json(option, opt, value): # pylint: disable=W0613
   Takes a string containing JSON, returns a Python object.
 
   """
-  return simplejson.loads(value)
+  return json.loads(value)
 
 
 def check_filteraction(option, opt, value): # pylint: disable=W0613

--- a/lib/client/gnt_debug.py
+++ b/lib/client/gnt_debug.py
@@ -38,7 +38,7 @@ import logging
 import socket
 import time
 
-import simplejson
+import json
 
 from ganeti.cli import *
 from ganeti import cli
@@ -104,7 +104,7 @@ def GenericOpCodes(opts, args):
     ToStdout("Loading...")
   for job_idx in range(opts.rep_job):
     for fname in args:
-      op_data = simplejson.loads(utils.ReadFile(fname))
+      op_data = json.loads(utils.ReadFile(fname))
       op_list = [opcodes.OpCode.LoadOpCode(val) for val in op_data]
       op_list = op_list * opts.rep_op
       jex.QueueJob("file %s/%d" % (fname, job_idx), *op_list)

--- a/lib/client/gnt_instance.py
+++ b/lib/client/gnt_instance.py
@@ -36,9 +36,8 @@
 
 import copy
 import itertools
+import json
 import logging
-
-import simplejson
 
 from ganeti.cli import *
 from ganeti import opcodes
@@ -280,7 +279,7 @@ def BatchCreate(opts, args):
   cl = GetClient()
 
   try:
-    instance_data = simplejson.loads(utils.ReadFile(json_filename))
+    instance_data = json.loads(utils.ReadFile(json_filename))
   except Exception as err: # pylint: disable=W0703
     ToStderr("Can't parse the instance definition file: %s" % str(err))
     return 1

--- a/lib/rapi/client.py
+++ b/lib/rapi/client.py
@@ -42,6 +42,7 @@
 # No Ganeti-specific modules should be imported. The RAPI client is supposed to
 # be standalone.
 
+import json
 import logging
 import socket
 import threading
@@ -53,7 +54,6 @@ except ImportError:
     from urllib.parse import urlencode
 
 import pycurl
-import simplejson
 
 from io import StringIO, BytesIO
 
@@ -417,7 +417,7 @@ class GanetiRapiClient(object): # pylint: disable=R0904
 
   """
   USER_AGENT = "Ganeti RAPI Client"
-  _json_encoder = simplejson.JSONEncoder(sort_keys=True)
+  _json_encoder = json.JSONEncoder(sort_keys=True)
 
   def __init__(self, host, port=GANETI_RAPI_PORT,
                username=None, password=None, logger=logging,
@@ -596,7 +596,7 @@ class GanetiRapiClient(object): # pylint: disable=R0904
     # Was anything written to the response buffer?
     if encoded_resp_body.tell():
       encoded_resp_body.seek(0)
-      response_content = simplejson.load(encoded_resp_body)
+      response_content = json.load(encoded_resp_body)
     else:
       response_content = None
 

--- a/tools/cfgupgrade
+++ b/tools/cfgupgrade
@@ -30,8 +30,8 @@
 
 """Tool to upgrade the configuration file.
 
-This code handles only the types supported by simplejson. As an
-example, 'set' is a 'list'.
+This code handles only the types supported by the json python build-in module.
+As an example, 'set' is a 'list'.
 
 """
 

--- a/tools/cfgupgrade12
+++ b/tools/cfgupgrade12
@@ -36,8 +36,8 @@
 
 """Tool to upgrade the configuration file.
 
-This code handles only the types supported by simplejson. As an
-example, 'set' is a 'list'.
+This code handles only the types supported by the json python build-in module.
+As an example, 'set' is a 'list'.
 
 @note: this has lots of duplicate content with C{cfgupgrade}. Ideally, it
 should be merged.

--- a/tools/fmtjson
+++ b/tools/fmtjson
@@ -32,7 +32,7 @@
 """
 
 import sys
-import simplejson
+import json
 
 
 def main():
@@ -45,8 +45,8 @@ def main():
                      " no options or arguments.\n")
     sys.exit(1)
 
-  data = simplejson.load(sys.stdin)
-  simplejson.dump(data, sys.stdout, indent=2, sort_keys=True)
+  data = json.load(sys.stdin)
+  json.dump(data, sys.stdout, indent=2, sort_keys=True)
   sys.stdout.write("\n")
 
 


### PR DESCRIPTION
This PR replaces simplejson by the python build-in json module.
In the newer Python versions starting from 3.2, there is no reason to prefer simplejson to the build in
See https://bugs.python.org/issue7451

This removes simplejson as external dependency. 


