### PR TITLE
Utils.TimeDiff: simplified custom definition

### DIFF
--- a/src/Ganeti/DataCollectors/XenCpuLoad.hs
+++ b/src/Ganeti/DataCollectors/XenCpuLoad.hs
@@ -51,12 +51,13 @@ import Data.Maybe (mapMaybe)
 import qualified Data.Sequence as Seq
 import System.Process (readProcess)
 import qualified Text.JSON as J
-import System.Time (ClockTime, getClockTime, addToClockTime)
+import System.Time (ClockTime, getClockTime)
+import Ganeti.Utils (addToClockTime, diffClockTimes, clockTimeToUSec)
 
 import Ganeti.BasicTypes (GenericResult(..), Result, genericResult, runResultT)
 import qualified Ganeti.Constants as C
 import Ganeti.DataCollectors.Types
-import Ganeti.Utils (readMaybe, clockTimeToUSec, diffClockTimes)
+import Ganeti.Utils (readMaybe)
 
 -- | The name of this data collector.
 dcName :: String


### PR DESCRIPTION
that avoids bug in old-time:System.Time.addToClockTime

solves https://github.com/ganeti/ganeti/issues/1778
