### PR TITLE
redesign kvm qmp monitor

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -69,8 +69,7 @@ from ganeti import pathutils
 from ganeti.hypervisor import hv_base
 from ganeti.utils import wrapper as utils_wrapper
 
-from ganeti.hypervisor.hv_kvm.monitor import QmpConnection, QmpMessage, \
-                                             MonitorSocket
+from ganeti.hypervisor.hv_kvm.monitor import QmpConnection, QmpMessage
 from ganeti.hypervisor.hv_kvm.netdev import OpenTap
 
 from ganeti.hypervisor.hv_kvm.validation import check_boot_parameters, \
@@ -1108,10 +1107,10 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     try:
       qmp = QmpConnection(self._InstanceQmpMonitor(instance_name))
       qmp.connect()
-      vcpus = len(qmp.Execute("query-cpus-fast"))
+      vcpus = len(qmp.execute_qmp("query-cpus-fast"))
       # Will fail if ballooning is not enabled, but we can then just resort to
       # the value above.
-      mem_bytes = qmp.Execute("query-balloon")[qmp.ACTUAL_KEY]
+      mem_bytes = qmp.execute_qmp("query-balloon")[qmp.ACTUAL_KEY]
       memory = mem_bytes // 1048576
     except errors.HypervisorError:
       pass

--- a/test/py/ganeti.hypervisor.hv_kvm_unittest.py
+++ b/test/py/ganeti.hypervisor.hv_kvm_unittest.py
@@ -558,7 +558,7 @@ class TestQmpMessage(testutils.GanetiTestCase):
     self.assertEqual(len(serialized.splitlines()), 1,
                      msg="Got multi-line message")
 
-    rebuilt_message = hv_kvm.QmpMessage.BuildFromJsonString(serialized)
+    rebuilt_message = hv_kvm.QmpMessage.build_from_json_string(serialized)
     self.assertEqual(rebuilt_message, message)
     self.assertEqual(len(rebuilt_message), len(test_data))
 
@@ -619,7 +619,7 @@ class TestQmp(testutils.GanetiTestCase):
       # Format the script
       for request, expected_response in zip(self.REQUESTS,
                                             self.EXPECTED_RESPONSES):
-        response = qmp_connection.Execute(request["execute"],
+        response = qmp_connection.execute_qmp(request["execute"],
                                           request["arguments"])
         self.assertEqual(response, expected_response)
         msg = hv_kvm.QmpMessage({"return": expected_response})
@@ -627,7 +627,7 @@ class TestQmp(testutils.GanetiTestCase):
                          msg="Got multi-line message")
 
       self.assertRaises(monitor.QmpCommandNotSupported,
-                        qmp_connection.Execute,
+                        qmp_connection.execute_qmp,
                       "unsupported-command")
     finally:
       qmp_stub.shutdown()
@@ -645,7 +645,7 @@ class TestQmp(testutils.GanetiTestCase):
       with hv_kvm.QmpConnection(socket_file.name) as qmp:
         for request, expected_response in zip(self.REQUESTS,
                                               self.EXPECTED_RESPONSES):
-          response = qmp.Execute(request["execute"], request["arguments"])
+          response = qmp.execute_qmp(request["execute"], request["arguments"])
           self.assertEqual(response, expected_response)
     finally:
       qmp_stub.shutdown()


### PR DESCRIPTION
This commit has changed the substructure of QMP communication.  The code has been modernised with typehints codestyle and better logging.

The inheritance hierarchy has been adapted so that communication with the QGA agent is now possible.

Furthermore, the QmpConnection class can now wait for certain events (see QmpConnection#wait_for_qmp_event).  This can also solve the issue #1749.

To minimise code changes, the old method 'Execute' refers to the new 'execute_qmp'.