### PR TITLE
allow three alternative RegEx implementations: regex-pcre, regex-pcre-builtin, regex-tdfa

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -167,6 +167,13 @@ HS_DIRS = \
 	src/Ganeti/THH \
 	src/Ganeti/Utils \
 	src/Ganeti/WConfd \
+	regex \
+	regex/tdfa \
+	regex/tdfa/Ganeti \
+	regex/tdfa/Ganeti/Query \
+	regex/pcre \
+	regex/pcre/Ganeti \
+	regex/pcre/Ganeti/Query \
 	test/hs \
 	test/hs/Test \
 	test/hs/Test/Ganeti \
@@ -1191,6 +1198,10 @@ EXTRA_DIST += \
 	src/Ganeti/Metad/WebServer.hs
 endif
 
+HS_REGEX_SRCS = \
+	regex/tdfa/Ganeti/Query/RegEx.hs \
+	regex/pcre/Ganeti/Query/RegEx.hs
+
 HS_TEST_SRCS = \
 	test/hs/Test/AutoConf.hs \
 	test/hs/Test/Ganeti/Attoparsec.hs \
@@ -1260,7 +1271,7 @@ HS_TEST_SRCS = \
 
 HS_LIB_STEMS = $(patsubst %.hsc,%, $(patsubst %.hs,%, $(HS_LIB_SRCS)))
 
-HS_LIBTEST_SRCS = $(HS_LIB_SRCS) $(HS_TEST_SRCS)
+HS_LIBTEST_SRCS = $(HS_LIB_SRCS) $(HS_REGEX_SRCS) $(HS_TEST_SRCS)
 
 HS_BUILT_SRCS = \
 	test/hs/Test/Ganeti/TestImports.hs \
@@ -2314,6 +2325,7 @@ test/hs/Test/Ganeti/TestImports.hs: test/hs/Test/Ganeti/TestImports.hs.in \
 	  for name in $(filter-out Ganeti.THH,$(subst /,.,$(patsubst src/%,%,$(HS_LIB_STEMS)))) ; do \
 	    echo "import $$name ()" ; \
 	  done ; \
+	  echo "import Ganeti.Query.RegEx ()" ; \
 	} > $@
 
 lib/_constants.py: Makefile $(HS2PY_PROG) lib/_constants.py.in | stamp-directories
@@ -2993,7 +3005,9 @@ dist/setup-config: ganeti.cabal $(HS_BUILT_SRCS)
 	  -f`test $(HTEST) == yes && echo "htest" || echo "-htest"` \
 	  -f`test $(ENABLE_MOND) == True && echo "mond" || echo "-mond"` \
 	  -f`test $(ENABLE_METADATA) == True && echo "metad" || echo "-metad"` \
-	  -f`test $(ENABLE_NETWORK_BSD) == True && echo "network_bsd" || echo "-network_bsd"`
+	  -f`test $(ENABLE_NETWORK_BSD) == True && echo "network_bsd" || echo "-network_bsd"` \
+	  -f`test $(ENABLE_REGEX_PCRE_BUILTIN) == True && echo "regex-pcre-builtin" || echo "-regex-pcre-builtin"` \
+	  -f`test $(ENABLE_REGEX_TDFA) == True && echo "regex-tdfa" || echo "-regex-tdfa"`
 
 
 # Target that builds all binaries (including those that are not

--- a/configure.ac
+++ b/configure.ac
@@ -637,6 +637,34 @@ AC_ARG_ENABLE([metadata],
   [],
   [enable_metadata=check])
 
+# --enable-regex-pcre-builtin
+ENABLE_REGEX_PCRE_BUILTIN=
+AC_ARG_ENABLE([regex-pcre-builtin],
+  [AS_HELP_STRING([--enable-regex-pcre-builtin],
+  [use regex-pcre-builtin library for regex parsing (default: check)])],
+  [enable_regex_pcre_builtin=$enableval],
+  [enable_regex_pcre_builtin=check])
+if test "$enable_regex_pcre_builtin" != no; then
+  AC_GHC_PKG_REQUIRE(regex-pcre-builtin)
+fi
+
+# --enable-regex-tdfa
+ENABLE_REGEX_TDFA=
+AC_ARG_ENABLE([regex-tdfa],
+  [AS_HELP_STRING([--enable-regex-tdfa],
+  [use regex-tdfa library, that is,
+   POSIX instead of Perl regexes (default: regex-pcre)])],
+  [enable_regex_tdfa=$enableval],
+  [enable_regex_tdfa=no])
+if test "$enable_regex_tdfa" != no; then
+  AC_GHC_PKG_REQUIRE(regex-tdfa)
+fi
+
+if test "$enable_regex_pcre_builtin" == no &&
+   test "$enable_regex_tdfa" == no; then
+  AC_GHC_PKG_REQUIRE(regex-pcre)
+fi
+
 # Check for ghc
 AC_ARG_VAR(GHC, [ghc path])
 AC_PATH_PROG(GHC, [ghc], [])
