### PR TITLE
feat: add timeout param to rapi instance reboot & shutdown endpoint

### DIFF
--- a/doc/rapi.rst
+++ b/doc/rapi.rst
@@ -1374,8 +1374,8 @@ Reboots URI for an instance.
 
 Reboots the instance.
 
-The URI takes optional ``type=soft|hard|full`` and
-``ignore_secondaries=0|1`` parameters.
+The URI takes optional ``type=soft|hard|full``,
+``ignore_secondaries=0|1``and ``shutdown_timeout`` parameters.
 
 ``type`` defines the reboot type. ``soft`` is just a normal reboot,
 without terminating the hypervisor. ``hard`` means full shutdown
@@ -1386,6 +1386,10 @@ ground up as if you would have done a ``gnt-instance shutdown`` and
 
 ``ignore_secondaries`` is a bool argument indicating if we start the
 instance even if secondary disks are failing.
+
+``shutdown_timeout`` is an integer argument that specifies how
+long to wait before shutting down the instance. The default value is
+:pyeval:`constants.DEFAULT_SHUTDOWN_TIMEOUT`.
 
 It supports the ``dry-run`` argument.
 

--- a/lib/rapi/rlib2.py
+++ b/lib/rapi/rlib2.py
@@ -1268,6 +1268,9 @@ class R_2_instances_name_reboot(baserlib.OpcodeResource):
       "instance_name": self.items[0],
       "reboot_type":
         self.queryargs.get("type", [constants.INSTANCE_REBOOT_HARD])[0],
+      "shutdown_timeout": self._checkIntVariable(
+        "shutdown_timeout", constants.DEFAULT_SHUTDOWN_TIMEOUT
+      ),
       "ignore_secondaries": bool(self._checkIntVariable("ignore_secondaries")),
       "dry_run": self.dryRun(),
       })


### PR DESCRIPTION
The timeout during shutdown can now be passed to the RAPI, so the default can be overwritten and it is no longer necessary to wait 120 seconds.

The endpoint `/2/instances/[instance_name]/shutdown` gets `timeout` as new parameter and `/2/instances/[instance_name]/reboot` gets `shutdown_timeout`.