### PR TITLE
Ganeti.Lens: NoPolyKinds

### DIFF
--- a/src/Ganeti/Lens.hs
+++ b/src/Ganeti/Lens.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE Rank2Types, CPP #-}
+{-# LANGUAGE NoPolyKinds #-}
 
 {-| Provides all lens-related functions.
 
@@ -93,13 +94,13 @@ makeCustomLenses' name lst = makeCustomLensesFiltered f name
 -- Most often the @g@ functor is @(,) r@ and 'traverseOf2' is used to
 -- traverse an effectful computation that also returns an additional output
 -- value.
-traverseOf2 :: Over (->) (Compose f g) s t a b
+traverseOf2 :: LensLike (Compose f g) s t a b
             -> (a -> f (g b)) -> s -> f (g t)
 traverseOf2 k f = getCompose . traverseOf k (Compose . f)
 
 -- | Traverses over a composition of a monad and a functor.
 -- See 'traverseOf2'.
-mapMOf2 :: Over (->) (Compose (WrappedMonad m) g) s t a b
+mapMOf2 :: LensLike (Compose (WrappedMonad m) g) s t a b
         -> (a -> m (g b)) -> s -> m (g t)
 mapMOf2 k f = unwrapMonad . traverseOf2 k (WrapMonad . f)
 


### PR DESCRIPTION
NoPolyKinds enables compilation of this module with GHC>=9.2.

This should solve https://github.com/ganeti/ganeti/issues/1748.