### PR TITLE
shutdown timeout: correct docs to unit of seconds

### DIFF
--- a/lib/cli_opts.py
+++ b/lib/cli_opts.py
@@ -1225,7 +1225,7 @@ NOSHUTDOWN_OPT = cli_option("--noshutdown", dest="shutdown",
 
 TIMEOUT_OPT = cli_option("--timeout", dest="timeout", type="int",
                          default=constants.DEFAULT_SHUTDOWN_TIMEOUT,
-                         help="Maximum time (in minutes) to wait")
+                         help="Maximum time (in seconds) to wait")
 
 COMPRESS_OPT = cli_option("--compress", dest="compress",
                           type="string", default=constants.IEC_NONE,
@@ -1239,7 +1239,7 @@ TRANSPORT_COMPRESSION_OPT = \
 SHUTDOWN_TIMEOUT_OPT = cli_option("--shutdown-timeout",
                                   dest="shutdown_timeout", type="int",
                                   default=constants.DEFAULT_SHUTDOWN_TIMEOUT,
-                                  help="Maximum time (in minutes) to wait for"
+                                  help="Maximum time (in seconds) to wait for"
                                   " instance shutdown")
 
 INTERVAL_OPT = cli_option("--interval", dest="interval", type="int",

--- a/man/gnt-backup.rst
+++ b/man/gnt-backup.rst
@@ -42,7 +42,7 @@ Valid values are 'none', and any values defined in the
 'compression_tools' cluster parameter.
 
 The ``--shutdown-timeout`` is used to specify how much time (in
-minutes) to wait before forcing the shutdown (xl destroy in xen,
+seconds) to wait before forcing the shutdown (xl destroy in xen,
 killing the kvm process, for kvm). By default two minutes are given
 to each instance to stop.
 

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -1310,7 +1310,7 @@ even in the presence of errors during the removal of the instance
 given, the command will stop at the first error.
 
 The ``--shutdown-timeout`` is used to specify how much time (in
-minutes) to wait before forcing the shutdown (e.g. ``xl destroy`` in
+seconds) to wait before forcing the shutdown (e.g. ``xl destroy`` in
 Xen, killing the kvm process for KVM, etc.). By default two minutes
 are given to each instance to stop.
 
@@ -1725,7 +1725,7 @@ during a hardcoded interval (currently 2 minutes), it will forcibly
 stop the instance (equivalent to switching off the power on a physical
 machine).
 
-The ``--timeout`` is used to specify how much time (in minutes) to
+The ``--timeout`` is used to specify how much time (in seconds) to
 wait before forcing the shutdown (e.g. ``xl destroy`` in Xen, killing
 the kvm process for KVM, etc.). By default two minutes are given to
 each instance to stop.
@@ -1790,7 +1790,7 @@ The ``--instance``, ``--node``, ``--primary``, ``--secondary``,
 and they influence the actual instances being rebooted.
 
 The ``--shutdown-timeout`` is used to specify how much time (in
-minutes) to wait before forcing the shutdown (xl destroy in xen,
+seconds) to wait before forcing the shutdown (xl destroy in xen,
 killing the kvm process, for kvm). By default two minutes are given
 to each instance to stop.
 
@@ -2091,7 +2091,7 @@ disconnected DRBD drives). This flag requires the source node to be
 marked offline first to succeed.
 
 The ``--shutdown-timeout`` is used to specify how much time (in
-minutes) to wait before forcing the shutdown (xl destroy in xen,
+seconds) to wait before forcing the shutdown (xl destroy in xen,
 killing the kvm process, for kvm). By default two minutes are given
 to each instance to stop.
 
@@ -2234,7 +2234,7 @@ is used during the move. Valid values are 'none' (the default) and any
 values specified in the 'compression_tools' cluster parameter.
 
 The ``--shutdown-timeout`` is used to specify how much time (in
-minutes) to wait before forcing the shutdown (e.g. ``xl destroy`` in
+seconds) to wait before forcing the shutdown (e.g. ``xl destroy`` in
 XEN, killing the kvm process for KVM, etc.). By default two minutes
 are given to each instance to stop.
 


### PR DESCRIPTION
This fixes commit 1a5e269b2a69e10fe050f4b8b35703a8777025d6, where the unit for shutdown timeout was incorrectly documented as minutes. Looking at the default timeout it's clear, that the correct unit must be seconds.

fixes #1708 