### PR TITLE
try hotplug by default

### DIFF
--- a/doc/design-hotplug.rst
+++ b/doc/design-hotplug.rst
@@ -60,8 +60,7 @@ object manipulation and is ensured not to be written back to the config.
 
 We propose to make use of QEMU 1.7 QMP commands so that
 modifications to devices take effect instantly without the need for hard
-reboot. The only change exposed to the end-user will be the addition of
-a ``--hotplug`` option to the ``gnt-instance modify`` command.
+reboot.
 
 Upon hotplugging the PCI configuration of an instance is changed.
 Runtime files should be updated correspondingly. Currently this is
@@ -173,15 +172,15 @@ socket). The open file is passed as a socket-level control message
 User interface
 --------------
 
-The new ``--hotplug`` option to gnt-instance modify is introduced, which
-forces live modifications.
+The new ``--no-hotplug`` option to gnt-instance modify is introduced, which
+skips live modifications.
 
 
 Enabling hotplug
 ++++++++++++++++
 
-Hotplug will be optional during gnt-instance modify.  For existing
-instance, after installing a version that supports hotplugging we
+Hotplug is enabled by default for gnt-instance modify if it is supported.
+For existing instance, after installing a version that supports hotplugging we
 have the restriction that hotplug will not be supported for existing
 devices. The reason is that old runtime files lack of:
 
@@ -207,9 +206,9 @@ well.
 
 ::
 
- gnt-instance modify --net add --hotplug test
- gnt-instance modify --net 1:mac=aa:00:00:55:44:33 --hotplug test
- gnt-instance modify --net 1:remove --hotplug test
+ gnt-instance modify --net add test
+ gnt-instance modify --net 1:mac=aa:00:00:55:44:33 test
+ gnt-instance modify --net 1:remove test
 
 
 Disk Hotplug
@@ -221,8 +220,8 @@ support only disk addition/deletion.
 
 ::
 
- gnt-instance modify --disk add:size=1G --hotplug test
- gnt-instance modify --disk 1:remove --hotplug test
+ gnt-instance modify --disk add:size=1G test
+ gnt-instance modify --disk 1:remove test
 
 
 Dealing with chroot and uid pool (and disks in general)

