### PR TITLE
Up-/Downgrade Code for 3.0 <-> 3.1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1839,6 +1839,7 @@ TEST_FILES = \
 	test/data/cluster_config_2.15.json \
 	test/data/cluster_config_2.16.json \
 	test/data/cluster_config_3.0.json \
+	test/data/cluster_config_3.1.json \
 	test/data/instance-minor-pairing.txt \
 	test/data/instance-disks.txt \
 	test/data/ip-addr-show-dummy0.txt \

--- a/lib/tools/cfgupgrade.py
+++ b/lib/tools/cfgupgrade.py
@@ -365,6 +365,15 @@ class CfgUpgrade(object):
         cluster["hvparams"][constants.HT_KVM][constants.HV_DISK_DISCARD] = \
           constants.HT_DISCARD_IGNORE
 
+      # if machine_version is unset, it will be set to 'pc' with 3.1.0
+      # this way we avoid the soon-to-be QEMU default of 'q35' which is
+      # currently broken in Ganeti
+      if cluster["hvparams"][constants.HT_KVM]\
+              [constants.HV_KVM_MACHINE_VERSION] == "":
+        cluster["hvparams"][constants.HT_KVM]\
+          [constants.HV_KVM_MACHINE_VERSION] = \
+          constants.HT_KVM_MACHINE_VERSION_PC
+
   @OrFail("Upgrading groups")
   def UpgradeGroups(self):
     cl_ipolicy = self.config_data["cluster"].get("ipolicy")

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -2974,6 +2974,11 @@ htMigrationModes :: FrozenSet String
 htMigrationModes =
   ConstantUtils.mkSet $ map Types.migrationModeToRaw [minBound..]
 
+-- * Default Machine Type
+
+htKvmMachineVersionPc :: String
+htKvmMachineVersionPc = "pc"
+
 -- * Cluster verify steps
 
 verifyNplusoneMem :: String
@@ -4144,7 +4149,7 @@ hvcDefaults =
           , (hvUsbDevices,                      PyValueEx "")
           , (hvVga,                             PyValueEx "")
           , (hvKvmExtra,                        PyValueEx "")
-          , (hvKvmMachineVersion,               PyValueEx "")
+          , (hvKvmMachineVersion,               PyValueEx htKvmMachineVersionPc)
           , (hvKvmMigrationCaps,                PyValueEx "")
           , (hvVnetHdr,                         PyValueEx True)])
   , (Fake, Map.fromList [(hvMigrationMode, PyValueEx htMigrationLive)])

