### PR TITLE
Upgrade KVM runtime WRT to removal of `-chroot`

### DIFF
--- a/lib/hypervisor/hv_kvm/kvm_runtime.py
+++ b/lib/hypervisor/hv_kvm/kvm_runtime.py
@@ -224,11 +224,17 @@ def _upgrade_serialized_runtime(loaded_runtime: List) -> List:
       hvparams[constants.HV_DISK_DISCARD] = constants.HT_DISCARD_IGNORE
 
     # remove chroot from the runtime
+    # commit e607423 addresses that the -chroot parameter is now combined into
+    # -run-with. This happens in a way that -chroot is no longer written into
+    # the KVM runtime.  When live migrating, the old runtime (containing
+    # -chroot) is read and therefore has to be filtered out. Otherwise kvm_cmd
+    # will contain old -chroot and new -run-with. This makes live
+    # migration to >=Qemu-9.0 possible.
     try:
       idx = kvm_cmd.index("-chroot")
     except ValueError:
       pass
     else:
-      kvm_cmd[idx:idx+2] = []
+      del kvm_cmd[idx:idx+2]
 
   return [kvm_cmd, serialized_nics, hvparams, serialized_disks]

--- a/lib/hypervisor/hv_kvm/kvm_runtime.py
+++ b/lib/hypervisor/hv_kvm/kvm_runtime.py
@@ -223,4 +223,12 @@ def _upgrade_serialized_runtime(loaded_runtime: List) -> List:
         constants.HT_VALID_DISCARD_TYPES:
       hvparams[constants.HV_DISK_DISCARD] = constants.HT_DISCARD_IGNORE
 
+    # remove chroot from the runtime
+    try:
+      idx = kvm_cmd.index("-chroot")
+    except ValueError:
+      pass
+    else:
+      kvm_cmd[idx:idx+2] = []
+
   return [kvm_cmd, serialized_nics, hvparams, serialized_disks]

--- a/lib/hypervisor/hv_kvm/kvm_runtime.py
+++ b/lib/hypervisor/hv_kvm/kvm_runtime.py
@@ -232,9 +232,8 @@ def _upgrade_serialized_runtime(loaded_runtime: List) -> List:
     # migration to >=Qemu-9.0 possible.
     try:
       idx = kvm_cmd.index("-chroot")
+      del kvm_cmd[idx:idx+2]
     except ValueError:
       pass
-    else:
-      del kvm_cmd[idx:idx+2]
 
   return [kvm_cmd, serialized_nics, hvparams, serialized_disks]


### PR DESCRIPTION
Commit e607423b57521fec5a9a1d289ca736ec90266b18 has removed `-chroot` from the KVM runtime, but did not take into account, that instances started by <Qemu-9.0 needs to upgrade their runtime, too. Without that fix, a rolling upgrade to >=Qemu-9.0 wont be possible, if instances are using chroot.

Simple tests proved that chroot can be changed during live migration and doesn't need to be in the KVM runtime. However, no further knowledge exists why `-chroot` was in the runtime before.