### PR TITLE
mark qmp connection for close

### DIFF
--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -209,6 +209,7 @@ class UnixFileSocketConnection:
       self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
       self.sock.settimeout(self.timeout)
       self.sock.connect(self.socket_path)
+      self._connected = True
 
       logging.debug("Create Socket Connection to %s.", {self.socket_path})
 

--- a/test/py/unit/hypervisor/hv_kvm/test_monitor.py
+++ b/test/py/unit/hypervisor/hv_kvm/test_monitor.py
@@ -255,3 +255,10 @@ class TestQmpConnection:
     fake_qmp.execute_qmp("test-fire-event")
     test_event = fake_qmp.wait_for_qmp_event(['TEST_EVENT'], 0.3)
     assert test_event.event_type == "TEST_EVENT"
+
+  def test_is_connected(self, fake_qmp: QmpConnection):
+    assert not fake_qmp.is_connected()
+    fake_qmp.connect()
+    assert fake_qmp.is_connected()
+    fake_qmp.close()
+    assert not fake_qmp.is_connected()


### PR DESCRIPTION
commit 1d8adf0b70b2a56f42cbff25d83c2be83a43da95 has redesigned the KVM QMP monitor. It seems, that it was forgotten to mark the connection for closing at the end. This yields to blocking QMP socket, i.e. at instance shutdown, where frequent QMP connections sent the power down command competing with other QMP boilerplate (query balloon and cpu fast):

A running instance with no OS inside will timeout regularly on shutdown, but often the default timeout of 120s is not reached:

        root@master:~# gnt-instance shutdown test.vm
        Waiting for job 51 for test.vm ...
        Job 51 for test.vm has failed: Failure: command execution error:
        Could not shutdown instance 'test.vm': Error while executing backend function: [Errno 11] Resource temporarily unavailable

Looking at node-log in debug mode, one can see, that the close function is not called (no `Socket Connection to %s closed` in the log). With this fix, the connection is closed and shutdown / reboot works as expected.