### PR TITLE
make: allow C.utf8 alongside C.UTF-8

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,7 @@ EXTRA_DIST=
 SHELLTESTARGS = "-c"
 
 # Use C.UTF-8 for tests/checks when available, fall back to en_US.UTF-8 else
-UTF8_LOCALE := $(shell locale -a | grep -m 1 -xF "C.UTF-8" || echo "en_US.UTF-8")
+UTF8_LOCALE := $(shell locale -a | grep -m 1 -xF -e C.UTF-8 -e C.utf8 || echo en_US.UTF-8)
 
 ACLOCAL_AMFLAGS = -I autotools
 BUILD_BASH_COMPLETION = $(top_srcdir)/autotools/build-bash-completion

--- a/autotools/check-man-warnings
+++ b/autotools/check-man-warnings
@@ -29,11 +29,7 @@
 
 set -e
 
-if locale -a | grep -qF 'C.UTF-8'; then
-	loc="C.UTF-8"
-else
-	loc="en_US.UTF-8"
-fi
+loc="$(locale -a | grep -m 1 -xF -e C.UTF-8 -e C.utf8 || echo en_US.UTF-8)"
 
 ! LANG="$loc" LC_ALL="$loc" MANWIDTH=80 \
   man --warnings --encoding=utf8 --local-file "$1" 2>&1 >/dev/null | \


### PR DESCRIPTION
Since Debian glibc 2.34-1, the C.UTF-8 locale has been renamed to C.utf8 to match upstream naming. Update the grep command used to figure out the locale name to match against both names.

This patch is in [Debian](https://sources.debian.org/patches/ganeti/3.1.0~rc2-3/0003-make-allow-C.utf8-alongside-C.UTF-8.patch/), but missing upstream -> `./devel/release` fails without that.