### PR TITLE
Utils.Time: extracted from Utils

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1149,6 +1149,7 @@ HS_LIB_SRCS = \
 	src/Ganeti/Utils/MVarLock.hs \
 	src/Ganeti/Utils/Random.hs \
 	src/Ganeti/Utils/Statistics.hs \
+	src/Ganeti/Utils/Time.hs \
 	src/Ganeti/Utils/UniStd.hs \
 	src/Ganeti/Utils/Validate.hs \
 	src/Ganeti/VCluster.hs \
@@ -1252,6 +1253,7 @@ HS_TEST_SRCS = \
 	test/hs/Test/Ganeti/Utils.hs \
 	test/hs/Test/Ganeti/Utils/MultiMap.hs \
 	test/hs/Test/Ganeti/Utils/Statistics.hs \
+	test/hs/Test/Ganeti/Utils/Time.hs \
 	test/hs/Test/Ganeti/WConfd/Ssconf.hs \
 	test/hs/Test/Ganeti/WConfd/TempRes.hs
 

--- a/app/rpc-test.hs
+++ b/app/rpc-test.hs
@@ -51,6 +51,7 @@ import Ganeti.Objects
 import qualified Ganeti.Path as P
 import Ganeti.Rpc
 import Ganeti.Utils
+import Ganeti.Utils.Time (getCurrentTimeUSec)
 
 
 -- | Command line options structure.

--- a/ganeti.cabal
+++ b/ganeti.cabal
@@ -203,6 +203,7 @@ Library
     Ganeti.Utils.MultiMap
     Ganeti.Utils.Random
     Ganeti.Utils.Statistics
+    Ganeti.Utils.Time
     Ganeti.Utils.UniStd
     Ganeti.Utils.Validate
     Ganeti.VCluster
@@ -435,5 +436,6 @@ Executable htest
     Test.Ganeti.Utils
     Test.Ganeti.Utils.MultiMap
     Test.Ganeti.Utils.Statistics
+    Test.Ganeti.Utils.Time
     Test.Ganeti.WConfd.Ssconf
     Test.Ganeti.WConfd.TempRes

--- a/src/Ganeti/Confd/Server.hs
+++ b/src/Ganeti/Confd/Server.hs
@@ -67,6 +67,7 @@ import Ganeti.Hash
 import Ganeti.Logging
 import qualified Ganeti.Constants as C
 import qualified Ganeti.Query.Cluster as QCluster
+import qualified Ganeti.Utils.Time as Time
 import Ganeti.Utils
 import Ganeti.DataCollectors.Types (DataCollector(..))
 import Ganeti.DataCollectors (collectors)
@@ -298,7 +299,7 @@ serializeResponse r =
 -- | Main loop for a given client.
 responder :: CRef -> S.Socket -> HashKey -> String -> S.SockAddr -> IO ()
 responder cfgref socket hmac msg peer = do
-  ctime <- getCurrentTime
+  ctime <- Time.getCurrentTime
   case parseRequest hmac msg ctime of
     Ok (origmsg, rq) -> do
               logDebug $ "Processing request: " ++ rStripSpace origmsg

--- a/src/Ganeti/Confd/Utils.hs
+++ b/src/Ganeti/Confd/Utils.hs
@@ -41,7 +41,7 @@ module Ganeti.Confd.Utils
   , parseRequest
   , parseReply
   , signMessage
-  , getCurrentTime
+  , Time.getCurrentTime
   , extractJSONPath
   ) where
 
@@ -56,6 +56,7 @@ import Ganeti.Confd.Types
 import Ganeti.Hash
 import qualified Ganeti.Constants as C
 import qualified Ganeti.Path as Path
+import qualified Ganeti.Utils.Time as Time
 import Ganeti.JSON (fromJResult)
 import Ganeti.Utils
 

--- a/src/Ganeti/ConfigReader.hs
+++ b/src/Ganeti/ConfigReader.hs
@@ -48,11 +48,11 @@ import System.INotify
 import Ganeti.BasicTypes
 import Ganeti.Objects
 import Ganeti.Compat
-import Ganeti.Confd.Utils
 import Ganeti.Config
 import Ganeti.Logging
 import qualified Ganeti.Constants as C
 import qualified Ganeti.Path as Path