--- a/lib/cli_opts.py
+++ b/lib/cli_opts.py
@@ -107,8 +107,7 @@ __all__ = [
   "HELPER_SHUTDOWN_TIMEOUT_OPT",
   "HELPER_STARTUP_TIMEOUT_OPT",
   "HID_OS_OPT",
-  "HOTPLUG_IF_POSSIBLE_OPT",
-  "HOTPLUG_OPT",
+  "NOHOTPLUG_OPT",
   "HV_STATE_OPT",
   "HVLIST_OPT",
   "HVOPTS_OPT",
@@ -1540,15 +1539,9 @@ INCLUDEDEFAULTS_OPT = cli_option("--include-defaults", dest="include_defaults",
                                  default=False, action="store_true",
                                  help="Include default values")
 
-HOTPLUG_OPT = cli_option("--hotplug", dest="hotplug",
-                         action="store_true", default=False,
+NOHOTPLUG_OPT = cli_option("--no-hotplug", dest="hotplug",
+                         action="store_false", default=True,
                          help="Hotplug supported devices (NICs and Disks)")
-
-HOTPLUG_IF_POSSIBLE_OPT = cli_option("--hotplug-if-possible",
-                                     dest="hotplug_if_possible",
-                                     action="store_true", default=False,
-                                     help="Hotplug devices in case"
-                                          " hotplug is supported")
 
 INSTALL_IMAGE_OPT = \
     cli_option("--install-image",

--- a/lib/client/gnt_instance.py
+++ b/lib/client/gnt_instance.py
@@ -1432,7 +1432,6 @@ def SetInstanceParams(opts, args):
                                    nics=nics,
                                    disks=disks,
                                    hotplug=opts.hotplug,
-                                   hotplug_if_possible=opts.hotplug_if_possible,
                                    disk_template=opts.disk_template,
                                    ext_params=ext_params,
                                    file_driver=opts.file_driver,
@@ -1660,8 +1659,8 @@ commands = {
      OS_OPT, FORCE_VARIANT_OPT,
      OSPARAMS_OPT, OSPARAMS_PRIVATE_OPT, DRY_RUN_OPT, PRIORITY_OPT, NWSYNC_OPT,
      OFFLINE_INST_OPT, ONLINE_INST_OPT, IGNORE_IPOLICY_OPT, RUNTIME_MEM_OPT,
-     NOCONFLICTSCHECK_OPT, NEW_PRIMARY_OPT, HOTPLUG_OPT,
-     HOTPLUG_IF_POSSIBLE_OPT, INSTANCE_COMMUNICATION_OPT,
+     NOCONFLICTSCHECK_OPT, NEW_PRIMARY_OPT,
+     NOHOTPLUG_OPT, INSTANCE_COMMUNICATION_OPT,
      EXT_PARAMS_OPT, FILESTORE_DRIVER_OPT, FILESTORE_DIR_OPT],
     "<instance-name>", "Alters the parameters of an instance"),
   "shutdown": (

--- a/lib/tools/burnin.py
+++ b/lib/tools/burnin.py
@@ -1090,11 +1090,11 @@ class Burner(JobHandler):
 
       op_stop = self.StopInstanceOp(instance)
       op_add = opcodes.OpInstanceSetParams(
-        instance_name=instance, hotplug_if_possible=True,
+        instance_name=instance,
         disks=[(constants.DDM_ADD, {"size": self.disk_size[0],
                                     "name": disk_name})])
       op_detach = opcodes.OpInstanceSetParams(
-        instance_name=instance, hotplug_if_possible=True,
+        instance_name=instance,
         disks=[(constants.DDM_DETACH, {})])
       op_start = self.StartInstanceOp(instance)
       Log("adding a disk with name %s" % disk_name, indent=2)
@@ -1118,10 +1118,10 @@ class Burner(JobHandler):
 
       disk_name = self.FindMatchingDisk(instance)
       op_attach = opcodes.OpInstanceSetParams(
-        instance_name=instance, hotplug_if_possible=True,
+        instance_name=instance,
         disks=[(constants.DDM_ATTACH, {"name": disk_name})])
       op_rem = opcodes.OpInstanceSetParams(
-        instance_name=instance, hotplug_if_possible=True,
+        instance_name=instance,
         disks=[(constants.DDM_REMOVE, {})])
       op_stop = self.StopInstanceOp(instance)
       op_start = self.StartInstanceOp(instance)

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -1436,8 +1436,7 @@ MODIFY
 | [\--offline \| \--online]
 | [\--submit] [\--print-jobid]
 | [\--ignore-ipolicy]
-| [\--hotplug]
-| [\--hotplug-if-possible]
+| [\--no-hotplug]
 | {*instance-name*}
 
 Modifies the memory size, number of vcpus, ip address, MAC address
@@ -1539,20 +1538,15 @@ immediately.
 If ``--ignore-ipolicy`` is given any instance policy violations occurring
 during this operation are ignored.
 
-If ``--hotplug`` is given any disk and NIC modifications will take
-effect without the need of actual reboot. Please note that this feature
-is currently supported only for KVM hypervisor and there are some
-restrictions: a) NIC/Disk hot-remove should work for QEMU versions >= 1.0
-b) instances with chroot or pool/user security model support disk
-hot-add only for QEMU version > 1.7 where add-fd QMP command exists c)
-if hotplug fails (for any reason) a warning is printed but execution is
-continued d) for existing NIC modification interactive verification is
-needed unless ``--force`` option is passed.
+If ``--no-hotplug`` is given any disk and NIC modifications will not be
+hot-plugged. The change will take place after
+the reboot.
 
-If ``--hotplug-if-possible`` is given then ganeti won't abort in case
-hotplug is not supported. It will continue execution and modification
-will take place after reboot. This covers use cases where instances are
-not running or hypervisor is not KVM.
+Without the ``--no-hotplug`` parameter, Ganeti attempts to perform the operation
+hot if possible. Hotplug is currently supported only for disk and nic
+modifications in the KVM hypervisor. If hotplug fails (for any reason) a
+warning is printed but execution is continued. For existing NIC modification
+interactive verification is needed unless ``--force`` option is passed.
 
 See **ganeti**\(7) for a description of ``--submit`` and other common
 options.

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -1539,14 +1539,13 @@ If ``--ignore-ipolicy`` is given any instance policy violations occurring
 during this operation are ignored.
 
 If ``--no-hotplug`` is given any disk and NIC modifications will not be
-hot-plugged. The change will take place after
-the reboot.
+hot-plugged. The change will take place after the reboot.
 
 Without the ``--no-hotplug`` parameter, Ganeti attempts to perform the operation
-hot if possible. Hotplug is currently supported only for disk and nic
-modifications in the KVM hypervisor. If hotplug fails (for any reason) a
-warning is printed but execution is continued. For existing NIC modification
-interactive verification is needed unless ``--force`` option is passed.
+hot if possible. Hotplug is currently supported only for disk and NIC
+modifications in the KVM hypervisor. If hotplug fails (for any reason) a warning
+is printed but execution is continued. For existing NIC modification interactive
+verification is needed unless ``--force`` option is passed.
 
 See **ganeti**\(7) for a description of ``--submit`` and other common
 options.

