### PR TITLE
avoid warnings on use of the partial function `head`

### DIFF
--- a/src/Ganeti/HTools/Graph.hs
+++ b/src/Ganeti/HTools/Graph.hs
@@ -156,12 +156,14 @@ verticesColorSet cMap = IntSet.fromList . verticesColors cMap
 neighColors :: Graph.Graph -> VertColorMap -> Graph.Vertex -> [Color]
 neighColors g cMap v = verticesColors cMap $ neighbors g v
 
-{-# ANN colorNode "HLint: ignore Use alternative" #-}
 -- | Color one node.
 colorNode :: Graph.Graph -> VertColorMap -> Graph.Vertex -> Color
--- use of "head" is A-ok as the source is an infinite list
-colorNode g cMap v = head $ filter notNeighColor [0..]
-    where notNeighColor = (`notElem` neighColors g cMap v)
+colorNode g cMap v =
+    case filter (`notElem` neighColors g cMap v) [0..] of
+        c:_ -> c
+        [] -> error $ "colorNode: " ++
+            "we excluded finitely many colors from an infinite list, " ++
+            "thus the remaining list should be non-empty"
 
 -- | Color a node returning the updated color map.
 colorNodeInMap :: Graph.Graph -> Graph.Vertex -> VertColorMap -> VertColorMap
@@ -233,5 +235,5 @@ colorDsatur g =
 -- | ColorVertMap from VertColorMap.
 colorVertMap :: VertColorMap -> ColorVertMap
 colorVertMap = IntMap.foldrWithKey
-                 (flip (IntMap.insertWith ((:) . head)) . replicate 1)
+                 (flip (IntMap.insertWith (++)) . replicate 1)
                  IntMap.empty

--- a/src/Ganeti/HTools/Node.hs
+++ b/src/Ganeti/HTools/Node.hs
@@ -107,6 +107,7 @@ import qualified Data.Foldable as Foldable
 import Data.Function (on)
 import qualified Data.Graph as Graph
 import qualified Data.IntMap as IntMap
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.List as List
 import qualified Data.Map as Map
 import Data.Ord (comparing)
@@ -1398,13 +1399,10 @@ defaultFields =
   , "pfmem", "pfdsk", "rcpu"
   , "cload", "mload", "dload", "nload" ]
 
-{-# ANN computeGroups "HLint: ignore Use alternative" #-}
 -- | Split a list of nodes into a list of (node group UUID, list of
 -- associated nodes).
 computeGroups :: [Node] -> [(T.Gdx, [Node])]
 computeGroups nodes =
   let nodes' = List.sortBy (comparing group) nodes
-      nodes'' = List.groupBy ((==) `on` group) nodes'
-  -- use of head here is OK, since groupBy returns non-empty lists; if
-  -- you remove groupBy, also remove use of head
-  in map (\nl -> (group (head nl), nl)) nodes''
+      nodes'' = NonEmpty.groupBy ((==) `on` group) nodes'
+  in map (\nl -> (group (NonEmpty.head nl), NonEmpty.toList nl)) nodes''

--- a/src/Ganeti/HTools/Program/Hspace.hs
+++ b/src/Ganeti/HTools/Program/Hspace.hs
@@ -42,6 +42,7 @@ import Control.Monad
 import Data.Char (toUpper, toLower)
 import Data.Function (on)
 import qualified Data.IntMap as IntMap
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.List
 import Data.Maybe (fromMaybe)
 import Data.Ord (comparing)
@@ -251,17 +252,16 @@ printResults False ini_nl fin_nl _ allocs sreason = do
 printFinalHTS :: Bool -> IO ()
 printFinalHTS = printFinal htsPrefix
 
-{-# ANN tieredSpecMap "HLint: ignore Use alternative" #-}
--- | Compute the tiered spec counts from a list of allocated
--- instances.
+-- | Compute the tiered spec counts from a list of allocated instances.
 tieredSpecMap :: [Instance.Instance]
               -> [(RSpec, Int)]
 tieredSpecMap trl_ixes =
   let fin_trl_ixes = reverse trl_ixes
-      ix_byspec = groupBy ((==) `on` Instance.specOf) fin_trl_ixes
-      -- head is "safe" here, as groupBy returns list of non-empty lists
-      spec_map = map (\ixs -> (Instance.specOf $ head ixs, length ixs))
-                 ix_byspec
+      ix_byspec = NonEmpty.groupBy ((==) `on` Instance.specOf) fin_trl_ixes
+      spec_map =
+        map
+          (\ixs -> (Instance.specOf $ NonEmpty.head ixs, NonEmpty.length ixs))
+          ix_byspec
   in spec_map
 
 -- | Formats a spec map to strings.

--- a/src/Ganeti/Luxi.hs
+++ b/src/Ganeti/Luxi.hs
@@ -62,6 +62,8 @@ module Ganeti.Luxi
   , allLuxiCalls
   ) where
 
+import Data.Maybe (listToMaybe)
+
 import Control.Applicative (optional, liftA, (<|>))
 import Control.Monad
 import qualified Text.JSON as J
@@ -377,8 +379,8 @@ queryJobsStatus s jids = do
   return $ case rval of
              Bad x -> Bad x
              Ok y -> case J.readJSON y::(J.Result [[JobStatus]]) of
-                       J.Ok vals -> if any null vals
-                                    then Bad $
-                                         LuxiError "Missing job status field"
-                                    else Ok (map head vals)
+                       J.Ok vals ->
+                         case mapM listToMaybe vals of
+                           Nothing -> Bad $ LuxiError "Missing job status field"
+                           Just headVals -> Ok headVals
                        J.Error x -> Bad $ LuxiError x

--- a/src/Ganeti/Utils.hs
+++ b/src/Ganeti/Utils.hs
@@ -110,6 +110,7 @@ import qualified Data.Either as E
 import Data.Function (on)
 import Data.IORef
 import Data.List
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Set as S
@@ -813,8 +814,7 @@ ordNub =
         else x : go (S.insert x s) xs
   in go S.empty
 
-{-# ANN frequency "HLint: ignore Use alternative" #-}
 -- | Returns a list of tuples of elements and the number of times they occur
 -- in a list
 frequency :: Ord t => [t] -> [(Int, t)]
-frequency xs = map (\x -> (length x, head x)) . group . sort $ xs
+frequency = map (\x -> (length x, NonEmpty.head x)) . NonEmpty.group . sort

--- a/src/Ganeti/WConfd/TempRes.hs
+++ b/src/Ganeti/WConfd/TempRes.hs
@@ -249,7 +249,7 @@ computeDRBDMap cfg trs = do
   let dups = filterNested ((>= 2) . length) m
   unless (M.null dups) . resError
     $ "Duplicate DRBD ports detected: " ++ show (M.toList $ fmap M.toList dups)
-  return $ fmap (fmap head . M.filter ((== 1) . length)) m
+  return $ fmap (M.mapMaybe listToMaybe) m
            `M.union` (fmap (const mempty) . J.fromContainer . configNodes $ cfg)
 
 -- Allocate a drbd minor.


### PR DESCRIPTION
Those warnings are issued by GHC-9.10 and in principle also by HLint, if they were not silenced.