### PR TITLE
fix pydoctor conf

### DIFF
--- a/pydoctor.ini
+++ b/pydoctor.ini
@@ -1,3 +1,5 @@
-projectname: Ganeti
-projecturl: https://github.com/ganeti/ganeti
-makehtml: True
+[pydoctor]
+projectname = Ganeti
+projecturl = https://github.com/ganeti/ganeti
+makehtml = True
+


### PR DESCRIPTION
In commit da6aba31874a87e81280c41f65541b9cb780827a @newellz2 replaced broken epydoc by pydoctor as a drop in replacement. However the supplied configuration file did not work. Fix it according the [upstream documentation](https://pydoctor.readthedocs.io/en/latest/help.html#configuration-file). After years we can build now basic python API docs and publish them on [docs.ganeti.org.](https://docs.ganeti.org)