### PR TITLE
Do not use `pc` as the new default kvm `machine_version

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -2791,6 +2791,17 @@ class KVMHypervisor(hv_base.BaseHypervisor):
       warnings.append("machine_version is not explicitly configured so "
                       "Ganeti will autodetect the default value from "
                       "'kvm -M ?', this might produce unexpected results.")
+    if machine_version == "pc":
+      warnings.append("machine_version is set to the 'pc' type which "
+                      "could cause problems during live migration")
+
+    if machine_version.startswith("q35"):
+      warnings.append("machine_version is set to the 'q35' type which "
+                      "is currently not properly supported.")
+
+    if machine_version in ["none", "microvm", "isapc", "x-remote"]:
+      warnings.append("machine_version is set to %s which is unsupported "
+                      "in Ganeti." % machine_version)
 
     return warnings
 

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -898,16 +898,20 @@ machine\_version
 
     Use in case an instance must be booted with an exact type of
     machine version (due to e.g. outdated drivers). In case it's not set
-    the default version supported by your version of kvm is used. Starting
-    with Ganeti 3.1, new clusters will now default to 'pc'. This way Ganeti
-    users will not face any unexpected problems should Qemu/KVM change its
-    default model in the future. Please note that 'q35' is currently not
-    supported. You can query your Qemu/KVM installation for supported machine
-    versions:
+    the default version supported by your version of kvm is used. Ganeti
+    currently only supports the ``pc`` types properly.
+    However, you should not set it to ``pc`` but rather to a specific version,
+    e.g. ``pc-i440fx-9.2`` if you plan to use live migration. You can obtain
+    the default machine version by running:
 
     .. code-block:: bash
 
-      qemu-system-x86_64 -M ?
+      kvm -M ?
+
+    Look for the line containing (default). Setting it just to ``pc`` will
+    cause problems during rolling cluster upgrades, because your instance
+    will live-migrate into a different kvm version which has a different
+    understanding of what exactly "pc" is.
 
 
 migration\_caps

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -2970,11 +2970,6 @@ htMigrationModes :: FrozenSet String
 htMigrationModes =
   ConstantUtils.mkSet $ map Types.migrationModeToRaw [minBound..]
 
--- * Default Machine Type
-
-htKvmMachineVersionPc :: String
-htKvmMachineVersionPc = "pc"
-
 -- * Cluster verify steps
 
 verifyNplusoneMem :: String
@@ -4148,7 +4143,7 @@ hvcDefaults =
           , (hvUsbDevices,                      PyValueEx "")
           , (hvVga,                             PyValueEx "")
           , (hvKvmExtra,                        PyValueEx "")
-          , (hvKvmMachineVersion,               PyValueEx htKvmMachineVersionPc)
+          , (hvKvmMachineVersion,               PyValueEx "")
           , (hvKvmMigrationCaps,                PyValueEx "")
           , (hvVnetHdr,                         PyValueEx True)])
   , (Fake, Map.fromList [(hvMigrationMode, PyValueEx htMigrationLive)])


### PR DESCRIPTION
This commit partly reverts 86a41cecb24487f78ae867cefb0cadcd80c0df63 / #1822 

After some discussions with @saschalucas we concluded that the new default value of `pc` for the `machine_version` will only cause trouble in the long run. It might break instances during live-migration if the receiving end is a newer kvm release (e.g. during rolling cluster upgrades), since that end has a different understanding of what `pc` actually is. It would be more sane to configure an exact version, like `pc-i440fx-9.2`.

Documentation has been updated and also the cluster parameter assessment now warns if `machine_version` is set to unsupported values or to values that might cause trouble.