### PR TITLE
speedup CI cabal build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,11 @@ jobs:
         if: ${{ matrix.regex == 'tdfa' }}
         run: ./configure --enable-haskell-tests --enable-regex-tdfa
 
+      - name: pimp cabal parallelism
+        run: sed -e "s/\t\$(CABAL_SETUP) build/\t\$(CABAL_SETUP) build -j$(nproc)/" -i Makefile.am
+
       - name: Build
-        run: make -j 2
+        run: make -j $(nproc)
 
       - name: Check Local
         run: LC_ALL=C make check-local

--- a/Makefile.am
+++ b/Makefile.am
@@ -1485,7 +1485,7 @@ HS_SRCS = $(HS_LIBTESTBUILT_SRCS)
 $(HS_SRC_PROGS) exe/htest: dist/app.stamp
 
 dist/app.stamp: exe/ dist/setup-config
-	$(CABAL_SETUP) build -j
+	$(CABAL_SETUP) build
 	-(cd exe; \
 	 for name in ganeti-kvmd ganeti-wconfd ganeti-confd ganeti-luxid \
 		rpc-test ganeti-mond ganeti-metad \

--- a/Makefile.am
+++ b/Makefile.am
@@ -1485,7 +1485,7 @@ HS_SRCS = $(HS_LIBTESTBUILT_SRCS)
 $(HS_SRC_PROGS) exe/htest: dist/app.stamp
 
 dist/app.stamp: exe/ dist/setup-config
-	$(CABAL_SETUP) build
+	$(CABAL_SETUP) build -j
 	-(cd exe; \
 	 for name in ganeti-kvmd ganeti-wconfd ganeti-confd ganeti-luxid \
 		rpc-test ganeti-mond ganeti-metad \


### PR DESCRIPTION
... by utilizing all available CPUs. Unlike `make -j`, which runs many things in parallel, this still results in only one invocation of GHC compiler. Parallelism seems internal. Increase in memory usage on 8 vCPU VM stays within acceptable limit of less than 2 GiB:

without `-j`:
```
    297.38user 15.19system 5:11.03elapsed 100%CPU (0avgtext+0avgdata 1082668maxresident)k
    0inputs+2338560outputs (4367major+3696086minor)pagefaults 0swaps
```
with `-j`:
```
    530.65user 177.55system 3:19.71elapsed 354%CPU (0avgtext+0avgdata 1410948maxresident)k
    0inputs+2286024outputs (4453major+3776267minor)pagefaults 0swaps
```