### PR TITLE
[build] Refactor Haskell PCRE handling and support pcre2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
         exclude:
           - os: debian-testing
             regex: pcre
+        include:
+          - os: debian-testing
+            regex: pcre2
     container:
       image: ganeti/ci:${{ matrix.os }}-py3
       options: "--init"
@@ -40,6 +43,10 @@ jobs:
       - name: configure
         if: ${{ matrix.regex == 'tdfa' }}
         run: ./configure --enable-haskell-tests --with-haskell-pcre=tdfa
+
+      - name: configure
+        if: ${{ matrix.regex == 'pcre2' }}
+        run: ./configure --enable-haskell-tests --with-haskell-pcre=pcre2
 
       - name: Build
         run: make -j 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: configure
         if: ${{ matrix.regex == 'tdfa' }}
-        run: ./configure --enable-haskell-tests --enable-regex-tdfa
+        run: ./configure --enable-haskell-tests --with-haskell-pcre=tdfa
 
       - name: Build
         run: make -j 2

--- a/Makefile.am
+++ b/Makefile.am
@@ -174,6 +174,9 @@ HS_DIRS = \
 	regex/pcre \
 	regex/pcre/Ganeti \
 	regex/pcre/Ganeti/Query \
+	regex/pcre2 \
+	regex/pcre2/Ganeti \
+	regex/pcre2/Ganeti/Query \
 	test/hs \
 	test/hs/Test \
 	test/hs/Test/Ganeti \
@@ -1213,6 +1216,7 @@ endif
 HS_REGEX_SRCS = \
 	regex/tdfa/Ganeti/Query/RegEx.hs \
 	regex/pcre/Ganeti/Query/RegEx.hs
+	regex/pcre2/Ganeti/Query/RegEx.hs
 
 HS_TEST_SRCS = \
 	test/hs/Test/AutoConf.hs \
@@ -3036,8 +3040,9 @@ dist/setup-config: ganeti.cabal $(HS_BUILT_SRCS)
 	  -f`test $(ENABLE_MOND) == True && echo "mond" || echo "-mond"` \
 	  -f`test $(ENABLE_METADATA) == True && echo "metad" || echo "-metad"` \
 	  -f`test $(ENABLE_NETWORK_BSD) == True && echo "network_bsd" || echo "-network_bsd"` \
-	  -f`test $(ENABLE_REGEX_PCRE_BUILTIN) == True && echo "regex-pcre-builtin" || echo "-regex-pcre-builtin"` \
-	  -f`test $(ENABLE_REGEX_TDFA) == True && echo "regex-tdfa" || echo "-regex-tdfa"`
+	  -f`test $(HS_PCRE_BACKEND) == pcre-builtin && echo "regex-pcre-builtin" || echo "-regex-pcre-builtin"` \
+	  -f`test $(HS_PCRE_BACKEND) == tdfa && echo "regex-tdfa" || echo "-regex-tdfa"` \
+	  -f`test $(HS_PCRE_BACKEND) == pcre2 && echo "regex-pcre2" || echo "-regex-pcre2"`
 
 
 # Target that builds all binaries (including those that are not

--- a/configure.ac
+++ b/configure.ac
@@ -136,6 +136,22 @@ AC_ARG_WITH([haskell-flags],
   [hextra_configure=""])
 AC_SUBST(HEXTRA_CONFIGURE, $hextra_configure)
 
