### PR TITLE
wait_for_qmp_event extended to multiple events

### DIFF
--- a/test/py/unit/hypervisor/hv_kvm/test_monitor.py
+++ b/test/py/unit/hypervisor/hv_kvm/test_monitor.py
@@ -249,9 +249,9 @@ class TestQmpConnection:
     fake_qmp.connect()
 
     # test None if timeout exceeds
-    none_event = fake_qmp.wait_for_qmp_event('NONE_EXISTING_EVENT', 0.1)
+    none_event = fake_qmp.wait_for_qmp_event(['NONE_EXISTING_EVENT'], 0.1)
     assert none_event is None
 
     fake_qmp.execute_qmp("test-fire-event")
-    test_event = fake_qmp.wait_for_qmp_event('TEST_EVENT', 0.3)
+    test_event = fake_qmp.wait_for_qmp_event(['TEST_EVENT'], 0.3)
     assert test_event.event_type == "TEST_EVENT"


### PR DESCRIPTION
This PR is an improvement of #1803.
The wait_for_qmp_event method has been modified so that it can now wait for multiple event types.
This is now used in HotDelDisk(), where a DEVICE_DELETED event is waited for once on a successful unplug or a DEVICE_UNPLUG_GUEST_ERROR on a failed unplug.