### PR TITLE
workaround pandoc generating invalid fonts

### DIFF
--- a/autotools/check-man-warnings
+++ b/autotools/check-man-warnings
@@ -37,5 +37,6 @@ fi
 
 ! LANG="$loc" LC_ALL="$loc" MANWIDTH=80 \
   man --warnings --encoding=utf8 --local-file "$1" 2>&1 >/dev/null | \
-  grep -v -e "cannot adjust line" -e "can't break line" | \
+  grep -v -e "cannot adjust line" -e "can't break line" \
+    -e "cannot select font" | \
   grep .


### PR DESCRIPTION
In certain pandoc versions invalid fonts in groff output are generated[1]. Upstream seems to have fixed the issue[2], but as of now this issue is present in Debian testing+sid and Ubuntu 24.04. Besides the invalid fonts, the generated man-pages look fine. So ignore this warning as a workaround.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1062045
[2] https://github.com/jgm/pandoc/issues/9020