### PR TITLE
Various build fixes to get `make distcheck` running

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -903,7 +903,7 @@ if ENABLE_METADATA
 HS_COMPILE_PROGS += exe/ganeti-metad
 endif
 
-CABAL_SETUP = runhaskell Setup
+CABAL_SETUP = runhaskell $(top_srcdir)/Setup
 
 # All Haskell non-test programs to be compiled but not automatically installed
 HS_PROGS = $(HS_BIN_PROGS) $(HS_MYEXECLIB_PROGS)
@@ -2139,6 +2139,7 @@ srclink_files = \
 	test/py/import-export_unittest.bash \
 	test/py/cli-test.bash \
 	test/py/bash_completion.bash \
+	test/hs/htest.hs \
 	test/hs/offline-test.sh \
 	test/hs/cli-tests-defs.sh \
 	$(all_python_code) \
@@ -3031,6 +3032,7 @@ man: $(man_MANS) $(manhtml)
 
 dist/setup-config: ganeti.cabal $(HS_BUILT_SRCS)
 	$(CABAL_SETUP) configure --user \
+	  --cabal-file=$(top_srcdir)/ganeti.cabal \
 	  -f`test $(HTEST) == yes && echo "htest" || echo "-htest"` \
 	  -f`test $(ENABLE_MOND) == True && echo "mond" || echo "-mond"` \
 	  -f`test $(ENABLE_METADATA) == True && echo "metad" || echo "-metad"` \

--- a/Makefile.am
+++ b/Makefile.am
@@ -2076,10 +2076,10 @@ check_SCRIPTS += \
 	$(HS_BUILT_TEST_HELPERS)
 endif
 
-test/hs/hpc-htools:	src/htools
+test/hs/hpc-htools:	exe/htools
 	$(LN_S) ../../$< $@
 
-test/hs/hpc-mon-collector:	src/mon-collector
+test/hs/hpc-mon-collector:	exe/mon-collector
 	$(LN_S) ../../$< $@
 
 TESTS = $(dist_TESTS) $(nodist_TESTS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1659,8 +1659,7 @@ EXTRA_DIST += \
 	$(HS_PROG_SRCS) \
 	src/lint-hints.hs \
 	test/hs/cli-tests-defs.sh \
-	test/hs/offline-test.sh \
-	.ghci
+	test/hs/offline-test.sh
 
 man_MANS = \
 	man/ganeti-cleaner.8 \

--- a/Makefile.am
+++ b/Makefile.am
@@ -2132,13 +2132,13 @@ endif
 
 srclink_files = \
 	man/footer.rst \
-	test/py/check-cert-expired_unittest.bash \
-	test/py/daemon-util_unittest.bash \
-	test/py/systemd_unittest.bash \
-	test/py/ganeti-cleaner_unittest.bash \
-	test/py/import-export_unittest.bash \
-	test/py/cli-test.bash \
-	test/py/bash_completion.bash \
+	test/py/legacy/check-cert-expired_unittest.bash \
+	test/py/legacy/daemon-util_unittest.bash \
+	test/py/legacy/systemd_unittest.bash \
+	test/py/legacy/ganeti-cleaner_unittest.bash \
+	test/py/legacy/import-export_unittest.bash \
+	test/py/legacy/cli-test.bash \
+	test/py/legacy/bash_completion.bash \
 	test/hs/htest.hs \
 	test/hs/offline-test.sh \
 	test/hs/cli-tests-defs.sh \

--- a/autotools/run-in-tempdir
+++ b/autotools/run-in-tempdir
@@ -28,7 +28,7 @@ mv $tmpdir/lib $tmpdir/ganeti
 ln -T -s $tmpdir/ganeti $tmpdir/lib
 
 mkdir -p $tmpdir/exe $tmpdir/test/hs
-for hfile in htools ganeti-confd mon-collector hs2py; do
+for hfile in htest htools ganeti-confd mon-collector hs2py; do
   exe=exe/$hfile
   if [ -e $exe ]; then
     ln -s $PWD/$exe $tmpdir/exe/

--- a/test/py/legacy/check-cert-expired_unittest.bash
+++ b/test/py/legacy/check-cert-expired_unittest.bash
@@ -41,7 +41,7 @@ err() {
 }
 
 impexpd_helper() {
-  $PYTHON "${TOP_SRCDIR:-.}/test/py/import-export_unittest-helper" "$@"
+  $PYTHON "${TOP_SRCDIR:-.}/test/py/legacy/import-export_unittest-helper" "$@"
 }
 
 $CCE 2>/dev/null && err 'Accepted empty argument list'

--- a/test/py/legacy/cli-test.bash
+++ b/test/py/legacy/cli-test.bash
@@ -4,5 +4,5 @@ export SCRIPTS=${TOP_BUILDDIR:-.}/scripts
 export DAEMONS=${TOP_BUILDDIR:-.}/daemons
 
 shelltest $SHELLTESTARGS \
-  ${TOP_SRCDIR:-.}/test/py/{gnt,ganeti}-*.test \
+  ${TOP_SRCDIR:-.}/test/py/legacy/{gnt,ganeti}-*.test \
   -- --hide-successes

--- a/test/py/legacy/ganeti-cleaner_unittest.bash
+++ b/test/py/legacy/ganeti-cleaner_unittest.bash
@@ -53,7 +53,7 @@ upto() {
 gencert() {
   local path=$1 validity=$2
   VALIDITY=$validity $PYTHON \
-    ${TOP_SRCDIR:-.}/test/py/import-export_unittest-helper \
+    ${TOP_SRCDIR:-.}/test/py/legacy/import-export_unittest-helper \
     $path gencert
 }
 

--- a/test/py/legacy/import-export_unittest.bash
+++ b/test/py/legacy/import-export_unittest.bash
@@ -153,7 +153,7 @@ cat $(get_testfile proc_drbd8.txt) $(get_testfile cert1.pem) > $testdata
 } > $largetestdata
 
 impexpd_helper() {
-  $PYTHON $(get_testpath)/py/import-export_unittest-helper "$@"
+  $PYTHON $(get_testpath)/py/legacy/import-export_unittest-helper "$@"
 }
 
 start_test() {


### PR DESCRIPTION
This PR includes several fixes to get `make distcheck` (almost) running again:

1. **Copy htest binary to the runner tempdir**: 
   - We now explicitly copy the **htest** binary to the temporary directory used for testing. This was necessary because of the Haskell build system changes that moved it to a different location (from `src/` to `exe/`).

2. **Fix Python test script paths**:
   - Adjust paths in Python test scripts to reflect the new structure after moving files to `test/py/legacy`.

3. **Update Haskell test dependencies**:
   - Correct the dependencies for Haskell tests in the Makefile to point to the new locations of `htools` and `mon-collector`.

4. **Call Cabal with full path**:
   - Modify the Makefile to use full paths for Cabal files during builds to ensure they are located correctly, especially during an out-of-source-tree ("[VPATH](https://www.gnu.org/software/automake/manual/html_node/VPATH-Builds.html)") build, like the one performed by `make distcheck-release`.

5. **Remove .ghci from distribution**:
   - Remove the outdated `.ghci` reference from the distribution list in the Makefile since the file itself was removed previously from the source tree.

Note that `make distcheck-release` is still broken because of some integration test failures, which will be dealt with on a different PR.