### PR TITLE
Fix multiple incompabilities with Qemu 7 and 9

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -2192,7 +2192,7 @@ class KVMHypervisor(hv_base.BaseHypervisor):
       blockdevice = self._GenerateKVMBlockDevice(target, disk_info, up_hvp,
                                                  kvm_devid)
 
-      self.qmp.HotAddDisk(device, access_mode, writeback, blockdevice)
+      self.qmp.HotAddDisk(device, access_mode, writeback, direct, blockdevice)
     elif dev_type == constants.HOTPLUG_TARGET_NIC:
       kvmpath = instance.hvparams[constants.HV_KVM_PATH]
       is_chrooted = instance.hvparams[constants.HV_KVM_USE_CHROOT]

--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -48,6 +48,8 @@ from ganeti import utils
 from ganeti import constants
 from ganeti import serializer
 
+import ganeti.hypervisor.hv_kvm.kvm_utils as kvm_utils
+
 
 class QmpCommandNotSupported(errors.HypervisorError):
   """QMP command not supported by the monitor.
@@ -549,7 +551,7 @@ class QmpConnection(QemuMonitorSocket):
 
     dev_arguments = {
       "drive": blockdevice["node-name"],
-      "write-cache": cache_writeback
+      "write-cache": kvm_utils.TranslateBoolToOnOff(cache_writeback)
     }
     # Note that hvinfo that _GenerateDeviceHVInfo() creates
     # should include *only* the driver, id, bus, and

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -846,9 +846,9 @@ cpu\_sockets
 soundhw
     Valid for Xen PVM, Xen HVM and KVM hypervisors.
 
-    Comma separated list of emulated sounds cards, or "all" to enable
-    all the available ones. See the **qemu**\(1) manpage for valid options and
-    additional details.
+    The soundcard to emulate inside your instance. Please consult
+    Qemu (``-audio model=help``) for a list of valid soundcard
+    models. ``hda`` or ``ac97`` are probably the most useful ones.
 
 cpuid
     Valid for the XEN hypervisor.

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -700,9 +700,9 @@ security\_domain
 kvm\_flag
     Valid for the KVM hypervisor.
 
-    If *enabled* the -enable-kvm flag is passed to kvm. If *disabled*
-    -disable-kvm is passed. If unset no flag is passed, and the
-    default running mode for your kvm binary will be used.
+    If *enabled* accel=kvm is appended to the -machine parameter
+    *Disabling* (or not setting this flag at all) currently does
+    nothing.
 
 mem\_path
     Valid for the KVM hypervisor.

--- a/qa/qa_cluster.py
+++ b/qa/qa_cluster.py
@@ -161,6 +161,7 @@ def PrepareHvParameterSets():
       "disk_cache": constants.HT_VALID_CACHE_TYPES,
       "usb_mouse": constants.HT_KVM_VALID_MOUSE_TYPES,
       "disk_type": ["ide", "paravirtual"],
+      "soundhw": ["ac97", "hda"],
     }
 
   assembled_tests = {}


### PR DESCRIPTION
This PR addresses multiple issues which have been uncovered by running the QA suite against Qemu 9.2 from Debian Testing:

- Qemu >= 9.0 requires O_DIRECT set on storage backends/fd's
- typing in QMP messages has become more strict ("on/off" settings need to be a literal string, previously a boolean was also accepted)
- Qemu >= 9.0 has removed `-no-acpi` and replaced it with a `-machine` parameter (that also uncovered some other, older bugs)
- Qemu >= 7.1 has removed `-soundhw` and is now replaced by `-audiodev`

I'll keep this as draft for now, as the QA suite might uncover more problems. The `soundhw` fix is also still WIP.