### PR TITLE
daemon-util: remove pidfile(s) on stop

### DIFF
--- a/daemons/daemon-util.in
+++ b/daemons/daemon-util.in
@@ -345,7 +345,7 @@ stop() {
     systemctl stop "${name}.service"
   elif type -p start-stop-daemon >/dev/null; then
     start-stop-daemon --stop --quiet --oknodo --retry 30 \
-      --pidfile $pidfile --name "$name"
+      --pidfile $pidfile --remove-pidfile --name "$name"
   else
     _ignore_error killproc -p $pidfile $name
   fi


### PR DESCRIPTION
The daemon pidfiles are created by start-stop-daemon and are not handled by the daemons themselves. Make sure we clean them up on stop. This fixes an autopkgtest failure on s390x.

Note: this patch is part of the Debian package.