### PR TITLE
Hscan.writeDataInner: remove now unused cdata parameter

### DIFF
--- a/src/Ganeti/HTools/Program/Hscan.hs
+++ b/src/Ganeti/HTools/Program/Hscan.hs
@@ -124,16 +124,15 @@ writeData nlen name opts (Ok cdata) = do
   case fixdata of
     Bad err -> printf "\nError for %s: failed to process data. Details:\n%s\n"
                name err >> return False
-    Ok processed -> writeDataInner nlen name opts cdata processed
+    Ok processed -> writeDataInner nlen name opts processed
 
 -- | Inner function for writing cluster data to disk.
 writeDataInner :: Int
                -> String
                -> Options
                -> ClusterData
-               -> ClusterData
                -> IO Bool
-writeDataInner nlen name opts cdata fixdata = do
+writeDataInner nlen name opts fixdata = do
   let (ClusterData _ nl il _ _) = fixdata
   printf "%-*s " nlen name :: IO ()
   hFlush stdout


### PR DESCRIPTION
Parameter `cdata` became unused with 837354e987c224a1ea9b1fc8d206b2cc3e08a4b8.