### PR TITLE
Prepare Release 3.1.0 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,27 @@ News
 ====
 
 
+Version 3.1.0
+-------------
+
+*(Released Fri, 22 Aug 2025)*
+
+Changes since 3.1.0 rc2
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- various Haskell cleanups/improvements (#1857, #1858, #1859, #1860)
+- HTools: improve handling of N+1 violations in hbal (#1850)
+- KVM: fix QMP connection handling (#1855, #1862)
+- KVM: fix handling of -chroot parameter after cluster upgrades (#1853)
+- KVM: fix zombie socat processes crated by kvm-console-wrapper (#1848)
+- move-instance: fixes related to NIC configuration and hostname resolution errors  (#1843, #1844)
+- fix socat handling for use with gnt-backup (#1840)
+- Python 3.6 compatibility (#1838)
+- doc/rapi.rst: remove randomness, fix/allow reproducible builds (#1837)
+- daemon-util: remove pidfile(s) on stop (#1836)
+- fix rare "broken pipe" error in QMP communication during instance shutdown (#1866)
+
+
 Version 3.1.0 rc2
 -----------------
 
@@ -14,7 +35,7 @@ Changes since 3.1.0 rc1
 - various bugs related to `make dist / distcheck` have been fixed (which is
   the reason there never was an official -rc1 tarball) (#1833, #1834)
 - builds are now reproducible (#1831)
-- QA suite now default to RSA instead of DSA SSH keys (#1829)
+- QA suite now defaults to RSA instead of DSA SSH keys (#1829)
 - `--enable-regex-pcre-builtin` and `--enable-regex-tdfa` have been dropped from
   `./configure` and replaced by -`-with-haskell-pcre=auto|$library` (#1832)
 - support for the Haskell pcre2 library has been added (#1832)

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 m4_define([gnt_version_major], [3])
 m4_define([gnt_version_minor], [1])
 m4_define([gnt_version_revision], [0])
-m4_define([gnt_version_suffix], [~rc2])
+m4_define([gnt_version_suffix], [])
 m4_define([gnt_version_full],
           m4_format([%d.%d.%d%s],
                     gnt_version_major, gnt_version_minor,


### PR DESCRIPTION
Prepare release of final/stable version 3.1.0

@saschalucas @codefritzel @apoikos is there anything important missing from the `-rc2` that needs fixing before merging this?

Looking at the automated QA runs from the past days I see sometimes the KVM/DRBD QA run failing when trying to shutdown an instance:

> Could not shutdown instance 'kvm-test-instance02.staging.ganeti.org': Error while executing backend function: [Errno 32] Broken pipe

This happens at different stages of the QA run (sometimes 20 minutes in, sometimes after 5 hours). To put this into perspective: 8 out of 26 QA runs on Trixie failed with that error in the past weeks. 

I have opened #1865, but not sure if we should delay 3.1.0 any further. We can still ship 3.1.1 :-)