### PR TITLE
Add remove export to RAPI

### DIFF
--- a/doc/rapi.rst
+++ b/doc/rapi.rst
@@ -1645,7 +1645,7 @@ Manages exports.
 ``PUT``
 ~~~~~~~
 
-Create an exports of an instance.
+Create an export of an instance.
 
 Returns a job ID.
 

--- a/doc/rapi.rst
+++ b/doc/rapi.rst
@@ -1667,9 +1667,7 @@ Job result:
 
 Delete an export.
 
-Returns:
-
-``None``
+Returns: Id of created job
 
 Body parameters:
 

--- a/doc/rapi.rst
+++ b/doc/rapi.rst
@@ -1635,7 +1635,7 @@ Job result:
 ``/2/instances/[instance_name]/export``
 +++++++++++++++++++++++++++++++++++++++++++++++++
 
-Exports an instance.
+Manages exports.
 
 .. rapi_resource_details:: /2/instances/[instance_name]/export
 
@@ -1644,6 +1644,8 @@ Exports an instance.
 
 ``PUT``
 ~~~~~~~
+
+Create an exports of an instance.
 
 Returns a job ID.
 
@@ -1656,6 +1658,27 @@ Body parameters:
 Job result:
 
 .. opcode_result:: OP_BACKUP_EXPORT
+
+
+.. _rapi-res-instances-instance_name-export+delete:
+
+``DELETE``
+~~~~~~~~~~
+
+Delete an export.
+
+Returns:
+
+``None``
+
+Body parameters:
+
+.. opcode_params:: OP_BACKUP_REMOVE
+   :exclude: instance_name
+
+Job result:
+
+.. opcode_result:: OP_BACKUP_REMOVE
 
 
 .. _rapi-res-instances-instance_name-migrate:

--- a/lib/rapi/rlib2.py
+++ b/lib/rapi/rlib2.py
@@ -1493,6 +1493,7 @@ class R_2_instances_name_export(baserlib.OpcodeResource):
   PUT_RENAME = {
     "destination": "target_node",
     }
+  DELETE_OPCODE = opcodes.OpBackupRemove
 
   def GetPutOpInput(self):
     """Exports an instance.
@@ -1502,6 +1503,13 @@ class R_2_instances_name_export(baserlib.OpcodeResource):
       "instance_name": self.items[0],
       })
 
+  def GetDeleteOpInput(self):
+    """Deletes an export.
+
+    """
+    return (self.request_body, {
+      "instance_name": self.items[0],
+      })
 
 class R_2_instances_name_migrate(baserlib.OpcodeResource):
   """/2/instances/[instance_name]/migrate resource.

--- a/test/py/legacy/docs_unittest.py
+++ b/test/py/legacy/docs_unittest.py
@@ -53,7 +53,6 @@ VALID_URI_RE = re.compile(r"^[-/a-z0-9]*$")
 
 RAPI_OPCODE_EXCLUDE = compat.UniqueFrozenset([
   # Not yet implemented
-  opcodes.OpBackupRemove,
   opcodes.OpClusterConfigQuery,
   opcodes.OpClusterRepairDiskSizes,
   opcodes.OpClusterVerify,


### PR DESCRIPTION
Add HTTP DELETE to /2/instances/[instance_name]/export to remote a export e.g. created via HTTP PUT of the same path. This was previously available with `gnt-backup remove` , but not in the RAPI.

@saschalucas for review

Closes: #1867