### PR TITLE
QMP: call connect only if not connected

### DIFF
--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -175,7 +175,8 @@ def _ensure_connection(fn):
     """Ensure proper connect/close and exception propagation"""
     mon = args[0]
     already_connected = mon.is_connected()
-    mon.connect()
+    if not already_connected:
+      mon.connect()
     try:
       ret = fn(*args, **kwargs)
     finally:
@@ -417,7 +418,7 @@ class QmpConnection(QemuMonitorSocket):
       if greeting[self._EVENT_KEY]:
         continue
       if not greeting[self._FIRST_MESSAGE_KEY]:
-        self._connected = False
+        self.close()
         raise errors.HypervisorError("kvm: QMP communication error (wrong"
                                      " server greeting)")
       else:


### PR DESCRIPTION
The pure socket connection is already conditional in the `UnixFileSocketConnection` class. So it does not hurt to call connect() many times. However the subclass `QmpConnection` additionally handles QMP greeting, capabilities and supported commands. Since commit 5fa52d3630813001b4d4b797bcd79685dcc827ce the QMP connection is correctly marked as connected, the decorator `_ensure_connection` won't close it and further instances of `QmpConnection` will block / timeout. As a work around call connect() in the decorator only when not connected.

And while at it, close the connection if the greeting does not match a known key, instead of just setting the _connected flag.