+import Ganeti.Utils.Time (getCurrentTime, getCurrentTimeUSec)
 import Ganeti.Utils
 
 -- | A type for functions that can return the configuration when

--- a/src/Ganeti/DataCollectors/CPUload.hs
+++ b/src/Ganeti/DataCollectors/CPUload.hs
@@ -58,6 +58,7 @@ import qualified Ganeti.Constants as C
 import Ganeti.Cpu.LoadParser(cpustatParser)
 import Ganeti.DataCollectors.Types
 import qualified Ganeti.JSON as GJ
+import Ganeti.Utils.Time (clockTimeToUSec)
 import Ganeti.Utils
 import Ganeti.Cpu.Types
 

--- a/src/Ganeti/DataCollectors/Types.hs
+++ b/src/Ganeti/DataCollectors/Types.hs
@@ -65,7 +65,7 @@ import Text.JSON
 import Ganeti.Constants as C
 import Ganeti.Objects (ConfigData)
 import Ganeti.THH
-import Ganeti.Utils (getCurrentTimeUSec)
+import Ganeti.Utils.Time (getCurrentTimeUSec)
 
 -- | The possible classes a data collector can belong to.
 data DCCategory = DCInstance | DCStorage | DCDaemon | DCHypervisor

--- a/src/Ganeti/DataCollectors/XenCpuLoad.hs
+++ b/src/Ganeti/DataCollectors/XenCpuLoad.hs
@@ -52,7 +52,7 @@ import qualified Data.Sequence as Seq
 import System.Process (readProcess)
 import qualified Text.JSON as J
 import System.Time (ClockTime, getClockTime)
-import Ganeti.Utils (addToClockTime, diffClockTimes, clockTimeToUSec)
+import Ganeti.Utils.Time (addToClockTime, diffClockTimes, clockTimeToUSec)
 
 import Ganeti.BasicTypes (GenericResult(..), Result, genericResult, runResultT)
 import qualified Ganeti.Constants as C

--- a/src/Ganeti/HTools/Program/Harep.hs
+++ b/src/Ganeti/HTools/Program/Harep.hs
@@ -64,6 +64,7 @@ import Ganeti.Utils
 import qualified Ganeti.Constants as C
 import qualified Ganeti.Luxi as L
 import qualified Ganeti.Path as Path
+import qualified Ganeti.Utils.Time as Time
 
 import Ganeti.HTools.CLI
 import Ganeti.HTools.Loader
@@ -269,7 +270,7 @@ updateTag :: AutoRepairData -> AutoRepairData
 updateTag arData =
   let ini = [autoRepairTypeToRaw $ arType arData,
              arUuid arData,
-             clockTimeToString $ arTime arData]
+             Time.clockTimeToString $ arTime arData]
       end = [intercalate "+" . map (show . fromJobId) $ arJobs arData]
       (pfx, middle) =
          case arResult arData of

--- a/src/Ganeti/JQueue.hs
+++ b/src/Ganeti/JQueue.hs
@@ -106,7 +106,7 @@ import System.Posix.Files
 import System.Posix.Signals (sigHUP, sigTERM, sigUSR1, sigKILL, signalProcess)
 import System.Posix.Types (ProcessID)
 import System.Time (ClockTime(TOD), getClockTime)
-import Ganeti.Utils (TimeDiff(..), addToClockTime, noTimeDiff)
+import Ganeti.Utils.Time (TimeDiff(..), addToClockTime, noTimeDiff)
 import qualified System.Time as Time
 import qualified Text.JSON
 import Text.JSON.Types

--- a/src/Ganeti/Monitoring/Server.hs
+++ b/src/Ganeti/Monitoring/Server.hs
@@ -70,7 +70,8 @@ import Ganeti.Objects (DataCollectorConfig(..))
 import qualified Ganeti.Constants as C
 import qualified Ganeti.ConstantUtils as CU
 import Ganeti.Runtime
-import Ganeti.Utils (getCurrentTimeUSec, withDefaultOnIOError)
+import Ganeti.Utils.Time (getCurrentTimeUSec)
+import Ganeti.Utils (withDefaultOnIOError)
 
 -- * Types and constants definitions
 

--- a/src/Ganeti/Query/Cluster.hs
+++ b/src/Ganeti/Query/Cluster.hs
@@ -47,7 +47,7 @@ import Ganeti.Errors
 import Ganeti.Logging
 import Ganeti.Objects
 import Ganeti.Path
