### PR TITLE
merge pending patches from Debian into stable-3.0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,7 @@ EXTRA_DIST=
 SHELLTESTARGS = "-c"
 
 # Use C.UTF-8 for tests/checks when available, fall back to en_US.UTF-8 else
-UTF8_LOCALE := $(shell locale -a | grep -m 1 -xF "C.UTF-8" || echo "en_US.UTF-8")
+UTF8_LOCALE := $(shell locale -a | grep -m 1 -xF -e C.UTF-8 -e C.utf8 || echo en_US.UTF-8)
 
 ACLOCAL_AMFLAGS = -I autotools
 BUILD_BASH_COMPLETION = $(top_srcdir)/autotools/build-bash-completion

--- a/autotools/check-man-warnings
+++ b/autotools/check-man-warnings
@@ -29,11 +29,7 @@
 
 set -e
 
-if locale -a | grep -qF 'C.UTF-8'; then
-	loc="C.UTF-8"
-else
-	loc="en_US.UTF-8"
-fi
+loc="$(locale -a | grep -m 1 -xF -e C.UTF-8 -e C.utf8 || echo en_US.UTF-8)"
 
 ! LANG="$loc" LC_ALL="$loc" MANWIDTH=80 \
   man --warnings --encoding=utf8 --local-file "$1" 2>&1 >/dev/null | \

--- a/cabal/ganeti.template.cabal
+++ b/cabal/ganeti.template.cabal
@@ -63,14 +63,14 @@ library
     , unix                          >= 2.5.1.0
     , utf8-string                   >= 0.3.7
 
-    , attoparsec                    >= 0.10.1.1   && < 0.14
-    , base64-bytestring             >= 1.0.0.1    && < 1.2
+    , attoparsec                    >= 0.10.1.1   && < 0.15
+    , base64-bytestring             >= 1.0.0.1    && < 1.3
     , case-insensitive              >= 0.4.0.1    && < 1.3
     , curl                          >= 1.3.7      && < 1.4
     , hinotify                      >= 0.3.2      && < 0.5
     , hslogger                      >= 1.1.4      && < 1.4
     , json                          >= 0.5        && < 1.0
-    , lens                          >= 3.10       && < 5.0
+    , lens                          >= 3.10       && < 6.0
     , lifted-base                   >= 0.2.0.3    && < 0.3
     , monad-control                 >= 0.3.1.3    && < 1.1
     , parallel                      >= 3.2.0.2    && < 3.3

--- a/qa/qa_utils.py
+++ b/qa/qa_utils.py
@@ -450,7 +450,7 @@ def GetObjectInfo(infocmd):
   master = qa_config.GetMasterNode()
   cmdline = utils.ShellQuoteArgs(infocmd)
   info_out = GetCommandOutput(master.primary, cmdline)
-  return yaml.load(info_out)
+  return yaml.load(info_out, Loader=yaml.FullLoader)
 
 
 def UploadFile(node, src):

--- a/qa/qa_utils.py
+++ b/qa/qa_utils.py
@@ -450,7 +450,7 @@ def GetObjectInfo(infocmd):
   master = qa_config.GetMasterNode()
   cmdline = utils.ShellQuoteArgs(infocmd)
   info_out = GetCommandOutput(master.primary, cmdline)
-  return yaml.load(info_out, Loader=yaml.FullLoader)
+  return yaml.load(info_out, Loader=yaml.SafeLoader)
 
 
 def UploadFile(node, src):

--- a/src/Ganeti/Network.hs
+++ b/src/Ganeti/Network.hs
@@ -87,11 +87,11 @@ data PoolPart = PoolInstances | PoolExt
 addressPoolIso :: Iso' AddressPool BA.BitArray
 addressPoolIso = iso apReservations AddressPool
 
---poolLens :: PoolPart -> Lens' Network (Maybe AddressPool)
+poolLens :: PoolPart -> Lens' Network (Maybe AddressPool)
 poolLens PoolInstances = networkReservationsL
 poolLens PoolExt = networkExtReservationsL
 
---poolArrayLens :: PoolPart -> Lens' Network (Maybe BA.BitArray)
+poolArrayLens :: PoolPart -> Lens' Network (Maybe BA.BitArray)
 poolArrayLens part = poolLens part . mapping addressPoolIso
 
 netIpv4NumHosts :: Network -> Integer
@@ -135,12 +135,12 @@ withPool_ :: (MonadError e m, Error e)
 withPool_ part f = execStateT $ withPool part ((liftM ((,) ()) .) . f)
 
 readPool :: PoolPart -> Network -> Maybe BA.BitArray
-readPool = view . poolArrayLens
+readPool part = view (poolArrayLens part)
 
 readPoolE :: (MonadError e m, Error e)
           => PoolPart -> Network -> m BA.BitArray
 readPoolE part net =
-  liftM apReservations $ orNewPool net ((view . poolLens) part net)
+  liftM apReservations $ orNewPool net (view (poolLens part) net)
 
 readAllE :: (MonadError e m, Error e)
          => Network -> m BA.BitArray

