### PR TITLE
Print saved and loaded ClusterData for debugging purposes

### DIFF
--- a/src/Ganeti/HTools/ExtLoader.hs
+++ b/src/Ganeti/HTools/ExtLoader.hs
@@ -130,6 +130,9 @@ loadExternalData opts = do
       ldresult = input_data >>= (if ignoreDynU then clearDynU else return)
                             >>= mergeData eff_u exTags selInsts exInsts now
   cdata <- exitIfBad "failed to load data, aborting" ldresult
+  putStrLn ">>>>> loadExternalData >>>>>"
+  print cdata
+  putStrLn "<<<<< loadExternalData <<<<<"
   (cdata', ok) <- runWriterT $ if optMonD opts
                                  then MonD.queryAllMonDDCs cdata opts
                                  else return cdata
@@ -141,6 +144,9 @@ loadExternalData opts = do
 
   unless (optVerbose opts == 0) $ maybeShowWarnings fix_msgs
 
+  putStrLn ">>>>> loadExternalData modified >>>>>"
+  print cdata' {cdNodes = nl}
+  putStrLn "<<<<< loadExternalData modified <<<<<"
   return cdata' {cdNodes = nl}
 
 -- | Function to save the cluster data to a file.

--- a/src/Ganeti/HTools/Program/Hscan.hs
+++ b/src/Ganeti/HTools/Program/Hscan.hs
@@ -144,6 +144,9 @@ writeDataInner nlen name opts cdata fixdata = do
   hFlush stdout
   when (isJust shownodes) .
        putStr $ Cluster.printNodes nl (fromJust shownodes)
+  putStrLn ">>>>> writeDataInner >>>>>"
+  print cdata
+  putStrLn "<<<<< writeDataInner <<<<<"
   writeFile (oname <.> "data") (serializeCluster cdata)
   return True
 


### PR DESCRIPTION
Please do not merge!

It prints written `ClusterData` in `hscan` after `>>>>> writeDataInner >>>>>` and in other tools it prints received `ClusterData` after `>>>>> loadExternalData >>>>>`. Data from `loadExternalData` can come from any source, e.g. Luxi or text file.

`ClusterData` is written in Haskell syntax. You may indent and format it nicely using the [hindent](https://hackage.haskell.org/package/hindent) tool.