### PR TITLE
Metad.WebServer: rqRemoteAddr -> rqClientAddr

### DIFF
--- a/ganeti.cabal
+++ b/ganeti.cabal
@@ -276,8 +276,8 @@ Library
 
   If flag(metad)
     Build-Depends:
-        snap-core                     >= 0.8.1
-      , snap-server                   >= 0.8.1
+        snap-core                     >= 1.0.0
+      , snap-server                   >= 1.0.0
     Exposed-Modules:
       Ganeti.Metad.ConfigServer
       Ganeti.Metad.Server

--- a/src/Ganeti/Metad/WebServer.hs
+++ b/src/Ganeti/Metad/WebServer.hs
@@ -147,7 +147,7 @@ handleMetadata
 handleMetadata _ GET  "ganeti" "latest" "meta_data.json" =
   liftIO $ Logging.logInfo "ganeti metadata"
 handleMetadata params GET  "ganeti" "latest" "os/os-install-package" =
-  do remoteAddr <- ByteString.unpack . rqRemoteAddr <$> getRequest
+  do remoteAddr <- ByteString.unpack . rqClientAddr <$> getRequest
      instanceParams <- liftIO $ do
        Logging.logInfo $ "OS install package for " ++ show remoteAddr
        readMVar params
@@ -159,13 +159,13 @@ handleMetadata params GET  "ganeti" "latest" "os/os-install-package" =
            Logging.logWarning $ "Could not serve OS install package: " ++ e
          error404
 handleMetadata params GET  "ganeti" "latest" "os/package" =
-  do remoteAddr <- ByteString.unpack . rqRemoteAddr <$> getRequest
+  do remoteAddr <- ByteString.unpack . rqClientAddr <$> getRequest
      instanceParams <- liftIO $ do
        Logging.logInfo $ "OS package for " ++ show remoteAddr
        readMVar params
      serveOsPackage remoteAddr instanceParams "os-package"
 handleMetadata params GET  "ganeti" "latest" "os/parameters.json" =
-  do remoteAddr <- ByteString.unpack . rqRemoteAddr <$> getRequest
+  do remoteAddr <- ByteString.unpack . rqClientAddr <$> getRequest
      instanceParams <- liftIO $ do
        Logging.logInfo $ "OS parameters for " ++ show remoteAddr
        readMVar params
@@ -175,7 +175,7 @@ handleMetadata params GET  "ganeti" "latest" "os/parameters.json" =
          liftIO . Logging.logWarning $ "Could not serve OS parameters: " ++ e
          error404
 handleMetadata params GET  "ganeti" "latest" script | isScript script =
-  do remoteAddr <- ByteString.unpack . rqRemoteAddr <$> getRequest
+  do remoteAddr <- ByteString.unpack . rqClientAddr <$> getRequest
      instanceParams <- liftIO $ do
        Logging.logInfo $ "OS package for " ++ show remoteAddr
        readMVar params


### PR DESCRIPTION
replacement as suggested by snap's deprecation warnings