+# --with-haskell-pcre=
+AC_ARG_WITH([haskell-pcre],
+  [AS_HELP_STRING([--with-haskell-pcre=auto|pcre|pcre2|pcre-builtin|tdfa],
+    [Haskell PCRE regex to use]
+  )],
+  [case "$withval" in
+      auto|pcre|pcre2|pcre-builtin|tdfa)
+        hs_pcre_backend="$withval"
+        ;;
+      *)
+        AC_MSG_ERROR([Unsupported value ${withval} for --with-haskell-pcre])
+        ;;
+    esac
+   ],
+  [hs_pcre_backend="auto"])
+
 # --with-sshd-restart-command=...
 AC_ARG_WITH([sshd-restart-command],
   [AS_HELP_STRING([--with-sshd-restart-command=SCRIPT],
@@ -637,23 +653,6 @@ AC_ARG_ENABLE([metadata],
   [],
   [enable_metadata=check])
 
-# --enable-regex-pcre-builtin
-ENABLE_REGEX_PCRE_BUILTIN=
-AC_ARG_ENABLE([regex-pcre-builtin],
-  [AS_HELP_STRING([--enable-regex-pcre-builtin],
-  [use regex-pcre-builtin library for regex parsing (default: regex-pcre)])],
-  [enable_regex_pcre_builtin=$enableval],
-  [enable_regex_pcre_builtin=no])
-
-# --enable-regex-tdfa
-ENABLE_REGEX_TDFA=
-AC_ARG_ENABLE([regex-tdfa],
-  [AS_HELP_STRING([--enable-regex-tdfa],
-  [use regex-tdfa library, that is,
-   POSIX instead of Perl regexes (default: regex-pcre)])],
-  [enable_regex_tdfa=$enableval],
-  [enable_regex_tdfa=no])
-
 # Check for ghc
 AC_ARG_VAR(GHC, [ghc path])
 AC_PATH_PROG(GHC, [ghc], [])
@@ -717,25 +716,29 @@ AC_GHC_PKG_REQUIRE(lens)
 AC_GHC_PKG_REQUIRE(old-time)
 AC_GHC_PKG_REQUIRE(temporary)
 
-HS_REGEX_TDFA=False
-HS_REGEX_PCRE_BUILTIN=False
-if test "$enable_regex_tdfa" != no; then
+case "$hs_pcre_backend" in
+  auto)
+  AC_GHC_PKG_CHECK([regex-pcre], [hs_pcre_backend=pcre],
+    [AC_GHC_PKG_CHECK([regex-pcre2], [hs_pcre_backend=pcre2],
+      [AC_GHC_PKG_CHECK([regex-pcre-builtin], [hs_pcre_backend=pcre-builtin],
+        [AC_GHC_PKG_CHECK([regex-tdfa], [hs_pcre_backend=tdfa], [
+	  AC_MSG_ERROR([No supported Haskell PCRE library found]) ])])])])
+  ;;
+  tdfa)
   AC_GHC_PKG_REQUIRE(regex-tdfa)
-  HS_REGEX_TDFA=True
-elif test "$enable_regex_pcre_builtin" != no; then
-  AC_GHC_PKG_REQUIRE(regex-pcre-builtin)
-  HS_REGEX_PCRE_BUILTIN=True
-else
+  ;;
+  pcre)
   AC_GHC_PKG_REQUIRE(regex-pcre)
-fi
+  ;;
+  pcre2)
+  AC_GHC_PKG_REQUIRE(regex-pcre2)
+  ;;
+  pcre-builtin)
+  AC_GHC_PKG_REQUIRE(regex-pcre-builtin)
+  ;;
+esac
 
-AC_SUBST(ENABLE_REGEX_PCRE_BUILTIN, $HS_REGEX_PCRE_BUILTIN)
-AM_CONDITIONAL([ENABLE_REGEX_PCRE_BUILTIN],
-               [test x$HS_REGEX_PCRE_BUILTIN=xTrue])
-
-AC_SUBST(ENABLE_REGEX_TDFA, $HS_REGEX_TDFA)
-AM_CONDITIONAL([ENABLE_REGEX_TDFA], [test x$HS_REGEX_TDFA=xTrue])
-
+AC_SUBST(HS_PCRE_BACKEND, $hs_pcre_backend)
 
 #extra modules for monitoring daemon functionality; also needed for tests
 MONITORING_PKG=

--- a/ganeti.cabal
+++ b/ganeti.cabal
@@ -45,6 +45,10 @@ Flag regex-pcre-builtin
   Description: use regex-pcre-builtin instead of regex-pcre
   Default:     False
 
+Flag regex-pcre2
+  Description: use regex-pcre2 instead of regex-pcre
+  Default:     False
+
 Library
   Exposed-Modules:
     AutoConf
@@ -300,6 +304,10 @@ Library
     Hs-Source-Dirs: regex/tdfa
     Build-Depends:
       regex-tdfa                      >= 1.2        && < 1.4
+  Elif flag(regex-pcre2)
+    Hs-Source-Dirs: regex/pcre2
+    Build-Depends:
+      regex-pcre2                     >= 1.0.0.0    && < 1.1
   Else
     Hs-Source-Dirs: regex/pcre
     If flag(regex-pcre-builtin)

--- a/regex/pcre2/Ganeti/Query/RegEx.hs
+++ b/regex/pcre2/Ganeti/Query/RegEx.hs
@@ -1,0 +1,8 @@
+module Ganeti.Query.RegEx (
+    RegEx.Regex,
+    RegEx.match,
+    RegEx.makeRegexM,
+    (RegEx.=~),
+    ) where
+
+import qualified Text.Regex.PCRE2 as RegEx


### PR DESCRIPTION
Change from using multiple `--enable-haskell-pcre` flags to a single `--with-haskell-pcre=` option and support library autodetection. This allows `./configure` to be run without specifying a pcre option and will pick the first available supported PCRE regex library.

Note that without this, `make distcheck-release` on Debian fails, as it runs `./configure` without any arguments which in turn would expect the (deprecated) haskell-pcre library to be present.

Finally, add support for pcre2 (fixes #1830, thanks to @AdrianBunk) and adjust the CI workflow to the new ./configure flag.