### PR TITLE
Test.Ganeti.Utils: correct instance Arbitrary ClockTime

### DIFF
--- a/test/hs/Test/Ganeti/Utils.hs
+++ b/test/hs/Test/Ganeti/Utils.hs
@@ -291,7 +291,8 @@ prop_clockTimeToString ts pico =
   clockTimeToString (TOD ts pico) ==? show ts
 
 instance Arbitrary ClockTime where
-  arbitrary = TOD <$> choose (946681200, 2082754800) <*> choose (0, 999999999999)
+  arbitrary =
+    TOD <$> choose (946681200, 2082754800) <*> choose (0, 999999999999)
 
 -- | Verify our work-around for ghc bug #2519. Taking `diffClockTimes` form
 -- `System.Time`, this test fails with an exception.

--- a/test/hs/Test/Ganeti/Utils.hs
+++ b/test/hs/Test/Ganeti/Utils.hs
@@ -291,7 +291,7 @@ prop_clockTimeToString ts pico =
   clockTimeToString (TOD ts pico) ==? show ts
 
 instance Arbitrary ClockTime where
-  arbitrary = TOD <$> choose (946681200, 2082754800) <*> choose (0, 99999999999)
+  arbitrary = TOD <$> choose (946681200, 2082754800) <*> choose (0, 999999999999)
 
 -- | Verify our work-around for ghc bug #2519. Taking `diffClockTimes` form
 -- `System.Time`, this test fails with an exception.


### PR DESCRIPTION
There was one digit missing to 10^12-1.