@@ -697,7 +725,6 @@ AC_GHC_PKG_REQUIRE(hinotify)
 AC_GHC_PKG_REQUIRE(cryptonite)
 AC_GHC_PKG_REQUIRE(lifted-base)
 AC_GHC_PKG_REQUIRE(lens)
-AC_GHC_PKG_REQUIRE(regex-pcre)
 AC_GHC_PKG_REQUIRE(old-time)
 AC_GHC_PKG_REQUIRE(temporary)
 

--- a/ganeti.cabal
+++ b/ganeti.cabal
@@ -358,6 +358,7 @@ Executable htest
     test-framework-quickcheck2    >= 0.2.12.1   && < 0.4,
     temporary                     >= 1.1.2.3    && < 1.4,
     attoparsec,
+    regex-pcre,
     containers,
     text,
     bytestring,

--- a/ganeti.cabal
+++ b/ganeti.cabal
@@ -37,6 +37,14 @@ Flag network_bsd
   Description: use the split network-bsd package
   Default:     False
 
+Flag regex-tdfa
+  Description: use regex-tdfa instead of regex-pcre
+  Default:     False
+
+Flag regex-pcre-builtin
+  Description: use regex-pcre-builtin instead of regex-pcre
+  Default:     False
+
 Library
   Exposed-Modules:
     AutoConf
@@ -253,7 +261,6 @@ Library
     , lifted-base                   >= 0.2.0.3    && < 0.3
     , monad-control                 >= 0.3.1.3    && < 1.1
     , parallel                      >= 3.2.0.2    && < 3.3
-    , regex-pcre                    >= 0.94.2     && < 0.96
     , transformers-base             >= 0.4.1      && < 0.5
     , unix                          >= 2.5.1.0    && < 2.9
     , zlib                          >= 0.5.3.3    && < 0.8
@@ -287,6 +294,20 @@ Library
   If flag(mcio_xformers)
     Build-Depends:
         MonadCatchIO-transformers
+
+  Exposed-Modules: Ganeti.Query.RegEx
+  If flag(regex-tdfa)
+    Hs-Source-Dirs: regex/tdfa
+    Build-Depends:
+      regex-tdfa                      >= 1.2        && < 1.4
+  Else
+    Hs-Source-Dirs: regex/pcre
+    If flag(regex-pcre-builtin)
+      Build-Depends:
+        regex-pcre-builtin            >= 0.94.2     && < 0.96
+    Else
+      Build-Depends:
+        regex-pcre                    >= 0.94.2     && < 0.96
 
   Hs-Source-Dirs:     src
   Build-Tool-Depends: hsc2hs:hsc2hs
@@ -358,7 +379,6 @@ Executable htest
     test-framework-quickcheck2    >= 0.2.12.1   && < 0.4,
     temporary                     >= 1.1.2.3    && < 1.4,
     attoparsec,
-    regex-pcre,
     containers,
     text,
     bytestring,

--- a/regex/pcre/Ganeti/Query/RegEx.hs
+++ b/regex/pcre/Ganeti/Query/RegEx.hs
@@ -1,0 +1,8 @@
+module Ganeti.Query.RegEx (
+    RegEx.Regex,
+    RegEx.match,
+    RegEx.makeRegexM,
+    (RegEx.=~),
+    ) where
+
+import qualified Text.Regex.PCRE as RegEx

--- a/regex/tdfa/Ganeti/Query/RegEx.hs
+++ b/regex/tdfa/Ganeti/Query/RegEx.hs
@@ -1,0 +1,8 @@
+module Ganeti.Query.RegEx (
+    RegEx.Regex,
+    RegEx.match,
+    RegEx.makeRegexM,
+    (RegEx.=~),
+    ) where
+
+import qualified Text.Regex.TDFA as RegEx

--- a/src/Ganeti/Query/Filter.hs
+++ b/src/Ganeti/Query/Filter.hs
@@ -73,8 +73,8 @@ import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
 import Text.JSON (JSValue(..), fromJSString)
 import Text.JSON.Pretty (pp_value)
