### PR TITLE
add .github/workflows to makelfile exclude

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,7 @@ jobs:
         run: make -j 2
 
       - name: Check Local
-        run: mv .github/ /tmp/
-             && LC_ALL=C make check-local
-             && mv /tmp/.github/ .
+        run: LC_ALL=C make check-local
 
       - name: Python tests
         run: make py-tests

--- a/Makefile.am
+++ b/Makefile.am
@@ -284,7 +284,9 @@ DIRCHECK_EXCLUDE = \
 	doc/man-html/_* \
 	tools/shebang \
 	autom4te.cache \
-	.devcontainer
+	.devcontainer \
+	.github \
+	.github/workflows
 
 # some helper vars
 COVERAGE_DIR = doc/coverage


### PR DESCRIPTION
.github/workflows was added to DIRCHECK_EXCLUDE in the makefile.

Now the actions can be executed locally (e.g. with act[1]) without losing the .github directory in the container If the actions failed in check-local, the directory has been lost with act.

[1] https://github.com/nektos/act