### PR TITLE
Release 3.1.0-rc2

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,26 @@ News
 ====
 
 
+Version 3.1.0 rc2
+-----------------
+
+*(Released Wed, 12 Mar 2025)*
+
+Changes since 3.1.0 rc1
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- various tests have been fixed (Python and Haskell) (#1833)
+- various bugs related to `make dist / distcheck` have been fixed (which is
+  the reason there never was an official -rc1 tarball) (#1833, #1834)
+- builds are now reproducible (#1831)
+- QA suite now default to RSA instead of DSA SSH keys (#1829)
+- `--enable-regex-pcre-builtin` and `--enable-regex-tdfa` have been dropped from
+  `./configure` and replaced by -`-with-haskell-pcre=auto|$library` (#1832)
+- support for the Haskell pcre2 library has been added (#1832)
+- `start-stop-daemon` is now invoked with `--remove-pidfile` to avoid stale PID
+  files which confused tests (#1836)
+
+
 Version 3.1.0 rc1
 -----------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 m4_define([gnt_version_major], [3])
 m4_define([gnt_version_minor], [1])
 m4_define([gnt_version_revision], [0])
-m4_define([gnt_version_suffix], [~rc1])
+m4_define([gnt_version_suffix], [~rc2])
 m4_define([gnt_version_full],
           m4_format([%d.%d.%d%s],
                     gnt_version_major, gnt_version_minor,


### PR DESCRIPTION
The recent `-rc1` tag contained several issues regarding tests and `make dist[check]`, hence there never was an official release or even just a tarball. Thanks to @apoikos all problems have been addressed and we are now ready for `-rc2`.