--- a/test/data/cluster_config_3.1.json
+++ b/test/data/cluster_config_3.1.json
@@ -1,0 +1,660 @@
+{
+  "cluster": {
+    "beparams": {
+      "default": {
+        "always_failover": false,
+        "auto_balance": true,
+        "maxmem": 128,
+        "minmem": 128,
+        "spindle_use": 1,
+        "vcpus": 1
+      }
+    },
+    "blacklisted_os": [],
+    "candidate_certs": {},
+    "candidate_pool_size": 10,
+    "cluster_name": "cluster.name.example.com",
+    "compression_tools": [
+      "gzip",
+      "gzip-fast",
+      "gzip-slow"
+    ],
+    "ctime": 1343869045.6048839,
+    "data_collectors": {
+      "cpu-avg-load": {
+        "active": true,
+        "interval": 5000000.0
+      },
+      "diskstats": {
+        "active": true,
+        "interval": 5000000.0
+      },
+      "drbd": {
+        "active": true,
+        "interval": 5000000.0
+      },
+      "inst-status-xen": {
+        "active": true,
+        "interval": 5000000.0
+      },
+      "lv": {
+        "active": true,
+        "interval": 5000000.0
+      },
+      "xen-cpu-avg-load": {
+        "active": true,
+        "interval": 5000000.0
+      }
+    },
+    "default_iallocator": "hail",
+    "default_iallocator_params": {},
+    "disk_state_static": {},
+    "diskparams": {
+      "blockdev": {},
+      "diskless": {},
+      "drbd": {
+        "c-delay-target": 1,
+        "c-fill-target": 200,
+        "c-max-rate": 2048,
+        "c-min-rate": 1024,
+        "c-plan-ahead": 1,
+        "data-stripes": 2,
+        "disk-barriers": "bf",
+        "disk-custom": "",
+        "dynamic-resync": false,
+        "meta-barriers": true,
+        "meta-stripes": 2,
+        "metavg": "xenvg",
+        "net-custom": "",
+        "protocol": "C",
+        "resync-rate": 1024
+      },
+      "ext": {
+        "access": "kernelspace"
+      },
+      "file": {},
+      "gluster": {
+        "access": "kernelspace",
+        "host": "127.0.0.1",
+        "port": 24007,
+        "volume": "gv0"
+      },
+      "plain": {
+        "stripes": 2
+      },
+      "rbd": {
+        "access": "kernelspace",
+        "pool": "rbd"
+      },
+      "sharedfile": {}
+    },
+    "drbd_usermode_helper": "/bin/true",
+    "enabled_disk_templates": [
+      "drbd",
+      "plain",
+      "file",
+      "sharedfile"
+    ],
+    "enabled_hypervisors": [
+      "xen-pvm"
+    ],
+    "enabled_user_shutdown": false,
+    "file_storage_dir": "",
+    "gluster_storage_dir": "",
+    "hidden_os": [],
+    "highest_used_port": 32105,
+    "hv_state_static": {
+      "xen-pvm": {
+        "cpu_node": 1,
+        "cpu_total": 1,
+        "mem_hv": 0,
+        "mem_node": 0,
+        "mem_total": 0
+      }
+    },
+    "hvparams": {
+      "chroot": {
+        "init_script": "/ganeti-chroot"
+      },
+      "fake": {
+        "migration_mode": "live"
+      },
+      "kvm": {
+        "acpi": true,
+        "boot_order": "disk",
+        "cdrom2_image_path": "",
+        "cdrom_disk_type": "",
+        "cdrom_image_path": "",
+        "cpu_cores": 0,
+        "cpu_mask": "all",
+        "cpu_sockets": 0,
+        "cpu_threads": 0,
+        "cpu_type": "",
+        "debug_threads": false,
+        "disk_aio": "threads",
+        "disk_cache": "default",
+        "disk_discard": "ignore",
+        "disk_type": "paravirtual",
+        "floppy_image_path": "",
+        "initrd_path": "",
+        "kernel_args": "ro",
+        "kernel_path": "/boot/vmlinuz-kvmU",
+        "keymap": "",
+        "kvm_extra": "",
+        "kvm_flag": "",
+        "kvm_path": "/usr/bin/kvm",
+        "machine_version": "pc",
+        "mem_path": "",
+        "migration_bandwidth": 4,
+        "migration_caps": "",
+        "migration_downtime": 30,
+        "migration_mode": "live",
+        "migration_port": 4041,
+        "nic_type": "paravirtual",
+        "reboot_behavior": "reboot",
+        "root_path": "/dev/vda1",
+        "security_domain": "",
+        "security_model": "none",
+        "serial_console": true,
+        "serial_speed": 38400,
+        "soundhw": "",
+        "spice_bind": "",
+        "spice_image_compression": "",
+        "spice_ip_version": 0,
+        "spice_jpeg_wan_compression": "",
+        "spice_password_file": "",
+        "spice_playback_compression": true,
+        "spice_streaming_video": "",
+        "spice_tls_ciphers": "HIGH:-DES:-3DES:-EXPORT:-ADH",
+        "spice_use_tls": false,
+        "spice_use_vdagent": true,
+        "spice_zlib_glz_wan_compression": "",
+        "usb_devices": "",
+        "usb_mouse": "",
+        "use_chroot": false,
+        "use_localtime": false,
+        "user_shutdown": false,
+        "vga": "",
+        "vhost_net": false,
+        "virtio_net_queues": 1,
+        "vnc_bind_address": "",
+        "vnc_password_file": "",
+        "vnc_tls": false,
+        "vnc_x509_path": "",
+        "vnc_x509_verify": false,
+        "vnet_hdr": true
+      },
+      "lxc": {
+        "cpu_mask": "",
+        "devices": "c 1:3 rw,c 1:5 rw,c 1:7 rw,c 1:8 rw,c 1:9 rw,c 1:10 rw,c 5:0 rw,c 5:1 rw,c 5:2 rw,c 136:* rw",
+        "drop_capabilities": "mac_override,sys_boot,sys_module,sys_time,sys_admin",
+        "extra_cgroups": "",
+        "extra_config": "",
+        "lxc_cgroup_use": "",
+        "lxc_devices": "c 1:3 rw,c 1:5 rw,c 1:7 rw,c 1:8 rw,c 1:9 rw,c 1:10 rw,c 5:0 rw,c 5:1 rw,c 5:2 rw,c 136:* rw",
+        "lxc_drop_capabilities": "mac_override,sys_boot,sys_module,sys_time",
+        "lxc_extra_config": "",
+        "lxc_startup_wait": 30,
+        "lxc_tty": 6,
+        "num_ttys": 6,
+        "startup_timeout": 30
+      },
+      "xen-hvm": {
+        "acpi": true,
+        "blockdev_prefix": "hd",
+        "boot_order": "cd",
+        "cdrom_image_path": "",
+        "cpu_cap": 0,
+        "cpu_mask": "all",
+        "cpu_weight": 256,
+        "cpuid": "",
+        "device_model": "/usr/lib/xen/bin/qemu-dm",
+        "disk_type": "paravirtual",
+        "kernel_path": "/usr/lib/xen/boot/hvmloader",
+        "migration_mode": "non-live",
+        "migration_port": 8082,
+        "nic_type": "rtl8139",
+        "pae": true,
+        "pci_pass": "",
+        "reboot_behavior": "reboot",
+        "soundhw": "",
+        "use_localtime": false,
+        "vif_script": "",
+        "vif_type": "ioemu",
+        "viridian": false,
+        "vnc_bind_address": "0.0.0.0",
+        "vnc_password_file": "/your/vnc-cluster-password",
+        "xen_cmd": "xl"
+      },
+      "xen-pvm": {
+        "blockdev_prefix": "sd",
+        "bootloader_args": "",
+        "bootloader_path": "",
+        "cpu_cap": 0,
+        "cpu_mask": "all",
+        "cpu_weight": 256,
+        "cpuid": "",
+        "initrd_path": "",
+        "kernel_args": "ro",
+        "kernel_path": "/boot/vmlinuz-xenU",
+        "migration_mode": "live",
+        "migration_port": 8082,
+        "reboot_behavior": "reboot",
+        "root_path": "/dev/xvda1",
+        "soundhw": "",
+        "use_bootloader": false,
+        "vif_script": "",
+        "xen_cmd": "xl"
+      }
+    },
+    "install_image": "",
+    "instance_communication_network": "",
+    "ipolicy": {
+      "disk-templates": [
+        "drbd",
+        "plain",
+        "sharedfile",
+        "file"
+      ],
+      "minmax": [
+        {
+          "max": {
+            "cpu-count": 8,
+            "disk-count": 16,
+            "disk-size": 1048576,
+            "memory-size": 32768,
+            "nic-count": 8,
+            "spindle-use": 12
+          },
+          "min": {
+            "cpu-count": 1,
+            "disk-count": 1,
+            "disk-size": 1024,
+            "memory-size": 128,
+            "nic-count": 1,
+            "spindle-use": 1
+          }
+        }
+      ],
+      "spindle-ratio": 32.0,
+      "std": {
+        "cpu-count": 1,
+        "disk-count": 1,
+        "disk-size": 1024,
+        "memory-size": 128,
+        "nic-count": 1,
+        "spindle-use": 1
+      },
+      "vcpu-ratio": 1.0
+    },
+    "mac_prefix": "aa:bb:cc",
+    "maintain_node_health": false,
+    "master_ip": "192.0.2.87",
+    "master_netdev": "eth0",
+    "master_netmask": 32,
+    "master_node": "9a12d554-75c0-4cb1-8064-103365145db0",
+    "max_running_jobs": 20,
+    "max_tracked_jobs": 25,
+    "modify_etc_hosts": true,
+    "modify_ssh_setup": true,
+    "mtime": 1361964122.7947099,
+    "ndparams": {
+      "cpu_speed": 1.0,
+      "exclusive_storage": false,
+      "oob_program": "",
+      "ovs": false,
+      "ovs_link": "",
+      "ovs_name": "switch1",
+      "spindle_count": 1,
+      "ssh_port": 22
+    },
+    "nicparams": {
+      "default": {
+        "link": "br974",
+        "mode": "bridged",
+        "vlan": ""
+      }
+    },
+    "os_hvp": {
+      "TEMP-Ganeti-QA-OS": {
+        "xen-hvm": {
+          "acpi": false,
+          "pae": true
+        },
+        "xen-pvm": {
+          "root_path": "/dev/sda5"
+        }
+      }
+    },
+    "osparams": {},
+    "osparams_private_cluster": {},
+    "prealloc_wipe_disks": false,
+    "primary_ip_family": 2,
+    "reserved_lvs": [],
+    "rsahostkeypub": "YOURKEY",
+    "serial_no": 3189,
+    "shared_file_storage_dir": "/srv/ganeti/shared-file-storage",
+    "tags": [
+      "mytag"
+    ],
+    "tcpudp_port_pool": [
+      32104,
+      32105,
+      32101,
+      32102,
+      32103
+    ],
+    "uid_pool": [],
+    "use_external_mip_script": false,
+    "uuid": "dddf8c12-f2d8-4718-a35b-7804daf12a3f",
+    "volume_group_name": "xenvg",
+    "zeroing_image": "",
+    "ssh_key_type": "rsa",
+    "ssh_key_bits": 2048
+  },
+  "ctime": 1343869045.6055231,
+  "disks": {
+    "150bd154-8e23-44d1-b762-5065ae5a507b": {
+      "ctime": 1354038435.343601,
+      "dev_type": "plain",
+      "iv_name": "disk/0",
+      "logical_id": [
+        "xenvg",
+        "b27a576a-13f7-4f07-885c-63fcad4fdfcc.disk0"
+      ],
+      "mode": "rw",
+      "mtime": 1354038435.343601,
+      "nodes": [
+        "2ae3d962-2dad-44f2-bdb1-85f77107f907"
+      ],
+      "params": {},
+      "serial_no": 1,
+      "size": 1280,
+      "uuid": "150bd154-8e23-44d1-b762-5065ae5a507b"
+    },
+    "77ced3a5-6756-49ae-8d1f-274e27664c05": {
+      "children": [
+        {
+          "ctime": 1421677173.7280669,
+          "dev_type": "plain",
+          "logical_id": [
+            "xenvg",
+            "5c390722-6a7a-4bb4-9cef-98d896a8e6b1.disk0_data"
+          ],
+          "mtime": 1421677173.7280591,
+          "nodes": [
+            "9a12d554-75c0-4cb1-8064-103365145db0",
+            "41f9c238-173c-4120-9e41-04ad379b647a"
+          ],
+          "params": {},
+          "serial_no": 1,
+          "size": 1024
+        },
+        {
+          "ctime": 1421677173.728096,
+          "dev_type": "plain",
+          "logical_id": [
+            "xenvg",
+            "5c390722-6a7a-4bb4-9cef-98d896a8e6b1.disk0_meta"
+          ],
+          "mtime": 1421677173.7280879,
+          "nodes": [
+            "9a12d554-75c0-4cb1-8064-103365145db0",
+            "41f9c238-173c-4120-9e41-04ad379b647a"
+          ],
+          "params": {},
+          "serial_no": 1,
+          "size": 128
+        }
+      ],
+      "ctime": 1363620258.6089759,
+      "dev_type": "drbd",
+      "iv_name": "disk/0",
+      "logical_id": [
+        "9a12d554-75c0-4cb1-8064-103365145db0",
+        "41f9c238-173c-4120-9e41-04ad379b647a",
+        32100,
+        0,
+        0,
+        "d3c3fd475fcbaf5fd177fb245ac43b71247ada38"
+      ],
+      "mode": "rw",
+      "mtime": 1363620258.6089759,
+      "nodes": [
+        "9a12d554-75c0-4cb1-8064-103365145db0",
+        "41f9c238-173c-4120-9e41-04ad379b647a"
+      ],
+      "params": {},
+      "serial_no": 1,
+      "size": 1024,
+      "uuid": "77ced3a5-6756-49ae-8d1f-274e27664c05"
+    },
+    "79acf611-be58-4334-9fe4-4f2b73ae8abb": {
+      "ctime": 1355186880.4511809,
+      "dev_type": "plain",
+      "iv_name": "disk/0",
+      "logical_id": [
+        "xenvg",
+        "3e559cd7-1024-4294-a923-a9fd13182b2f.disk0"
+      ],
+      "mode": "rw",
+      "mtime": 1355186880.4511809,
+      "nodes": [
+        "41f9c238-173c-4120-9e41-04ad379b647a"
+      ],
+      "params": {},
+      "serial_no": 1,
+      "size": 102400,
+      "uuid": "79acf611-be58-4334-9fe4-4f2b73ae8abb"
+    }
+  },
+  "filters": {},
+  "instances": {
+    "4e091bdc-e205-4ed7-8a47-0c9130a6619f": {
+      "admin_state": "up",
+      "admin_state_source": "admin",
+      "beparams": {},
+      "ctime": 1354038435.343601,
+      "disks": [
+        "150bd154-8e23-44d1-b762-5065ae5a507b"
+      ],
+      "disks_active": true,
+      "hvparams": {},
+      "hypervisor": "xen-pvm",
+      "mtime": 1354224585.700732,
+      "name": "instance3.example.com",
+      "nics": [
+        {
+          "mac": "aa:bb:cc:5e:5c:75",
+          "nicparams": {},
+          "uuid": "1ab090c1-e017-406c-afb4-fc285cb43e31"
+        }
+      ],
+      "os": "debian-image",
+      "osparams": {},
+      "osparams_private": {},
+      "primary_node": "2ae3d962-2dad-44f2-bdb1-85f77107f907",
+      "serial_no": 4,
+      "tags": [],
+      "uuid": "4e091bdc-e205-4ed7-8a47-0c9130a6619f"
+    },
+    "6c078d22-3eb6-4780-857d-81772e09eef1": {
+      "admin_state": "up",
+      "admin_state_source": "admin",
+      "beparams": {},
+      "ctime": 1363620258.6089759,
+      "disks": [
+        "77ced3a5-6756-49ae-8d1f-274e27664c05"
+      ],
+      "disks_active": true,
+      "hvparams": {},
+      "hypervisor": "xen-pvm",
+      "mtime": 1363620320.8749011,
+      "name": "instance1.example.com",
+      "nics": [
+        {
+          "mac": "aa:bb:cc:b2:6e:0b",
+          "nicparams": {},
+          "uuid": "2c953d72-fac4-4aa9-a225-4131bb271791"
+        }
+      ],
+      "os": "busybox",
+      "osparams": {},
+      "osparams_private": {},
+      "primary_node": "9a12d554-75c0-4cb1-8064-103365145db0",
+      "serial_no": 2,
+      "uuid": "6c078d22-3eb6-4780-857d-81772e09eef1"
+    },
+    "8fde9f6d-e1f1-4850-9e9c-154966f622f5": {
+      "admin_state": "up",
+      "admin_state_source": "admin",
+      "beparams": {},
+      "ctime": 1355186880.4511809,
+      "disks": [
+        "79acf611-be58-4334-9fe4-4f2b73ae8abb"
+      ],
+      "disks_active": true,
+      "hvparams": {},
+      "hypervisor": "xen-pvm",
+      "mtime": 1355186898.307642,
+      "name": "instance2.example.com",
+      "nics": [
+        {
+          "mac": "aa:bb:cc:56:83:fb",
+          "nicparams": {},
+          "uuid": "1cf95562-e676-4fd0-8214-e8b84a2f7bd1"
+        }
+      ],
+      "os": "debian-image",
+      "osparams": {},
+      "osparams_private": {},
+      "primary_node": "41f9c238-173c-4120-9e41-04ad379b647a",
+      "serial_no": 2,
+      "tags": [],
+      "uuid": "8fde9f6d-e1f1-4850-9e9c-154966f622f5"
+    }
+  },
+  "mtime": 1421677173.729104,
+  "networks": {
+    "99f0128a-1c84-44da-90b9-9581ea00c075": {
+      "ext_reservations": "1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+      "name": "a network",
+      "network": "203.0.113.0/24",
+      "reservations": "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "serial_no": 1,
+      "uuid": "99f0128a-1c84-44da-90b9-9581ea00c075"
+    }
+  },
+  "nodegroups": {
+    "5244a46d-7506-4e14-922d-02b58153dde1": {
+      "alloc_policy": "preferred",
+      "diskparams": {},
+      "ipolicy": {},
+      "mtime": 1361963775.5750091,
+      "name": "default",
+      "ndparams": {},
+      "networks": {},
+      "serial_no": 125,
+      "tags": [],
+      "uuid": "5244a46d-7506-4e14-922d-02b58153dde1"
+    },
+    "6c0a8916-b719-45ad-95dd-82192b1e473f": {
+      "alloc_policy": "preferred",
+      "diskparams": {},
+      "ipolicy": {
+        "disk-templates": [
+          "plain"
+        ],
+        "minmax": [
+          {
+            "max": {
+              "cpu-count": 8,
+              "disk-count": 16,
+              "disk-size": 1048576,
+              "memory-size": 32768,
+              "nic-count": 18,
+              "spindle-use": 14
+            },
+            "min": {
+              "cpu-count": 2,
+              "disk-count": 2,
+              "disk-size": 1024,
+              "memory-size": 128,
+              "nic-count": 1,
+              "spindle-use": 1
+            }
+          }
+        ],
+        "spindle-ratio": 5.2000000000000002,
+        "vcpu-ratio": 3.1400000000000001
+      },
+      "mtime": 1361963775.5750091,
+      "name": "another",
+      "ndparams": {
+        "exclusive_storage": true
+      },
+      "networks": {},
+      "serial_no": 125,
+      "tags": [],
+      "uuid": "6c0a8916-b719-45ad-95dd-82192b1e473f"
+    }
+  },
+  "nodes": {
+    "2ae3d962-2dad-44f2-bdb1-85f77107f907": {
+      "ctime": 1343869045.6048839,
+      "drained": false,
+      "group": "5244a46d-7506-4e14-922d-02b58153dde1",
+      "master_candidate": true,
+      "master_capable": true,
+      "mtime": 1358348755.779906,
+      "name": "node2.example.com",
+      "ndparams": {},
+      "offline": false,
+      "powered": true,
+      "primary_ip": "192.0.2.83",
+      "secondary_ip": "198.51.100.83",
+      "serial_no": 6,
+      "tags": [],
+      "uuid": "2ae3d962-2dad-44f2-bdb1-85f77107f907",
+      "vm_capable": true
+    },
+    "41f9c238-173c-4120-9e41-04ad379b647a": {
+      "ctime": 1343869205.9348071,
+      "drained": false,
+      "group": "5244a46d-7506-4e14-922d-02b58153dde1",
+      "master_candidate": true,
+      "master_capable": true,
+      "mtime": 1353019704.8853681,
+      "name": "node3.example.com",
+      "ndparams": {},
+      "offline": false,
+      "powered": true,
+      "primary_ip": "192.0.2.84",
+      "secondary_ip": "198.51.100.84",
+      "serial_no": 2,
+      "tags": [],
+      "uuid": "41f9c238-173c-4120-9e41-04ad379b647a",
+      "vm_capable": true
+    },
+    "9a12d554-75c0-4cb1-8064-103365145db0": {
+      "ctime": 1349722460.022264,
+      "drained": false,
+      "group": "5244a46d-7506-4e14-922d-02b58153dde1",
+      "master_candidate": true,
+      "master_capable": true,
+      "mtime": 1359986533.3533289,
+      "name": "node1.example.com",
+      "ndparams": {},
+      "offline": false,
+      "powered": true,
+      "primary_ip": "192.0.2.82",
+      "secondary_ip": "198.51.100.82",
+      "serial_no": 197,
+      "tags": [],
+      "uuid": "9a12d554-75c0-4cb1-8064-103365145db0",
+      "vm_capable": true
+    }
+  },
+  "serial_no": 7627,
+  "version": 3010000
+}

