### PR TITLE
Test delay fixed precision

### DIFF
--- a/lib/opcodes.py.in_before
+++ b/lib/opcodes.py.in_before
@@ -52,6 +52,16 @@ from ganeti import ht
 from ganeti import opcodes_base
 
 
+def FormatDuration(value):
+  """Custom formatter for duration.
+
+  """
+  try:
+    return "%.9f" % value
+  except TypeError:
+    return str(value)
+
+
 class OpCode(opcodes_base.BaseOpCode):
   """Abstract OpCode.
 

--- a/src/Ganeti/Hs2Py/GenOpCodes.hs
+++ b/src/Ganeti/Hs2Py/GenOpCodes.hs
@@ -72,6 +72,11 @@ showPyClass (OpCodeDescriptor name typ doc fields dsc) =
     opDscField
       | null dsc = ""
       | otherwise = "  OP_DSC_FIELD = " ++ show dsc ++ "\n"
+    opDscFormatter
+      | name == "OpTestDelay" =
+          "  def OP_DSC_FORMATTER(self, value):\n" ++
+          "    return FormatDuration(value)\n"
+      | otherwise = ""
     withLU
       | name == "OpTestDummy" = "\n  WITH_LU = False"
       | otherwise = ""
@@ -82,6 +87,7 @@ showPyClass (OpCodeDescriptor name typ doc fields dsc) =
    "  OP_PARAMS = [" ++
    intercalateIndent (map pyClassField fields) ++
    "\n    ]" ++ "\n" ++
+   opDscFormatter ++
    "  OP_RESULT = " ++ showValue typ ++
    withLU ++ "\n\n"
 

--- a/src/Ganeti/OpCodes.hs
+++ b/src/Ganeti/OpCodes.hs
@@ -63,6 +63,7 @@ import Data.List (intercalate)
 import Data.Map (Map)
 import qualified Text.JSON
 import Text.JSON (readJSON, JSObject, JSON, JSValue(..), fromJSObject)
+import Text.Printf (printf)
 
 import qualified Ganeti.Constants as C
 import qualified Ganeti.Hs2Py.OpDoc as OpDoc
@@ -1046,7 +1047,7 @@ opSummaryVal OpBackupExport { opInstanceName = s } = Just s
 opSummaryVal OpBackupRemove { opInstanceName = s } = Just s
 opSummaryVal OpTagsGet { opKind = s } = Just (show s)
 opSummaryVal OpTagsSearch { opTagSearchPattern = s } = Just (fromNonEmpty s)
-opSummaryVal OpTestDelay { opDelayDuration = d } = Just (show d)
+opSummaryVal OpTestDelay { opDelayDuration = d } = Just (printf "%.9f" d)
 opSummaryVal OpTestAllocator { opIallocator = s } =
   -- FIXME: Python doesn't handle None fields well, so we have behave the same
   Just $ maybe "None" fromNonEmpty s


### PR DESCRIPTION
I am now using formatted printing with format "%.9f" (nanoseconds) both in Haskell and Python.