### PR TITLE
python-compatibiliy: for bitarray >=3 (part 2)

### DIFF
--- a/lib/utils/bitarray_compat.py
+++ b/lib/utils/bitarray_compat.py
@@ -35,23 +35,24 @@ With bitarray-3 the signature of search() has changed:
   new: search(sub_bitarray, start=0, stop=<end>, /, right=False)
          -> iterator
 """
-from __future__ import annotations
 from typing import Union, List
 from bitarray import bitarray as _BaseBitarray
 from ganeti import errors
 
 class CompatBitarray(_BaseBitarray):
   # constructor forwarding for immutable C-Extension types
-  def __new__(cls, *args, **kwargs):
+  def __new__(cls: "type[CompatBitarray]", *args, **kwargs) -> "CompatBitarray":
     return _BaseBitarray.__new__(cls, *args, **kwargs)
 
-  def search(self, sub_bitarray: Union[bitarray, int], *args) -> List[int]:
+  def search(self, sub_bitarray: Union[_BaseBitarray, int], *args) -> List[int]:
     # compatibility: accept at most one optional int (old 'limit')
     if len(args) > 1:
       raise errors.GenericError("The bitarray.search() compatibility only "
                                 "supports one optional argument")
 
-    limit = args[0] if args and isinstance(args[0], int) else None
+    limit = None
+    if args and isinstance(args[0], int):
+      limit = args[0]
 
     res = list(super().search(sub_bitarray))
     if limit is None:


### PR DESCRIPTION
As it turns out, the fix in commit
65574a9c08415d48af9e2e42c37f4fae517c7319 was incomplete. It handles only the return value of the signature change, but does not take care of the callers parameters. Commit ec714797092409db4200dfe07e4c66ad1b66284b introduces a new bus allocation abstraction layer, which hides the mismatch on the caller's parameters (by making relevant code paths obsolete).

An attempt to backport the bitarray >=3 compatibiliy fix to the stable-3.1 branch (i.e. for Debian Forky) unveils this problem. And while at it, make it Python 3.6 happy where Ganeti-3.1 should run, too.