### PR TITLE
use full image uri for devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Ganeti Dev Container",
-    "image": "ganeti/ci:bookworm-py3",
+    "image": "docker.io/ganeti/ci:bookworm-py3",
 
     "customizations":{
         "vscode": {


### PR DESCRIPTION
With this change, container-engines other than Docker (e.g. Podman) can also be used.