### PR TITLE
Make builds reproducible

### DIFF
--- a/doc/design-chained-jobs.rst
+++ b/doc/design-chained-jobs.rst
@@ -61,7 +61,7 @@ be submitted in the right order.
 The new attribute's value would be a list of two-valued tuples. Each
 tuple contains a job ID and a list of requested status for the job
 depended upon. Only final status are accepted
-(:pyeval:`utils.CommaJoin(constants.JOBS_FINALIZED)`). An empty list is
+(:pyeval:`utils.CommaJoin(sorted(constants.JOBS_FINALIZED))`). An empty list is
 equivalent to specifying all final status (except
 :pyeval:`constants.JOB_STATUS_CANCELED`, which is treated specially).
 An opcode runs only once all its dependency requirements have been

--- a/lib/ht.py
+++ b/lib/ht.py
@@ -257,7 +257,7 @@ def TElemOf(target_list):
   def fn(val):
     return val in target_list
 
-  return WithDesc("OneOf %s" % (utils.CommaJoin(target_list), ))(fn)
+  return WithDesc("OneOf %s" % (utils.CommaJoin(sorted(target_list)), ))(fn)
 
 
 # Container types


### PR DESCRIPTION
According to [1], ganeti does not build reproducibly due to some randomness in the generated docs. In particular, auto-generated documentation using utils.CommaJoin() on frozensets does not have stable output. Fix this by sorting the input passed to utils.CommaJoin in the two places that seem to introduce randomness.

[1] https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/diffoscope-results/ganeti.html