### PR TITLE
HTools.Loader.updateMemStat: initialize failN1

### DIFF
--- a/src/Ganeti/HTools/Loader.hs
+++ b/src/Ganeti/HTools/Loader.hs
@@ -386,13 +386,15 @@ setStaticKvmNodeMem nl static_node_mem =
      then Container.map updateNM nl
      else nl
 
--- | Update node memory stat based on instance list.
+-- | Update node memory stat and Fail-N+1 state based on instance list.
 updateMemStat :: Node.Node -> Instance.List -> Node.Node
 updateMemStat node il =
   let node2 = node { Node.iMem = nodeImem node il }
       node3 = node2 { Node.xMem = Node.missingMem node2 }
-  in node3 { Node.pMem = fromIntegral (Node.unallocatedMem node3)
-                         / Node.tMem node3 }
+  in  node3 {
+        Node.failN1 = Node.unallocatedMem node3 <= Node.rMem node3,
+        Node.pMem = fromIntegral (Node.unallocatedMem node3) / Node.tMem node3
+      }
 
 -- | Check the cluster for memory/disk allocation consistency and update stats.
 updateMissing :: Node.List -- ^ All nodes in the cluster

--- a/src/Ganeti/HTools/Node.hs
+++ b/src/Ganeti/HTools/Node.hs
@@ -480,10 +480,10 @@ buildPeers t il =
               (sList t)
       pmap = P.accumArray (+) mdata
       new_rmem = computeMaxRes pmap
-      new_failN1 = fMem t < new_rmem
       new_prem = fromIntegral new_rmem / tMem t
   in t { peers = pmap
-       , failN1 = new_failN1
+       {- failN1 is initialized in Loader.updateMemStat,
+          after iMem is initialized and nMem updated -}
        , rMem = new_rmem
        , pRem = new_prem
 


### PR DESCRIPTION
failN1 is now based on umem, not fmem anymore,
but umem (Node.unallocatedMem) requires corrected values for imem and nmem, that are not known before the call to Loader.updateMissing.

Before that change some N+1 violations were not recognized by hbal.