--- a/src/Ganeti/OpCodes.hs
+++ b/src/Ganeti/OpCodes.hs
@@ -705,7 +705,6 @@ $(genOpCode "OpCode"
      , withDoc "Whether to mark the instance as offline" pOffline
      , pIpConflictsCheck
      , pHotplug
-     , pHotplugIfPossible
      , pOptInstanceCommunication
      ],
      "instance_name")

--- a/src/Ganeti/OpParams.hs
+++ b/src/Ganeti/OpParams.hs
@@ -111,7 +111,6 @@ module Ganeti.OpParams
   , pDiskState
   , pIgnoreIpolicy
   , pHotplug
-  , pHotplugIfPossible
   , pAllowRuntimeChgs
   , pInstDisks
   , pDiskTemplate
@@ -594,10 +593,7 @@ pGroupName =
 
 -- | Whether to hotplug device.
 pHotplug :: Field
-pHotplug = defaultFalse "hotplug"
-
-pHotplugIfPossible :: Field
-pHotplugIfPossible = defaultFalse "hotplug_if_possible"
+pHotplug = defaultTrue "hotplug"
 
 pInstances :: Field
 pInstances =

--- a/test/hs/Test/Ganeti/OpCodes.hs
+++ b/test/hs/Test/Ganeti/OpCodes.hs
@@ -445,7 +445,6 @@ instance Arbitrary OpCodes.OpCode where
           <*> arbitrary                       -- offline
           <*> arbitrary                       -- conflicts_check
           <*> arbitrary                       -- hotplug
-          <*> arbitrary                       -- hotplug_if_possible
           <*> arbitrary                       -- instance_communication
       "OP_INSTANCE_GROW_DISK" ->
         OpCodes.OpInstanceGrowDisk <$> genFQDN <*> return Nothing <*>

--- a/test/py/legacy/cmdlib/instance_unittest.py
+++ b/test/py/legacy/cmdlib/instance_unittest.py
@@ -2344,17 +2344,16 @@ class TestLUInstanceSetParams(CmdlibTestCase):
   def testNoHotplugSupport(self):
     op = self.CopyOpCode(self.op,
                          nics=[(constants.DDM_ADD, -1, {})],
-                         hotplug=True)
+                         )
     self.rpc.call_hotplug_supported.return_value = \
       self.RpcResultsBuilder() \
         .CreateFailedNodeResult(self.master)
-    self.ExecOpCodeExpectOpPrereqError(op, "Hotplug is not possible")
-    self.assertTrue(self.rpc.call_hotplug_supported.called)
+    self.assertFalse(self.rpc.call_hotplug_supported.called)
 
   def testHotplugIfPossible(self):
     op = self.CopyOpCode(self.op,
-                         nics=[(constants.DDM_ADD, -1, {})],
-                         hotplug_if_possible=True)
+                         nics=[(constants.DDM_ADD, -1, {})]
+                         )
     self.rpc.call_hotplug_supported.return_value = \
       self.RpcResultsBuilder() \
         .CreateFailedNodeResult(self.master)