-import Ganeti.Utils (getCurrentTime)
+import Ganeti.Utils.Time (getCurrentTime)
 
 -- | Get master node name.
 clusterMasterNodeName :: ConfigData -> ErrorResult String

--- a/src/Ganeti/Rpc.hs
+++ b/src/Ganeti/Rpc.hs
@@ -137,6 +137,7 @@ import Ganeti.Ssconf
 import Ganeti.THH
 import Ganeti.THH.Field
 import Ganeti.Types
+import Ganeti.Utils.Time (cTimeToClockTime)
 import Ganeti.Utils
 import Ganeti.VCluster
 

--- a/src/Ganeti/UDSServer.hs
+++ b/src/Ganeti/UDSServer.hs
@@ -99,6 +99,7 @@ import Ganeti.JSON (fromJResult, fromJVal, fromJResultE, fromObj)
 import Ganeti.Logging
 import Ganeti.THH
 import Ganeti.Utils
+import Ganeti.Utils.Time (getCurrentTimeUSec)
 import Ganeti.Constants (privateParametersBlacklist)
 
 -- * Utility functions

--- a/src/Ganeti/Utils/Time.hs
+++ b/src/Ganeti/Utils/Time.hs
@@ -1,0 +1,107 @@
+{-| Time utility functions. -}
+
+{-
+
+Copyright (C) 2009, 2010, 2011, 2012, 2013 Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-}
+
+module Ganeti.Utils.Time
+  ( getCurrentTime
+  , getCurrentTimeUSec
+  , clockTimeToString
+  , clockTimeToCTime
+  , clockTimeToUSec
+  , cTimeToClockTime
+  , diffClockTimes
+  , addToClockTime
+  , noTimeDiff
+  , TimeDiff(..)
+  ) where
+
+import qualified System.Time as STime
+import System.Time (ClockTime(..), getClockTime)
+
+import Foreign.C.Types (CTime(CTime))
+import System.Posix.Types (EpochTime)
+
+
+-- | Returns the current time as an 'Integer' representing the number
+-- of seconds from the Unix epoch.
+getCurrentTime :: IO Integer
+getCurrentTime = do
+  TOD ctime _ <- getClockTime
+  return ctime
+
+-- | Returns the current time as an 'Integer' representing the number
+-- of microseconds from the Unix epoch (hence the need for 'Integer').
+getCurrentTimeUSec :: IO Integer
+getCurrentTimeUSec = fmap clockTimeToUSec getClockTime
+
+-- | Convert a ClockTime into a (seconds-only) timestamp.
+clockTimeToString :: ClockTime -> String
+clockTimeToString (TOD t _) = show t
+
+-- | Convert a ClockTime into a (seconds-only) 'EpochTime' (AKA @time_t@).
+clockTimeToCTime :: ClockTime -> EpochTime
+clockTimeToCTime (TOD secs _) = fromInteger secs
+
+-- | Convert a ClockTime the number of microseconds since the epoch.
+clockTimeToUSec :: ClockTime -> Integer
+clockTimeToUSec (TOD ctime pico) =
+  -- pico: 10^-12, micro: 10^-6, so we have to shift seconds left and
+  -- picoseconds right
+  ctime * 1000000 + pico `div` 1000000
+
+-- | Convert a ClockTime into a (seconds-only) 'EpochTime' (AKA @time_t@).
+cTimeToClockTime :: EpochTime -> ClockTime
+cTimeToClockTime (CTime timet) = TOD (toInteger timet) 0
+
+
+{- |
+Like 'System.Time.TimeDiff' but misses 'tdYear', 'tdMonth'.
+Their meaning depends on the start date and causes bugs like this one:
+<https://github.com/haskell/old-time/issues/18>
+This type is much simpler and less error-prone.
+Also, our 'tdSec' has type 'Integer', which cannot overflow.
+Like in original 'System.Time.TimeDiff' picoseconds can be negative,
+that is, TimeDiff's are not normalized by default.
+-}
+data TimeDiff = TimeDiff {tdSec :: Integer, tdPicosec :: Integer}
+  deriving (Show)
+
+noTimeDiff :: TimeDiff
+noTimeDiff = TimeDiff 0 0
+
+diffClockTimes :: ClockTime -> ClockTime -> TimeDiff
+diffClockTimes (STime.TOD secA picoA) (STime.TOD secB picoB) =
+  TimeDiff (secA-secB) (picoA-picoB)
+
+addToClockTime :: TimeDiff -> ClockTime -> ClockTime
+addToClockTime (TimeDiff secDiff picoDiff) (TOD secA picoA) =
+  case divMod (picoA+picoDiff) (1000*1000*1000*1000) of
+    (secD, picoB) ->
+      TOD (secA+secDiff+secD) picoB

