### PR TITLE
add Haskel lib regex-tdfa to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,11 @@ jobs:
         run: ./autogen.sh
 
       - name: configure
-        if: ${{ matrix.regex = 'pcre' }}
+        if: ${{ matrix.regex == 'pcre' }}
         run: ./configure --enable-haskell-tests
 
       - name: configure
-        if: ${{ matrix.regex = 'tdfa' }}
+        if: ${{ matrix.regex == 'tdfa' }}
         run: ./configure --enable-haskell-tests --enable-regex-tdfa
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions: read-all
 
 jobs:
   build:
-    name: Build on ${{ matrix.os }}
+    name: Build on ${{ matrix.os }}-${{ matrix.regex }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [bookworm, focal, jammy, debian-testing]
+        regex: [pcre, tdfa]
+        exclude:
+          - os: debian-testing
+            regex: pcre
     container:
       image: ganeti/ci:${{ matrix.os }}-py3
       options: "--init"
@@ -30,7 +34,12 @@ jobs:
         run: ./autogen.sh
 
       - name: configure
+        if: ${{ matrix.regex = 'pcre' }}
         run: ./configure --enable-haskell-tests
+
+      - name: configure
+        if: ${{ matrix.regex = 'tdfa' }}
+        run: ./configure --enable-haskell-tests --enable-regex-tdfa
 
       - name: Build
         run: make -j 2


### PR DESCRIPTION
Recently regex-pcre is no longer available in Debian testing (Trixi) and an alternative regex-tdfa has been implemented, but at the coast of losing PCRE regex in favor of POSIX. Adding regex-tdfa to the CI matrix. This means that pcre and tdfa are tested both (where possible) for a transitional period.