--- a/src/Ganeti/Network.hs
+++ b/src/Ganeti/Network.hs
@@ -87,11 +87,11 @@ data PoolPart = PoolInstances | PoolExt
 addressPoolIso :: Iso' AddressPool BA.BitArray
 addressPoolIso = iso apReservations AddressPool
 
-poolLens :: PoolPart -> Lens' Network (Maybe AddressPool)
+--poolLens :: PoolPart -> Lens' Network (Maybe AddressPool)
 poolLens PoolInstances = networkReservationsL
 poolLens PoolExt = networkExtReservationsL
 
-poolArrayLens :: PoolPart -> Lens' Network (Maybe BA.BitArray)
+--poolArrayLens :: PoolPart -> Lens' Network (Maybe BA.BitArray)
 poolArrayLens part = poolLens part . mapping addressPoolIso
 
 netIpv4NumHosts :: Network -> Integer

--- a/src/Ganeti/THH.hs
+++ b/src/Ganeti/THH.hs
@@ -884,7 +884,7 @@ genLoadOpCode opdefs fn = do
                   ) $ zip mexps opdefs
       defmatch = Match WildP (NormalB fails) []
       cst = NoBindS $ CaseE (VarE opid) $ mpats++[defmatch]
-      body = DoE [st, cst]
+      body = mkDoE [st, cst]
   -- include "OP_ID" to the list of used keys
   bodyAndOpId <- [| $(return body)
                     <* tell (mkUsedKeys . S.singleton . T.pack $ opidKey) |]
@@ -1541,7 +1541,7 @@ loadExcConstructor inname sname fields = do
                 [x] -> BindS (ListP [VarP x])
                 _   -> BindS (TupP (map VarP f_names))
       cval = appCons name $ map VarE f_names
