### PR TITLE
remove sphinx.util.compat

### DIFF
--- a/lib/build/sphinx_ext.py
+++ b/lib/build/sphinx_ext.py
@@ -45,7 +45,6 @@ import docutils.parsers.rst
 from docutils.parsers.rst import Directive
 
 import sphinx.errors
-import sphinx.util.compat
 import sphinx.roles
 import sphinx.addnodes
 


### PR DESCRIPTION
Remove a leftover import of sphinx.util.compat, which was officially removed in Sphinx-1.7.0[1], but not detected until now in Ubuntu-24.04/Sphinx-7.2.6.

[1] https://www.sphinx-doc.org/en/master/changes/1.7.html#release-1-7-0-released-feb-12-2018