### PR TITLE
implement 'return' using 'pure' to silence warnings in GHC-9.10

### DIFF
--- a/src/Ganeti/BasicTypes.hs
+++ b/src/Ganeti/BasicTypes.hs
@@ -117,7 +117,7 @@ type Result = GenericResult String
 instance (Error a) => Monad (GenericResult a) where
   (>>=) (Bad x) _ = Bad x
   (>>=) (Ok x) fn = fn x
-  return = Ok
+  return = pure
 #if !MIN_VERSION_base(4,13,0)
   fail   = Bad . strMsg
 #endif
@@ -175,11 +175,11 @@ elimResultT l r = ResultT . (runResultT . result <=< runResultT)
 {-# INLINE elimResultT #-}
 
 instance (Applicative m, Monad m, Error a) => Applicative (ResultT a m) where
-  pure = return
+  pure = lift . pure
   (<*>) = ap
 
 instance (Monad m, Error a) => Monad (ResultT a m) where
-  return   = lift . return
+  return   = pure
   (>>=)    = flip (elimResultT throwError)
 #if !MIN_VERSION_base(4,13,0)
   fail err = ResultT (return . Bad $ strMsg err)

--- a/src/Ganeti/Types.hs
+++ b/src/Ganeti/Types.hs
@@ -995,7 +995,7 @@ instance Applicative Private where
 
 instance Monad Private where
   (Private x) >>= f = f x
-  return = Private
+  return = pure
 
 showPrivateJSObject :: (JSON.JSON a) =>
                        [(String, a)] -> JSON.JSObject (Private JSON.JSValue)
@@ -1025,7 +1025,7 @@ instance Applicative Secret where
 
 instance Monad Secret where
   (Secret x) >>= f = f x
-  return = Secret
+  return = pure
 
 -- | We return "\<redacted\>" here to satisfy the idempotence of serialization
 -- and deserialization, although this will impact the meaningfulness of secret


### PR DESCRIPTION
in anticipation of the "Monad of no Return" proposal