-import qualified Text.Regex.PCRE as PCRE
 
+import qualified Ganeti.Query.RegEx as RegEx
 import Ganeti.BasicTypes
             (GenericResult (Ok, Bad), goodLookupResult, compareNameComponent)
 import Ganeti.Errors
@@ -173,7 +173,7 @@ binOpFilter _ expr actual =
 -- | Implements the 'RegexpFilter' matching.
 regexpFilter :: FilterRegex -> JSValue -> ErrorResult Bool
 regexpFilter re (JSString val) =
-  Ok $! PCRE.match (compiledRegex re) (fromJSString val)
+  Ok $! RegEx.match (compiledRegex re) (fromJSString val)
 regexpFilter _ x =
   Bad . ParameterError $ "Invalid field value used in regexp matching,\
         \ expecting string but got '" ++ show (pp_value x) ++ "'"

--- a/src/Ganeti/Query/Language.hs
+++ b/src/Ganeti/Query/Language.hs
@@ -72,8 +72,8 @@ import Data.Ratio (numerator, denominator)
 import Text.JSON.Pretty (pp_value)
 import Text.JSON.Types
 import Text.JSON
-import qualified Text.Regex.PCRE as PCRE
 
+import qualified Ganeti.Query.RegEx as RegEx
 import qualified Ganeti.Constants as C
 import Ganeti.THH
 
@@ -323,14 +323,14 @@ instance JSON FilterValue where
 -- we don't re-compile the regex at each match attempt.
 data FilterRegex = FilterRegex
   { stringRegex   :: String      -- ^ The string version of the regex
-  , compiledRegex :: PCRE.Regex  -- ^ The compiled regex
+  , compiledRegex :: RegEx.Regex  -- ^ The compiled regex
   }
 
 -- | Builder for 'FilterRegex'. We always attempt to compile the
 -- regular expression on the initialisation of the data structure;
 -- this might fail, if the RE is not well-formed.
 mkRegex :: (MonadFail m) => String -> m FilterRegex
-mkRegex str = FilterRegex str <$> PCRE.makeRegexM str
+mkRegex str = FilterRegex str <$> RegEx.makeRegexM str
 
 -- | 'Show' instance: we show the constructor plus the string version
 -- of the regex.

--- a/test/hs/Test/Ganeti/Utils.hs
+++ b/test/hs/Test/Ganeti/Utils.hs
@@ -47,7 +47,7 @@ import Data.List
 import Data.Maybe (listToMaybe)
 import qualified Data.Set as S
 import qualified Text.JSON as J
-import Text.Regex.PCRE
+import Ganeti.Query.RegEx ((=~))
 
 import Test.Ganeti.TestHelper
 import Test.Ganeti.TestCommon

--- a/test/hs/Test/Ganeti/Utils.hs
+++ b/test/hs/Test/Ganeti/Utils.hs
@@ -47,9 +47,7 @@ import Data.List
 import Data.Maybe (listToMaybe)
 import qualified Data.Set as S
 import qualified Text.JSON as J
-#ifdef VERSION_regex_pcre
 import Text.Regex.PCRE
-#endif
 
 import Test.Ganeti.TestHelper
 import Test.Ganeti.TestCommon
@@ -274,7 +272,6 @@ case_new_uuid = do
   uuid <- newUUID
   assertBool "newUUID" $ isUUID uuid
 
-#ifdef VERSION_regex_pcre
 {-# ANN case_new_uuid_regex "HLint: ignore Use camelCase" #-}
 
 -- | Tests that the newUUID function produces valid UUIDs.
@@ -282,7 +279,6 @@ case_new_uuid_regex :: Assertion
 case_new_uuid_regex = do
   uuid <- newUUID
   assertBool "newUUID" $ uuid =~ C.uuidRegex
-#endif
 
 
 -- | Test normal operation for 'chompPrefix'.
@@ -379,9 +375,7 @@ testSuite "Utils"
             , 'prop_rStripSpace
             , 'prop_trim
             , 'case_new_uuid
-#ifdef VERSION_regex_pcre
             , 'case_new_uuid_regex
-#endif
             , 'prop_chompPrefix_normal
             , 'prop_chompPrefix_last
             , 'prop_chompPrefix_empty_string


### PR DESCRIPTION
regex-pcre remains the default
Query.RegEx: module providing a uniform interface across RegEx implementations

I still have to find out, how to make a `configure` option for those alternatives.