### PR TITLE
fix token permissions for codeql

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,10 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
In commit 977e71715fc12ed6f6744c45832eda00e0410b44 token permissions are set to read. However codeql needs also write for uploading security-events:
```
    Uploading results
      Processing sarif files: ["/home/runner/work/ganeti/results/python.sarif"]
      Validating /home/runner/work/ganeti/results/python.sarif
      Combining SARIF files using the CodeQL CLI
      Adding fingerprints to SARIF file. See https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#providing-data-to-track-code-scanning-alerts-across-runs for more information.
      Uploading results
      Warning: Resource not accessible by integration
      Error: Resource not accessible by integration
```
See also https://github.com/github/codeql/issues/8843