### PR TITLE
`move-instance`: accept NICs with network assigned

### DIFF
--- a/tools/move-instance
+++ b/tools/move-instance
@@ -603,6 +603,15 @@ class MoveDestExecutor(object):
       raise Error("Received NIC information does not match expected format; "
                   "Do the versions of this tool and the source cluster match?")
 
+    # remove mode, link and vlan if a network is supplied
+    skip_keys = [constants.INIC_MODE, constants.INIC_LINK, constants.INIC_VLAN]
+    for idx, nic in enumerate(nics):
+      if nic[constants.INIC_NETWORK] is not None:
+        nics[idx] = objects.FillDict(nic, nic, skip_keys)
+        # use symbolic network name, not uuid
+        netinfo = instance["nics"][idx][8]
+        nics[idx][constants.INIC_NETWORK] = netinfo["name"]
+
     if len(override_nics) > len(nics):
       raise Error("Can not create new NICs")
 


### PR DESCRIPTION
When NICs use the `network` parameter, settings for `mode`, `link` and `vlan` ar inherited and can not be specified at the same time. Make `move-instance` aware of this.

fixes #1842

Maybe this is a ugly hack. Suggestions welcome.