### PR TITLE
Update kvm-console-wrapper to run unpause in a subshell

### DIFF
--- a/tools/kvm-console-wrapper
+++ b/tools/kvm-console-wrapper
@@ -48,5 +48,5 @@ unpause() {
   echo "c" | "$SOCAT" STDIO "UNIX-CONNECT:$MONITOR" &>/dev/null
 }
 
-unpause &
+(unpause &)
 exec "$SOCAT" "$PARAMS" "$CONSOLE"


### PR DESCRIPTION
Running unpause in the background creates a zombie process with socat as the parent.

To reproduce simply connect to a serial console `gnt-instance console $instance` and check for zombie processes `ps axuw | grep '<defunct>'`