### PR TITLE
Network.poolLens, poolArrayLens: reactivate Lens' type signature

### DIFF
--- a/src/Ganeti/Network.hs
+++ b/src/Ganeti/Network.hs
@@ -87,11 +87,11 @@ data PoolPart = PoolInstances | PoolExt
 addressPoolIso :: Iso' AddressPool BA.BitArray
 addressPoolIso = iso apReservations AddressPool
 
---poolLens :: PoolPart -> Lens' Network (Maybe AddressPool)
+poolLens :: PoolPart -> Lens' Network (Maybe AddressPool)
 poolLens PoolInstances = networkReservationsL
 poolLens PoolExt = networkExtReservationsL
 
---poolArrayLens :: PoolPart -> Lens' Network (Maybe BA.BitArray)
+poolArrayLens :: PoolPart -> Lens' Network (Maybe BA.BitArray)
 poolArrayLens part = poolLens part . mapping addressPoolIso
 
 netIpv4NumHosts :: Network -> Integer
@@ -135,12 +135,12 @@ withPool_ :: (MonadError e m, Error e)
 withPool_ part f = execStateT $ withPool part ((liftM ((,) ()) .) . f)
 
 readPool :: PoolPart -> Network -> Maybe BA.BitArray
-readPool = view . poolArrayLens
+readPool part = view (poolArrayLens part)
 
 readPoolE :: (MonadError e m, Error e)
           => PoolPart -> Network -> m BA.BitArray
 readPoolE part net =
-  liftM apReservations $ orNewPool net ((view . poolLens) part net)
+  liftM apReservations $ orNewPool net (view (poolLens part) net)
 
 readAllE :: (MonadError e m, Error e)
          => Network -> m BA.BitArray

--- a/src/Ganeti/Utils/MultiMap.hs
+++ b/src/Ganeti/Utils/MultiMap.hs
@@ -91,7 +91,7 @@ multiMap :: (Ord k, Ord v) => M.Map k (S.Set v) -> MultiMap k v
 multiMap = MultiMap . M.filter (not . S.null)
 
 -- | A 'Lens' that allows to access a set under a given key in a multi-map.
---multiMapL :: (Ord k, Ord v) => k -> Lens' (MultiMap k v) (S.Set v)
+multiMapL :: (Ord k, Ord v) => k -> Lens' (MultiMap k v) (S.Set v)
 multiMapL k f = fmap MultiMap
                  . at k (fmap (mfilter (not . S.null) . Just)
                          . f . fromMaybe S.empty)
@@ -100,7 +100,7 @@ multiMapL k f = fmap MultiMap
 
 -- | Return the set corresponding to a given key.
 lookup :: (Ord k, Ord v) => k -> MultiMap k v -> S.Set v
-lookup = view . multiMapL
+lookup k = view (multiMapL k)
 
 -- | Tests if the given key has a non-empty set of values.
 member :: (Ord k, Ord v) => k -> MultiMap k v -> Bool


### PR DESCRIPTION
readPool, readPoolE: avoid use of function composition (.) since its type does not match the forall quantifier hidden in the `Lens'` type synonym.

This reverts 5e30bad1bba63c9f6c782003ef2560f107a0ba24