### PR TITLE
Classify DRBD devices in StandAlone mode as faulty

### DIFF
--- a/lib/storage/drbd.py
+++ b/lib/storage/drbd.py
@@ -674,10 +674,10 @@ class DRBD8Dev(base.BlockDev):
     stats = self.GetProcStatus()
     is_degraded = not stats.is_connected or not stats.is_disk_uptodate
 
-    if stats.is_disk_uptodate:
-      ldisk_status = constants.LDS_OKAY
-    elif stats.is_diskless:
+    if stats.is_diskless or stats.is_standalone:
       ldisk_status = constants.LDS_FAULTY
+    elif stats.is_disk_uptodate:
+      ldisk_status = constants.LDS_OKAY
     elif stats.is_in_resync:
       ldisk_status = constants.LDS_SYNC
     else:


### PR DESCRIPTION
DRBD devices should be reported faulty not only when in diskless mode, but also in StandAlone mode (as local data will most likely be outdated). This fixes the issue that degraded connections will be re-classified from ERROR to WARNING as long as they are not diskless on any of the nodes.

Broken/disconnected DRBD devices will now generate a proper ERROR and corresponding return code from `gnt-cluster verify`.

Fixes #1218

This is currently running through QA:
- [Bookworm](https://stargazer.ganeti.org/c0bd4ec49ed7c91aad1e05ec2682ff4fad2ae3e0/)
- [Trixie](https://stargazer.ganeti.org/2c99e54004702beccfde84e675decfb585b6a46b/)

*Update*: both finished successfully 