### PR TITLE
QA: change default SSH key type to RSA

### DIFF
--- a/qa/qa_config.py
+++ b/qa/qa_config.py
@@ -681,7 +681,7 @@ class _QaConfig(object):
       of the public key, file path of the 'authorized_keys' file
 
     """
-    key_type = "dsa"
+    key_type = "rsa"
     if self.get("ssh_key_type") is not None:
       key_type = self.get("ssh_key_type")
 


### PR DESCRIPTION
This doesn't even need a justification, but here it goes: DSA has long been deprecated and as of OpenSSH 9.8 completely unsupported (at least in Debian). Switch over to RSA instead.

This fixes QA runs in Debian trixie/unstable.