### PR TITLE
allow non contraction of can't

### DIFF
--- a/autotools/check-man-warnings
+++ b/autotools/check-man-warnings
@@ -34,5 +34,5 @@ loc="$(locale -a | grep -m 1 -xF -e C.UTF-8 -e C.utf8 || echo en_US.UTF-8)"
 ! LANG="$loc" LC_ALL="$loc" MANWIDTH=80 \
   man --warnings --encoding=utf8 --local-file "$1" 2>&1 >/dev/null | \
   grep -v -e "cannot adjust line" -e "can't break line" \
-    -e "cannot select font" | \
+    -e "cannot select font" -e "cannot break line" | \
   grep .


### PR DESCRIPTION
Currently `troff` fails with variant: "troff: ... cannot break line". Allow both versions with and without contraction.