--- a/test/hs/Test/Ganeti/Utils/Time.hs
+++ b/test/hs/Test/Ganeti/Utils/Time.hs
@@ -1,0 +1,106 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+{-| Unittests for time utilities
+
+-}
+
+{-
+
+Copyright (C) 2014 Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-}
+
+module Test.Ganeti.Utils.Time
+  ( testUtils_Time
+  ) where
+
+import Ganeti.Utils.Time
+        (TimeDiff(TimeDiff), noTimeDiff,
+         addToClockTime, diffClockTimes, clockTimeToString)
+import System.Time (ClockTime(TOD))
+
+import Test.QuickCheck
+
+import Test.Ganeti.TestHelper
+import Test.Ganeti.TestCommon
+
+
+prop_clockTimeToString :: Integer -> Integer -> Property
+prop_clockTimeToString ts pico =
+  clockTimeToString (TOD ts pico) ==? show ts
+
+genPicoseconds :: Gen Integer
+genPicoseconds = choose (0, 999999999999)
+
+genTimeDiff :: Gen TimeDiff
+genTimeDiff = TimeDiff <$> arbitrary <*> genPicoseconds
+
+genClockTime :: Gen ClockTime
+genClockTime = TOD <$> choose (946681200, 2082754800) <*> genPicoseconds
+
+prop_addToClockTime_identity :: Property
+prop_addToClockTime_identity = forAll genClockTime addToClockTime_identity
+
+addToClockTime_identity :: ClockTime -> Property
+addToClockTime_identity a =
+  addToClockTime noTimeDiff a ==? a
+
+{- |
+Verify our work-around for ghc bug #2519.
+Taking `diffClockTimes` form `System.Time`, this test fails with an exception.
+-}
+prop_timediffAdd :: Property
+prop_timediffAdd =
+  forAll genClockTime $ \a ->
+  forAll genClockTime $ \b ->
+  forAll genClockTime $ \c -> timediffAdd a b c
+
+timediffAdd :: ClockTime -> ClockTime -> ClockTime -> Property
+timediffAdd a b c =
+  let fwd = diffClockTimes a b
+      back = diffClockTimes b a
+  in addToClockTime fwd (addToClockTime back c) ==? c
+
+prop_timediffAddCommutative :: Property
+prop_timediffAddCommutative =
+  forAll genTimeDiff $ \a ->
+  forAll genTimeDiff $ \b ->
+  forAll genClockTime $ \c -> timediffAddCommutative a b c
+
+timediffAddCommutative :: TimeDiff -> TimeDiff -> ClockTime -> Property
+timediffAddCommutative a b c =
+  addToClockTime a (addToClockTime b c)
+  ==?
+  addToClockTime b (addToClockTime a c)
+
+
+testSuite "Utils/Time"
+  [ 'prop_clockTimeToString
+  , 'prop_addToClockTime_identity
+  , 'prop_timediffAdd
+  , 'prop_timediffAddCommutative
+  ]

--- a/test/hs/htest.hs
+++ b/test/hs/htest.hs
@@ -94,6 +94,7 @@ import Test.Ganeti.THH
 import Test.Ganeti.THH.Types
 import Test.Ganeti.Types
 import Test.Ganeti.Utils
+import Test.Ganeti.Utils.Time
 import Test.Ganeti.Utils.MultiMap
 import Test.Ganeti.Utils.Statistics
 import Test.Ganeti.WConfd.Ssconf
@@ -168,6 +169,7 @@ allTests =
   , testTHH_Types
   , testTypes
   , testUtils
+  , testUtils_Time
   , testUtils_MultiMap
   , testUtils_Statistics
   , testWConfd_Ssconf


### PR DESCRIPTION
I think the number of time related functions in `Ganeti.Utils` justifies a dedicated module.