### PR TITLE
Python 3.6 compatibility

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -85,7 +85,7 @@ from ganeti.hypervisor.hv_kvm.validation import check_boot_parameters, \
                                                 validate_vnc_parameters, \
                                                 validate_disk_parameters
 
-import ganeti.hypervisor.hv_kvm.kvm_utils as kvm_utils
+from ganeti.hypervisor.hv_kvm import kvm_utils
 
 _KVM_NETWORK_SCRIPT = pathutils.CONF_DIR + "/kvm-vif-bridge"
 _KVM_START_PAUSED_FLAG = "-S"

--- a/lib/hypervisor/hv_kvm/kvm_utils.py
+++ b/lib/hypervisor/hv_kvm/kvm_utils.py
@@ -59,7 +59,8 @@ def ParseStorageUriToBlockdevParam(uri):
   @param uri: storage-describing URI
   @return: dict
   """
-  if (match := re.match(_BLOCKDEV_URI_REGEX_GLUSTER, uri)) is not None:
+  match = re.match(_BLOCKDEV_URI_REGEX_GLUSTER, uri)
+  if match is not None:
     return {
         "driver": "gluster",
         "server": [
@@ -72,7 +73,8 @@ def ParseStorageUriToBlockdevParam(uri):
         "volume": match.group("volume"),
         "path": match.group("path")
       }
-  elif (match := re.match(_BLOCKDEV_URI_REGEX_RBD, uri)) is not None:
+  match = re.match(_BLOCKDEV_URI_REGEX_RBD, uri)
+  if match is not None:
     return {
         "driver": "rbd",
         "pool": match.group("pool"),

--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -48,7 +48,7 @@ from ganeti import utils
 from ganeti import constants
 from ganeti import serializer
 
-import ganeti.hypervisor.hv_kvm.kvm_utils as kvm_utils
+from ganeti.hypervisor.hv_kvm import kvm_utils
 
 
 class QmpCommandNotSupported(errors.HypervisorError):


### PR DESCRIPTION
Hi, I am trying to build RPM packages for Ganeti 3.1.0-rc2. (https://github.com/jfut/ganeti-rpm/issues/53)

This patch is necessary because `RHEL/AlmaLinux/Rocky Linux/others 8` ships with `Python 3.6.8` as the default Python version.

The [INSTALL](https://github.com/ganeti/ganeti/blob/v3.1.0rc2/INSTALL) documentation still lists "Python, version 3.6 or above" in the Software Requirements section. But if you decide to drop support for Python 3.6, it's fine not to merge this patch as we can maintain it in the ganeti-rpm repository.