--- a/test/py/legacy/cfgupgrade_unittest.py
+++ b/test/py/legacy/cfgupgrade_unittest.py
@@ -441,6 +441,9 @@ class TestCfgupgrade(unittest.TestCase):
   def testUpgradeFullConfigFrom_3_0(self):
     self._TestUpgradeFromFile("cluster_config_3.0.json", False)
 
+  def testUpgradeFullConfigFrom_3_1(self):
+    self._TestUpgradeFromFile("cluster_config_3.1.json", False)
+
   def testUpgradeCurrent(self):
     self._TestSimpleUpgrade(constants.CONFIG_VERSION, False)
 
@@ -463,6 +466,14 @@ class TestCfgupgrade(unittest.TestCase):
     _RunUpgrade(self.tmpdir, False, True, downgrade=True)
     oldconf = self._LoadTestDataConfig(oldconfname)
     newconf = self._LoadConfig()
+    # upgrade from 3.0 -> 3.1 sets machine_version to "pc" if it is unset
+    # but there is no exact downgrade path here (a value of "pc" does not
+    # break anything on 3.0, but reverting "pc" to "unset" would also not
+    # be correct here). Hence, we need this workaround to make the downgrade
+    # test pass
+    oldconf["cluster"]["hvparams"][constants.HT_KVM]\
+      [constants.HV_KVM_MACHINE_VERSION] = newconf["cluster"]["hvparams"]\
+      [constants.HT_KVM][constants.HV_KVM_MACHINE_VERSION]
     self.maxDiff = None
     self.assertEqual(oldconf, newconf)
 


### PR DESCRIPTION
This PR addresses the following things:
- add missing downgrade code for the `debug_threads`  KVM hvparam
- set `machine_version` KVM hvparam explicitly to `pc` if hvparam was unset prior to upgrade (we assume that users who have set that param to something specific know what they are doing)
- initialize new clusters with `machine_version` set to `pc`