-  return $ DoE [binds read_args, NoBindS (AppE (VarE 'return) cval)]
+  return $ mkDoE [binds read_args, NoBindS (AppE (VarE 'return) cval)]
 
 {-| Generates the loadException function.
 

--- a/src/Ganeti/THH/Compat.hs
+++ b/src/Ganeti/THH/Compat.hs
@@ -40,9 +40,11 @@ module Ganeti.THH.Compat
   , extractDataDConstructors
   , myNotStrict
   , nonUnaryTupE
+  , mkDoE
   ) where
 
 import Language.Haskell.TH
+import Language.Haskell.TH.Syntax
 
 -- | Convert Names to DerivClauses
 --
@@ -61,7 +63,11 @@ derivesFromNames names = map ConT names
 --
 -- Handle TH 2.11 and 2.12 changes in a transparent manner using the pre-2.11
 -- API.
+#if MIN_VERSION_template_haskell(2,17,0)
+gntDataD :: Cxt -> Name -> [TyVarBndr ()] -> [Con] -> [Name] -> Dec
+#else
 gntDataD :: Cxt -> Name -> [TyVarBndr] -> [Con] -> [Name] -> Dec
+#endif
 gntDataD x y z a b =
 #if MIN_VERSION_template_haskell(2,12,0)
     DataD x y z Nothing a $ derivesFromNames b
@@ -113,4 +119,13 @@ nonUnaryTupE :: [Exp] -> Exp
 nonUnaryTupE es = TupE $ map Just es
 #else
 nonUnaryTupE es = TupE $ es
+#endif
+
+-- | DoE is now qualified with an optional ModName
+mkDoE :: [Stmt] -> Exp
+mkDoE s =
+#if MIN_VERSION_template_haskell(2,17,0)
+    DoE Nothing s
+#else
+    DoE s
 #endif

--- a/src/Ganeti/Utils/MultiMap.hs
+++ b/src/Ganeti/Utils/MultiMap.hs
@@ -91,7 +91,7 @@ multiMap :: (Ord k, Ord v) => M.Map k (S.Set v) -> MultiMap k v
 multiMap = MultiMap . M.filter (not . S.null)
 
 -- | A 'Lens' that allows to access a set under a given key in a multi-map.
-multiMapL :: (Ord k, Ord v) => k -> Lens' (MultiMap k v) (S.Set v)
+--multiMapL :: (Ord k, Ord v) => k -> Lens' (MultiMap k v) (S.Set v)
 multiMapL k f = fmap MultiMap
                  . at k (fmap (mfilter (not . S.null) . Just)
                          . f . fromMaybe S.empty)

--- a/src/Ganeti/Utils/MultiMap.hs
+++ b/src/Ganeti/Utils/MultiMap.hs
@@ -91,7 +91,7 @@ multiMap :: (Ord k, Ord v) => M.Map k (S.Set v) -> MultiMap k v
 multiMap = MultiMap . M.filter (not . S.null)
 
 -- | A 'Lens' that allows to access a set under a given key in a multi-map.
---multiMapL :: (Ord k, Ord v) => k -> Lens' (MultiMap k v) (S.Set v)
+multiMapL :: (Ord k, Ord v) => k -> Lens' (MultiMap k v) (S.Set v)
 multiMapL k f = fmap MultiMap
                  . at k (fmap (mfilter (not . S.null) . Just)
                          . f . fromMaybe S.empty)
@@ -100,7 +100,7 @@ multiMapL k f = fmap MultiMap
 
 -- | Return the set corresponding to a given key.
 lookup :: (Ord k, Ord v) => k -> MultiMap k v -> S.Set v
-lookup = view . multiMapL
+lookup k = view (multiMapL k)
 
 -- | Tests if the given key has a non-empty set of values.
 member :: (Ord k, Ord v) => k -> MultiMap k v -> Bool

--- a/test/py/ganeti.cli_unittest.py
+++ b/test/py/ganeti.cli_unittest.py
@@ -1142,14 +1142,14 @@ class TestFormatPolicyInfo(unittest.TestCase):
     self.assertTrue(constants.IPOLICY_DTS in parsed)
     parsed[constants.IPOLICY_DTS] = yaml.load("[%s]" %
                                               parsed[constants.IPOLICY_DTS],
-                                              Loader=yaml.FullLoader)
+                                              Loader=yaml.SafeLoader)
 
   @staticmethod
   def _PrintAndParsePolicy(custom, effective, iscluster):
     formatted = cli.FormatPolicyInfo(custom, effective, iscluster)
     buf = StringIO()
     cli._SerializeGenericInfo(buf, formatted, 0)
-    return yaml.load(buf.getvalue(), Loader=yaml.FullLoader)
+    return yaml.load(buf.getvalue(), Loader=yaml.SafeLoader)
 
   def _PrintAndCheckParsed(self, policy):
     parsed = self._PrintAndParsePolicy(policy, NotImplemented, True)

--- a/test/py/ganeti.cli_unittest.py
+++ b/test/py/ganeti.cli_unittest.py
@@ -1141,14 +1141,15 @@ class TestFormatPolicyInfo(unittest.TestCase):
           self._RenameDictItem(minmax, key, keyparts[0])
     self.assertTrue(constants.IPOLICY_DTS in parsed)
     parsed[constants.IPOLICY_DTS] = yaml.load("[%s]" %
-                                              parsed[constants.IPOLICY_DTS])
+                                              parsed[constants.IPOLICY_DTS],
+                                              Loader=yaml.FullLoader)
 
   @staticmethod
   def _PrintAndParsePolicy(custom, effective, iscluster):
     formatted = cli.FormatPolicyInfo(custom, effective, iscluster)
     buf = StringIO()
     cli._SerializeGenericInfo(buf, formatted, 0)
-    return yaml.load(buf.getvalue())
+    return yaml.load(buf.getvalue(), Loader=yaml.FullLoader)
 
   def _PrintAndCheckParsed(self, policy):
     parsed = self._PrintAndParsePolicy(policy, NotImplemented, True)

--- a/test/py/ganeti.uidpool_unittest.py
+++ b/test/py/ganeti.uidpool_unittest.py
@@ -106,23 +106,24 @@ class TestUidPool(testutils.GanetiTestCase):
 
     # Check with a single, known unused user-id
     #
-    # We use "-1" here, which is not a valid user-id, so it's
-    # guaranteed that it's unused.
-    uid = uidpool.RequestUnusedUid(set([-1]))
-    self.assertEqualValues(uid.GetUid(), -1)
+    # We use 2^30+42 here, which is a valid UID, but unlikely to be used on
+    # most systems (even as a subuid).
+    free_uid = 2**30 + 42
+    uid = uidpool.RequestUnusedUid(set([free_uid]))
+    self.assertEqualValues(uid.GetUid(), free_uid)
 
     # Check uid-pool exhaustion
     #
-    # uid "-1" is locked now, so RequestUnusedUid is expected to fail
+    # free_uid is locked now, so RequestUnusedUid is expected to fail
     self.assertRaises(errors.LockError,
                       uidpool.RequestUnusedUid,
-                      set([-1]))
+                      set([free_uid]))
 
     # Check unlocking
     uid.Unlock()
     # After unlocking, "-1" should be available again
-    uid = uidpool.RequestUnusedUid(set([-1]))
-    self.assertEqualValues(uid.GetUid(), -1)
+    uid = uidpool.RequestUnusedUid(set([free_uid]))
+    self.assertEqualValues(uid.GetUid(), free_uid)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In order to test upgrades from `stable-3.0` to upcoming `stable-3.1` we need `stable-3.0` to build from git in Debian Bookworm. As the Haskell world in Debian Bookworm seems not stable, the maintainer (@apoikos) has accumulate some patches in Debian[1].

This PR cherry-picks most of them from master, expect:
* `0007-Allow-building-with-GHC-9-Lens-5.patch` (not relevant for master)
* `0008-make-allow-C.utf8-alongside-C.UTF-8.patch` (should be also in master?)

Also patches `0001-verify-warn-about-weak-certs.patch` and `0002-remove-hardcoded-libc-linux-constants.patch`should be considered for master.
 
[1] https://udd.debian.org/patches.cgi?src=ganeti&version=3.0.2-3