### PR TITLE
avoid hostname resolution on remote-import

### DIFF
--- a/lib/cmdlib/instance_create.py
+++ b/lib/cmdlib/instance_create.py
@@ -325,8 +325,7 @@ class LUInstanceCreate(LogicalUnit):
         raise errors.OpPrereqError("Missing source instance name",
                                    errors.ECODE_INVAL)
 
-      self.source_instance_name = \
-        netutils.GetHostname(name=src_instance_name).name
+      self.source_instance_name = src_instance_name
 
     else:
       raise errors.OpPrereqError("Invalid instance creation mode %r" %


### PR DESCRIPTION
There is an extra hostname resolution for instances created in mode remote-import (aka `move-instance`), but the reason is unknown. This causes an error, if the instance's name can not be resolved (visible in the job at the receiving cluster):

```
  Result:
    - OpPrereqError
    - - The given name (test.vm) does not resolve: Name or service not known
```

It seems to work without hostname resolution, so removing it here.

fixes #1841 