### PR TITLE
Distcheck fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -924,9 +924,8 @@ HS_DEFAULT_PROGS = \
 
 if HTEST
 HS_DEFAULT_PROGS += exe/htest
-else
-EXTRA_DIST += test/hs/htest.hs
 endif
+EXTRA_DIST += test/hs/htest.hs
 
 HS_ALL_PROGS = $(HS_DEFAULT_PROGS) $(HS_MYEXECLIB_PROGS)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1215,7 +1215,7 @@ endif
 
 HS_REGEX_SRCS = \
 	regex/tdfa/Ganeti/Query/RegEx.hs \
-	regex/pcre/Ganeti/Query/RegEx.hs
+	regex/pcre/Ganeti/Query/RegEx.hs \
 	regex/pcre2/Ganeti/Query/RegEx.hs
 
 HS_TEST_SRCS = \

--- a/autotools/check-news
+++ b/autotools/check-news
@@ -97,7 +97,7 @@ def UpdateAllowUnreleased(allow_unreleased, version_match, release):
 def main():
   # Ensure "C" locale is used
   curlocale = locale.getlocale()
-  if curlocale != (None, None):
+  if curlocale[0] not in (None, 'C'):
     Error("Invalid locale %s" % str(curlocale))
 
   # Get the release version, but replace "~" with " " as the version

--- a/test/py/legacy/ganeti-cleaner_unittest.bash
+++ b/test/py/legacy/ganeti-cleaner_unittest.bash
@@ -36,9 +36,7 @@ GNTC=daemons/ganeti-cleaner
 CCE=$PWD/tools/check-cert-expired
 
 # Expand relative PYTHONPATH passed as passed by the test environment.
-if [ "x$PYTHONPATH" = "x.:./test/py" ]
-then export PYTHONPATH=$PWD:$PWD/test/py
-fi
+PYTHONPATH="${PYTHONPATH/.:./$PWD:$PWD}"
 
 err() {
   echo "$@"

--- a/test/py/legacy/import-export_unittest-helper
+++ b/test/py/legacy/import-export_unittest-helper
@@ -106,7 +106,8 @@ def main():
   elif what == "connected":
     WaitForConnected(filename)
   elif what == "gencert":
-    utils.GenerateSelfSignedSslCert(filename, 1, validity=VALIDITY)
+    utils.GenerateSelfSignedSslCert(filename, 1, validity=VALIDITY,
+                                    common_name="localhost")
   else:
     raise Exception("Unknown command '%s'" % what)
 


### PR DESCRIPTION
This is the final set of fixes to get `make distcheck-release` running. It includes fixes for a couple of unit tests that were broken by changes introduced in 3.1, alongside a couple of smaller fixes in the build system.