### PR TITLE
Secure GH actions by restricting GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
   schedule:
     - cron: '42 3 * * *'
 
+permissions: read-all
+
 jobs:
   build:
     name: Build on ${{ matrix.os }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,8 @@ on:
   schedule:
     - cron: '0 12 * * 3'
 
+permissions: read-all
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/qa-suite-run.yml
+++ b/.github/workflows/qa-suite-run.yml
@@ -19,6 +19,7 @@ on:
         description: "Which Debian version to use"
         required: true
         default: "bullseye"
+permissions: read-all
 defaults:
   run:
     working-directory: /home/rbott/ganeti-cluster-testing


### PR DESCRIPTION
Currently GH actions can use GITHUB_TOKEN to possibly modify repositories/actions etc. from within a job. This commit restricts the use of the GITHUB_TOKEN in all existing workflows to read-only actions (more fine-grained configuration is possible).

This has been uncovered by the [OpenSSF security scorecard](https://scorecard.dev/) (see [Token-Permissions check documentation](https://github.com/ossf/scorecard/blob/2aa077c4fc2728eb9d70fa4c44ad55be99d73b16/docs/checks.md#token-permissions) for more details).

There are also other low-hanging-fruit improvements like adding a `SECURITY.md` to our project with information on how to report security vulnerabilities (and also define what a vulnerability is from a Ganeti point of view). If anyone wants to take on that job... :-) 