### PR TITLE
Make sure QA does not fail on empty hypervisor parameters

### DIFF
--- a/qa/qa_instance.py
+++ b/qa/qa_instance.py
@@ -126,14 +126,16 @@ def GetInstanceInfo(instance):
   storage_type = constants.MAP_DISK_TEMPLATE_STORAGE_TYPE[disk_template]
 
   hvparams = {}
-  for param, value in info["Hypervisor parameters"].items():
-    if type(value) == str and value.startswith("default ("):
-        result = re.search(r'^default \((.*)\)$', value)
-        try:
-            value = yaml.load(result.group(1), Loader=yaml.SafeLoader)
-        except yaml.YAMLError:
-            value = ''
-    hvparams[param] = value
+  # make sure to not iterate on hypervisors w/o parameters (e.g. fake HV)
+  if isinstance(info["Hypervisor parameters"], dict):
+    for param, value in info["Hypervisor parameters"].items():
+      if type(value) == str and value.startswith("default ("):
+          result = re.search(r'^default \((.*)\)$', value)
+          try:
+              value = yaml.load(result.group(1), Loader=yaml.SafeLoader)
+          except yaml.YAMLError:
+              value = ''
+      hvparams[param] = value
 
   assert nodes
   assert len(nodes) < 2 or vols


### PR DESCRIPTION
The fake HV does not come with any hypervisor parameters, which breaks the QA suite when parsing the YAML output of `gnt-instance info $instance`.

This commit adds a safety check to catch this corner case.