### PR TITLE
Replace query-cpus with query-cpus-fast

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -1108,7 +1108,7 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     try:
       qmp = QmpConnection(self._InstanceQmpMonitor(instance_name))
       qmp.connect()
-      vcpus = len(qmp.Execute("query-cpus"))
+      vcpus = len(qmp.Execute("query-cpus-fast"))
       # Will fail if ballooning is not enabled, but we can then just resort to
       # the value above.
       mem_bytes = qmp.Execute("query-balloon")[qmp.ACTUAL_KEY]


### PR DESCRIPTION
This replaces the query-cpus qmp command with query-cpus-fast. The query-cpus command can interrupt running cpus, which can cause performances problems.

See https://patchwork.kernel.org/project/qemu-devel/patch/20210318092512.250725-6-berrange@redhat.com