### PR TITLE
kvm online disk resize via qmp

### DIFF
--- a/lib/backend.py
+++ b/lib/backend.py
@@ -3180,6 +3180,20 @@ def GetMigrationStatus(instance):
     _Fail("Failed to get migration status: %s", err, exc=True)
 
 
+def ResizeDisk(instance, disk, new_size):
+  """Notify the hypervisor about a disk change.
+
+    @type disk: L{objects.Disk}
+    @param disk: the disk to be changed
+    @type new_size: int
+    @param new_size: the new size in bytes
+    @raise errors.HotplugError: if disk resize is not supported
+  """
+
+  hyper = hypervisor.GetHypervisor(instance.hypervisor)
+
+  return hyper.ResizeDisk(instance, disk, new_size)
+
 def HotplugDevice(instance, action, dev_type, device, extra, seq):
   """Hotplug a device
 

--- a/lib/hypervisor/hv_base.py
+++ b/lib/hypervisor/hv_base.py
@@ -761,6 +761,19 @@ class BaseHypervisor(object):
     else:
       return None
 
+  def ResizeDisk(self, instance, disk, new_size):
+    """Notify the hypervisor about a disk change.
+
+    @type disk: L{objects.Disk}
+    @param disk: the disk to be changed
+    @type new_size: int
+    @param new_size: the new size in bytes
+    @raise errors.HotplugError: if disk resize is not supported
+    """
+
+    raise errors.HotplugError("Disk resize is not supported by this hypervisor")
+
+
   # pylint: disable=R0201,W0613
   def HotAddDevice(self, instance, dev_type, device, extra, seq):
     """Hot-add a device.

--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -2155,6 +2155,17 @@ class KVMHypervisor(hv_base.BaseHypervisor):
       if action == constants.HOTPLUG_ACTION_ADD:
         self.qmp.CheckNicHotAddSupport()
 
+
+  @_with_qmp
+  def ResizeDisk(self, instance, disk, new_size):
+    """ Notify the HV about a disk change.
+    """
+
+    disk_id = _GenerateDeviceKVMId('disk', disk)
+
+    self.qmp.ResizeBlockDevice(disk_id, new_size)
+
+
   @_with_qmp
   def HotplugSupported(self, instance):
     """Checks if hotplug is generally supported.

--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -597,6 +597,19 @@ class QmpConnection(MonitorSocket):
     devices = bus["devices"]
     return devices
 
+
+  @_ensure_connection
+  def ResizeBlockDevice(self, disk_id: str, new_size: int):
+    """ Notify the guest about a disk change.
+    """
+    arguments = {
+      "node-name": disk_id,
+      "size": new_size
+    }
+
+    self.Execute("block_resize", arguments)
+
+
   def _HasPCIDevice(self, devid):
     """Check if a specific device ID exists on the PCI bus.
 

--- a/lib/rpc_defs.py
+++ b/lib/rpc_defs.py
@@ -304,6 +304,11 @@ _INSTANCE_CALLS = [
     ("extra", None, "Extra info for device (dev_path for disk)"),
     ("seq", None, "Device seq"),
     ], None, None, "Hotplug a device to a running instance"),
+  ("resize_disk", SINGLE, None, constants.RPC_TMO_NORMAL, [
+    ("instance", ED_INST_DICT, "Instance object"),
+    ("disk", None, "The disk to be resized"),
+    ("new_size", None, "The new disk size in bytes"),
+    ], None, None, "Notify the HV about a disk resize"),
   ("hotplug_supported", SINGLE, None, constants.RPC_TMO_NORMAL, [
     ("instance", ED_INST_DICT, "Instance object"),
     ], None, None, "Check if hotplug is supported"),

--- a/lib/server/noded.py
+++ b/lib/server/noded.py
@@ -645,6 +645,17 @@ class NodeRequestHandler(http.server.HttpServerHandler):
     return backend.StartInstance(instance, startup_paused, trail)
 
   @staticmethod
+  def perspective_resize_disk(params):
+    """Notify the hypervisor about a disk change.
+
+    """
+    (idict, disk, new_size) = params
+    instance = objects.Instance.FromDict(idict)
+    disk = objects.Disk.FromDict(disk)
+
+    return backend.ResizeDisk(instance, disk, new_size)
+
+  @staticmethod
   def perspective_hotplug_device(params):
     """Hotplugs device to a running instance.
 


### PR DESCRIPTION
This commit adds the ability to grow a disk of a kvm instance online without hook scripts. When the 'gnt-instance grow-disk' command is completed, an rpc call is called, which notifies the hypervisor of a disk change via qmp-socket.

This was realised with the new ‘abstracted‘ method 'ResizeDisk' in lib/hypervisor/hv_base.py, which was currently only implemented for the kvm hypervisor.

See #1549 & #28