@@ -3072,8 +3071,8 @@ class TestLUInstanceSetParams(CmdlibTestCase):
                                           self.cfg.CreateDisk()])
     op = self.CopyOpCode(self.op,
                          instance_name=inst.name,
-                         disks=[[constants.DDM_REMOVE, -1,
-                                 {}]]) # without hotplug
+                         disks=[[constants.DDM_REMOVE, -1, {}]],
+                         hotplug=False) # without hotplug
     self.rpc.call_instance_info.side_effect = [
       self.RpcResultsBuilder() \
         .CreateSuccessfulNodeResult(self.master,

--- a/test/py/legacy/cmdlib/instance_unittest.py
+++ b/test/py/legacy/cmdlib/instance_unittest.py
@@ -2342,16 +2342,17 @@ class TestLUInstanceSetParams(CmdlibTestCase):
     self.ExecOpCodeExpectOpPrereqError(op, msg)
 
   def testNoHotplugSupport(self):
-    op = self.CopyOpCode(self.op,
-                         nics=[(constants.DDM_ADD, -1, {})],
-                         )
+    op = self.CopyOpCode(self.running_op,
+                         nics=[(constants.DDM_ADD, -1, {})])
     self.rpc.call_hotplug_supported.return_value = \
       self.RpcResultsBuilder() \
         .CreateFailedNodeResult(self.master)
-    self.assertFalse(self.rpc.call_hotplug_supported.called)
+    self.ExecOpCode(op)
+    self.assertFalse(op.hotplug)
+    self.assertTrue(self.rpc.call_hotplug_supported.called)
 
   def testHotplugIfPossible(self):
-    op = self.CopyOpCode(self.op,
+    op = self.CopyOpCode(self.running_op,
                          nics=[(constants.DDM_ADD, -1, {})]
                          )
     self.rpc.call_hotplug_supported.return_value = \
@@ -2362,7 +2363,7 @@ class TestLUInstanceSetParams(CmdlibTestCase):
     self.assertFalse(self.rpc.call_hotplug_device.called)
 
   def testHotAddNic(self):
-    op = self.CopyOpCode(self.op,
+    op = self.CopyOpCode(self.running_op,
                          nics=[(constants.DDM_ADD, -1, {})],
                          hotplug=True)
     self.rpc.call_hotplug_supported.return_value = \
@@ -2458,7 +2459,7 @@ class TestLUInstanceSetParams(CmdlibTestCase):
     self.ExecOpCode(op)
 
   def testHotModifyNic(self):
-    op = self.CopyOpCode(self.op,
+    op = self.CopyOpCode(self.running_op,
                          nics=[(constants.DDM_MODIFY, 0, {})],
                          hotplug=True)
     self.rpc.call_hotplug_supported.return_value = \
@@ -2489,9 +2490,10 @@ class TestLUInstanceSetParams(CmdlibTestCase):
     self.ExecOpCodeExpectOpPrereqError(op, msg)
 
   def testHotRemoveNic(self):
-    inst = self.cfg.AddNewInstance(nics=[self.cfg.CreateNic(),
+    inst = self.cfg.AddNewInstance(admin_state=constants.ADMINST_UP,
+                                   nics=[self.cfg.CreateNic(),
                                          self.cfg.CreateNic()])
-    op = self.CopyOpCode(self.op,
+    op = self.CopyOpCode(self.running_op,
                          instance_name=inst.name,
                          nics=[(constants.DDM_REMOVE, 0, {})],
                          hotplug=True)
@@ -2640,7 +2642,7 @@ class TestLUInstanceSetParams(CmdlibTestCase):
         .CreateSuccessfulNodeResult(self.master, ("/dev/mocked_path",
                                     "/var/run/ganeti/instance-disks/mocked_d",
                                     None))
-    op = self.CopyOpCode(self.op,
+    op = self.CopyOpCode(self.running_op,
                          disks=[[constants.DDM_ADD, -1,
                                  {
                                    constants.IDISK_SIZE: 1024,
@@ -2779,7 +2781,7 @@ class TestLUInstanceSetParams(CmdlibTestCase):
                                     ("/dev/mocked_path",
                                      "/var/run/ganeti/instance-disks/mocked_d",
                                      None))
-    op = self.CopyOpCode(self.op,
+    op = self.CopyOpCode(self.running_op,
                          disks=[[constants.DDM_ATTACH, -1,
                                  {
                                    constants.IDISK_NAME: self.mocked_disk_name
@@ -2794,9 +2796,10 @@ class TestLUInstanceSetParams(CmdlibTestCase):
     self.assertTrue(self.rpc.call_hotplug_device.called)
 
   def testHotRemoveDisk(self):
-    inst = self.cfg.AddNewInstance(disks=[self.cfg.CreateDisk(),
+    inst = self.cfg.AddNewInstance(admin_state=constants.ADMINST_UP,
+                                   disks=[self.cfg.CreateDisk(),
                                           self.cfg.CreateDisk()])
-    op = self.CopyOpCode(self.op,
+    op = self.CopyOpCode(self.running_op,
                          instance_name=inst.name,
                          disks=[[constants.DDM_REMOVE, -1,
                                  {}]],
@@ -2811,9 +2814,10 @@ class TestLUInstanceSetParams(CmdlibTestCase):
     self.assertTrue(self.rpc.call_blockdev_remove.called)
 
   def testHotDetachDisk(self):
-    inst = self.cfg.AddNewInstance(disks=[self.cfg.CreateDisk(),
+    inst = self.cfg.AddNewInstance(admin_state=constants.ADMINST_UP,
+                                   disks=[self.cfg.CreateDisk(),
                                           self.cfg.CreateDisk()])
-    op = self.CopyOpCode(self.op,
+    op = self.CopyOpCode(self.running_op,
                          instance_name=inst.name,
                          disks=[[constants.DDM_DETACH, -1,
                                  {}]],


### PR DESCRIPTION
This PR enables hotplug by default for 'gnt-instance modify' and adds the option --no-hotplug to disable hotplug.
A restart should not always be carried out when parameters are changed if this is not necessary.

The parameter --hotplug_if_possible has been removed. Hotplug is now always tried with gnt-instance modify.
A warning is now displayed instead of an error.

See #1548


