### PR TITLE
py-tests-legacy: fix invalid escape sequence

### DIFF
--- a/test/py/legacy/cmdlib/cluster_unittest.py
+++ b/test/py/legacy/cmdlib/cluster_unittest.py
@@ -216,7 +216,7 @@ class TestLUClusterDestroy(CmdlibTestCase):
     self.cfg.AddNewNode()
     self.cfg.AddNewNode()
 
-    self.ExecOpCodeExpectOpPrereqError(op, "still 2 node\(s\)")
+    self.ExecOpCodeExpectOpPrereqError(op, r"still 2 node\(s\)")
 
   def testExistingInstances(self):
     op = opcodes.OpClusterDestroy()
@@ -224,7 +224,7 @@ class TestLUClusterDestroy(CmdlibTestCase):
     self.cfg.AddNewInstance()
     self.cfg.AddNewInstance()
 
-    self.ExecOpCodeExpectOpPrereqError(op, "still 2 instance\(s\)")
+    self.ExecOpCodeExpectOpPrereqError(op, r"still 2 instance\(s\)")
 
   def testEmptyCluster(self):
     op = opcodes.OpClusterDestroy()
@@ -1134,7 +1134,9 @@ class TestLUClusterVerifyConfig(CmdlibTestCase):
     result = self.ExecOpCode(op)
 
     self.mcpu.assertLogContainsRegex(
-      "following nodes \(and their instances\) belong to a non existing group")
+      r"following nodes \(and their instances\) belong to a non "
+      r"existing group"
+    )
     self.assertFalse(result)
 
   def testDanglingInstance(self):
@@ -1795,7 +1797,9 @@ class TestLUClusterVerifyGroupVerifyInstance(TestLUClusterVerifyGroupMethods):
   def testOfflineSecondary(self, lu):
     self.node1_img.offline = True
     lu._VerifyInstance(self.drbd_inst, self.node_imgs, self.diskstatus)
-    self.mcpu.assertLogContainsRegex("instance has offline secondary node\(s\)")
+    self.mcpu.assertLogContainsRegex(
+      r"instance has offline secondary node\(s\)"
+    )
 
 
 class TestLUClusterVerifyGroupVerifyOrphanVolumes(

--- a/test/py/legacy/cmdlib/instance_unittest.py
+++ b/test/py/legacy/cmdlib/instance_unittest.py
@@ -2697,7 +2697,7 @@ class TestLUInstanceSetParams(CmdlibTestCase):
     self.ExecOpCodeExpectOpPrereqError(op, msg)
 
   def testAttachDiskWrongNodes(self):
-    msg = "Disk nodes are \['mock_node_1134'\]"
+    msg = r"Disk nodes are \['mock_node_1134'\]"
 
     self.cfg.AddOrphanDisk(name=self.mocked_disk_name,
                            primary_node="mock_node_1134")
@@ -3240,8 +3240,8 @@ class TestLUInstanceChangeGroup(CmdlibTestCase):
     op = self.CopyOpCode(self.op,
                          target_groups=[self.group.name])
     self.ExecOpCodeExpectOpPrereqError(
-      op, "Can't use group\(s\) .* as targets, they are used by the"
-          " instance .*")
+      op, r"Can't use group\(s\) .* as targets, they are used by the"
+          r" instance .*")
 
   def testNoTargetGroups(self):
     inst = self.cfg.AddNewInstance(disk_template=constants.DT_DRBD8,

--- a/test/py/legacy/docs_unittest.py
+++ b/test/py/legacy/docs_unittest.py
@@ -115,7 +115,7 @@ class TestHooksDocs(unittest.TestCase):
     assert len(lu2opcode) == len(mcpu.Processor.DISPATCH_TABLE), \
       "Found duplicate entries"
 
-    hooks_paths = frozenset(re.findall("^:directory:\s*(.+)\s*$", hooksdoc,
+    hooks_paths = frozenset(re.findall(r"^:directory:\s*(.+)\s*$", hooksdoc,
                                        re.M))
     self.assertTrue(self.HOOK_PATH_OK.issubset(hooks_paths),
                     msg="Whitelisted path not found in documentation")

--- a/test/py/legacy/ganeti.ovf_unittest.py
+++ b/test/py/legacy/ganeti.ovf_unittest.py
@@ -549,7 +549,7 @@ class TestOVFImporter(BetterUnitTest):
     self.importer = ovf.OVFImporter(self.ganeti_ovf, OPTS_EXPORT)
     disks_list = self.importer.ovf_reader.GetDisksNames()
     results = [self.importer._GetDiskQemuInfo("%s/%s" %
-      (self.importer.input_dir, path), "file format: (\S+)")
+      (self.importer.input_dir, path), r"file format: (\S+)")
       for (path, _) in disks_list]
     self.assertEqual(results, ["vmdk"])
 


### PR DESCRIPTION
Some legacy python tests include strings which later are used in re.search(), where special chars needs escaping. Currently a "SyntaxWarning: invalid escape sequence" is emitted. Fix this by double escape the backslash.