### PR TITLE
multiple consoles can be managed

### DIFF
--- a/lib/backend.py
+++ b/lib/backend.py
@@ -2668,8 +2668,10 @@ def GetInstanceConsoleInfo(instance_param_dict,
     group = objects.NodeGroup.FromDict(group)
 
     h = get_hv_fn(instance.hypervisor)
-    output[inst_name] = h.GetInstanceConsole(instance, pnode, group,
-                                             hvparams, beparams).ToDict()
+    consoles = h.GetInstanceConsoles(instance, pnode, group,
+                                             hvparams, beparams)
+
+    output[inst_name] = [con.ToDict() for con in consoles]
 
   return output
 

--- a/lib/cli_opts.py
+++ b/lib/cli_opts.py
@@ -231,6 +231,7 @@ __all__ = [
   "SEQUENTIAL_OPT",
   "SHOW_MACHINE_OPT",
   "SHOWCMD_OPT",
+  "CONSOLE_TYPE_OPT",
   "SHUTDOWN_TIMEOUT_OPT",
   "SINGLE_NODE_OPT",
   "SPECS_CPU_COUNT_OPT",
@@ -944,6 +945,12 @@ COMMIT_OPT = cli_option("--commit", dest="commit",
 SHOWCMD_OPT = cli_option("--show-cmd", dest="show_command",
                          action="store_true", default=False,
                          help="Show command instead of executing it")
+
+CONSOLE_TYPE_OPT = cli_option("--type", dest="console_type",
+                              metavar="|".join(constants.CONS_ALL),
+                              choices=list(constants.CONS_ALL),
+                              default=constants.CONS_SSH,
+                              help="Preferred console type to use")
 
 CLEANUP_OPT = cli_option("--cleanup", dest="cleanup",
                          default=False, action="store_true",

--- a/lib/cmdlib/instance_operation.py
+++ b/lib/cmdlib/instance_operation.py
@@ -568,7 +568,7 @@ class LUInstanceReboot(LogicalUnit):
     self.cfg.MarkInstanceUp(self.instance.uuid)
 
 
-def GetInstanceConsole(cluster, instance, primary_node, node_group):
+def GetInstanceConsoles(cluster, instance, primary_node, node_group):
   """Returns console information for an instance.
 
   @type cluster: L{objects.Cluster}
@@ -583,13 +583,15 @@ def GetInstanceConsole(cluster, instance, primary_node, node_group):
   # instance and then saving the defaults in the instance itself.
   hvparams = cluster.FillHV(instance)
   beparams = cluster.FillBE(instance)
-  console = hyper.GetInstanceConsole(instance, primary_node, node_group,
+  consoles = hyper.GetInstanceConsoles(instance, primary_node, node_group,
                                      hvparams, beparams)
+  output = []
+  for console in consoles:
+    assert console.instance == instance.name
+    console.Validate()
+    output.append(console.ToDict())
 
-  assert console.instance == instance.name
-  console.Validate()
-
-  return console.ToDict()
+  return output
 
 
 class LUInstanceConsole(NoHooksLU):
@@ -645,5 +647,5 @@ class LUInstanceConsole(NoHooksLU):
 
     node = self.cfg.GetNodeInfo(self.instance.primary_node)
     group = self.cfg.GetNodeGroup(node.group)
-    return GetInstanceConsole(self.cfg.GetClusterInfo(),
+    return GetInstanceConsoles(self.cfg.GetClusterInfo(),
                               self.instance, node, group)

--- a/lib/hypervisor/hv_base.py
+++ b/lib/hypervisor/hv_base.py
@@ -49,7 +49,7 @@ dict is the same, see the docstring for L{BaseHypervisor.PARAMETERS}.
 import os
 import re
 import logging
-
+from typing import List
 
 from ganeti import constants
 from ganeti import errors
@@ -420,9 +420,9 @@ class BaseHypervisor(object):
     raise NotImplementedError
 
   @classmethod
-  def GetInstanceConsole(cls, instance, primary_node, node_group,
-                         hvparams, beparams):
-    """Return information for connecting to the console of an instance.
+  def GetInstanceConsoles(cls, instance, primary_node, node_group,
+                         hvparams, beparams) -> List[objects.InstanceConsole]:
+    """Return information for connecting all available consoles of an instance.
 
     """
     raise NotImplementedError

--- a/lib/hypervisor/hv_chroot.py
+++ b/lib/hypervisor/hv_chroot.py
@@ -36,6 +36,7 @@ import os
 import os.path
 import time
 import logging
+from typing import List
 
 from ganeti import constants
 from ganeti import errors # pylint: disable=W0611
@@ -276,8 +277,9 @@ class ChrootManager(hv_base.BaseHypervisor):
     return self.GetLinuxNodeInfo()
 
   @classmethod
-  def GetInstanceConsole(cls, instance, primary_node, # pylint: disable=W0221
-                         node_group, hvparams, beparams, root_dir=None):
+  def GetInstanceConsoles(cls, instance, primary_node, # pylint: disable=W0221
+                         node_group, hvparams, beparams, root_dir=None)\
+          -> List[objects.InstanceConsole]:
     """Return information for connecting to the console of an instance.
 
     """
@@ -287,12 +289,12 @@ class ChrootManager(hv_base.BaseHypervisor):
         raise HypervisorError("Instance %s is not running" % instance.name)
 
     ndparams = node_group.FillND(primary_node)
-    return objects.InstanceConsole(instance=instance.name,
+    return [objects.InstanceConsole(instance=instance.name,
                                    kind=constants.CONS_SSH,
                                    host=primary_node.name,
                                    port=ndparams.get(constants.ND_SSH_PORT),
                                    user=constants.SSH_CONSOLE_USER,
-                                   command=["chroot", root_dir, "/bin/sh"])
+                                   command=["chroot", root_dir, "/bin/sh"])]
 
   def Verify(self, hvparams=None):
     """Verify the hypervisor.

--- a/lib/hypervisor/hv_fake.py
+++ b/lib/hypervisor/hv_fake.py
@@ -35,6 +35,7 @@
 import os
 import os.path
 import logging
+from typing import List
 
 from ganeti import utils
 from ganeti import constants
@@ -240,15 +241,15 @@ class FakeHypervisor(hv_base.BaseHypervisor):
     return result
 
   @classmethod
-  def GetInstanceConsole(cls, instance, primary_node, node_group,
-                         hvparams, beparams):
+  def GetInstanceConsoles(cls, instance, primary_node, node_group,
+                         hvparams, beparams) -> List[objects.InstanceConsole]:
     """Return information for connecting to the console of an instance.
 
     """
-    return objects.InstanceConsole(instance=instance.name,
+    return [objects.InstanceConsole(instance=instance.name,
                                    kind=constants.CONS_MESSAGE,
                                    message=("Console not available for fake"
-                                            " hypervisor"))
+                                            " hypervisor"))]
 
   def Verify(self, hvparams=None):
     """Verify the hypervisor.

--- a/lib/hypervisor/hv_lxc.py
+++ b/lib/hypervisor/hv_lxc.py
@@ -38,6 +38,7 @@ import os.path
 import logging
 import sys
 import re
+from typing import List
 
 from ganeti import constants
 from ganeti import errors # pylint: disable=W0611
@@ -937,18 +938,19 @@ class LXCHypervisor(hv_base.BaseHypervisor):
     return self.GetLinuxNodeInfo()
 
   @classmethod
-  def GetInstanceConsole(cls, instance, primary_node, node_group,
-                         hvparams, beparams):
+  def GetInstanceConsoles(cls, instance, primary_node, node_group,
+                         hvparams, beparams) -> List[objects.InstanceConsole]:
     """Return a command for connecting to the console of an instance.
 
     """
     ndparams = node_group.FillND(primary_node)
-    return objects.InstanceConsole(instance=instance.name,
+    return [objects.InstanceConsole(instance=instance.name,
                                    kind=constants.CONS_SSH,
                                    host=primary_node.name,
                                    port=ndparams.get(constants.ND_SSH_PORT),
                                    user=constants.SSH_CONSOLE_USER,
-                                   command=["lxc-console", "-n", instance.name])
+                                   command=["lxc-console", "-n",
+                                            instance.name])]
 
   @classmethod
   def _GetLXCVersionFromCmd(cls, from_cmd):

--- a/lib/hypervisor/hv_xen.py
+++ b/lib/hypervisor/hv_xen.py
@@ -39,6 +39,7 @@ import string # pylint: disable=W0402
 import shutil
 import time
 from io import StringIO
+from typing import List
 
 from ganeti import constants
 from ganeti import errors
@@ -1127,19 +1128,19 @@ class XenHypervisor(hv_base.BaseHypervisor):
     return _GetNodeInfo(result.stdout, instance_list)
 
   @classmethod
-  def GetInstanceConsole(cls, instance, primary_node, node_group,
-                         hvparams, beparams):
+  def GetInstanceConsoles(cls, instance, primary_node, node_group,
+                         hvparams, beparams) -> List[objects.InstanceConsole]:
     """Return a command for connecting to the console of an instance.
 
     """
     ndparams = node_group.FillND(primary_node)
-    return objects.InstanceConsole(instance=instance.name,
+    return [objects.InstanceConsole(instance=instance.name,
                                    kind=constants.CONS_SSH,
                                    host=primary_node.name,
                                    port=ndparams.get(constants.ND_SSH_PORT),
                                    user=constants.SSH_CONSOLE_USER,
                                    command=[pathutils.XEN_CONSOLE_WRAPPER,
-                                            XEN_COMMAND, instance.name])
+                                            XEN_COMMAND, instance.name])]
 
   def Verify(self, hvparams=None):
     """Verify the hypervisor.

--- a/lib/query.py
+++ b/lib/query.py
@@ -1990,7 +1990,7 @@ def _GetInstDiskUsage(ctx, inst):
   return usage
 
 
-def _GetInstanceConsole(ctx, inst):
+def _GetInstanceConsoles(ctx, inst):
   """Get console information for instance.
 
   @type ctx: L{InstanceQueryData}
@@ -2230,8 +2230,8 @@ def _BuildInstanceFields():
     (_MakeField("tags", "Tags", QFT_OTHER, "Tags"), IQ_CONFIG, 0,
      lambda ctx, inst: list(inst.GetTags())),
     (_MakeField("console", "Console", QFT_OTHER,
-                "Instance console information"), IQ_CONSOLE, 0,
-     _GetInstanceConsole),
+                "List of possible consoles for the instance"), IQ_CONSOLE, 0,
+     _GetInstanceConsoles),
     (_MakeField("forthcoming", "Forthcoming", QFT_BOOL,
                 "Whether the Instance is forthcoming"), IQ_CONFIG, 0,
      lambda _, inst: bool(inst.forthcoming)),

--- a/lib/rapi/client.py
+++ b/lib/rapi/client.py
@@ -1473,8 +1473,9 @@ class GanetiRapiClient(object): # pylint: disable=R0904
     @param instance: Instance name
     @type reason: string
     @param reason: the reason for executing this operation
-    @rtype: dict
-    @return: dictionary containing information about instance's console
+    @rtype: list
+    @return: list of dictionaries containing information about available
+        instance consoles
 
     """
     query = []

--- a/lib/rapi/rlib2.py
+++ b/lib/rapi/rlib2.py
@@ -1646,15 +1646,15 @@ class R_2_instances_name_console(baserlib.ResourceBase):
     instance_name = self.items[0]
     client = self.GetClient()
 
-    (console, oper_state) = \
+    (consoles, oper_state) = \
       client.QueryInstances([instance_name], ["console", "oper_state"],
                             False)[0]
 
     if not oper_state:
       raise http.HttpServiceUnavailable("Instance console unavailable")
 
-    assert isinstance(console, dict)
-    return console
+    assert isinstance(consoles, list)
+    return consoles
 
 
 def _GetQueryFields(args):

--- a/qa/qa_rapi.py
+++ b/qa/qa_rapi.py
@@ -1149,9 +1149,11 @@ def TestRapiInstanceModify(instance):
 def TestRapiInstanceConsole(instance):
   """Test getting instance console information via RAPI"""
   result = _rapi_client.GetInstanceConsole(instance.name)
-  console = objects.InstanceConsole.FromDict(result)
-  AssertEqual(console.Validate(), None)
-  AssertEqual(console.instance, qa_utils.ResolveInstanceName(instance.name))
+
+  for console_item in result:
+    console = objects.InstanceConsole.FromDict(console_item)
+    AssertEqual(console.Validate(), None)
+    AssertEqual(console.instance, qa_utils.ResolveInstanceName(instance.name))
 
 
 @InstanceCheck(INST_DOWN, INST_DOWN, FIRST_ARG)

--- a/src/Ganeti/Rpc.hs
+++ b/src/Ganeti/Rpc.hs
@@ -485,11 +485,11 @@ $(buildObject "InstanceConsoleInfo" "instConsInfo"
   , optionalField $
     simpleField "command"     [t| [String] |]
   , optionalField $
-    simpleField "display"     [t| String |]
+    simpleField "display"     [t| Int |]
   ])
 
 $(buildObject "RpcResultInstanceConsoleInfo" "rpcResInstConsInfo"
-  [ simpleField "instancesInfo" [t| [(String, InstanceConsoleInfo)] |] ])
+  [ simpleField "instancesInfo" [t| [(String, [InstanceConsoleInfo])] |] ])
 
 instance RpcCall RpcCallInstanceConsoleInfo where
   rpcCallName _          = "instance_console_info"
@@ -503,8 +503,8 @@ instance Rpc RpcCallInstanceConsoleInfo RpcResultInstanceConsoleInfo where
     case res of
       J.JSObject res' ->
         let res'' = map (second J.readJSON) (J.fromJSObject res')
-                        :: [(String, J.Result InstanceConsoleInfo)] in
-        case sanitizeDictResults res'' of
+                        :: [(String, J.Result [InstanceConsoleInfo])]
+        in case sanitizeDictResults res'' of
           Left err -> Left err
           Right instInfos -> Right $ RpcResultInstanceConsoleInfo instInfos
       _ -> Left $ JsonDecodeError

--- a/test/py/legacy/ganeti.backend_unittest.py
+++ b/test/py/legacy/ganeti.backend_unittest.py
@@ -713,12 +713,12 @@ class TestInstanceConsoleInfo(unittest.TestCase):
 
   def setUp(self):
     self._test_hv_a = self._TestHypervisor()
-    self._test_hv_a.GetInstanceConsole = mock.Mock(
-      return_value = objects.InstanceConsole(instance="inst", kind="aHy")
+    self._test_hv_a.GetInstanceConsoles = mock.Mock(
+      return_value = [objects.InstanceConsole(instance="inst", kind="aHy")]
     )
     self._test_hv_b = self._TestHypervisor()
-    self._test_hv_b.GetInstanceConsole = mock.Mock(
-      return_value = objects.InstanceConsole(instance="inst", kind="bHy")
+    self._test_hv_b.GetInstanceConsoles = mock.Mock(
+      return_value = [objects.InstanceConsole(instance="inst", kind="bHy")]
     )
 
   class _TestHypervisor(hypervisor.hv_base.BaseHypervisor):
@@ -747,8 +747,8 @@ class TestInstanceConsoleInfo(unittest.TestCase):
 
     res = backend.GetInstanceConsoleInfo(call, get_hv_fn=self._GetHypervisor)
 
-    self.assertTrue(res["i1"]["kind"] == "aHy")
-    self.assertTrue(res["i2"]["kind"] == "bHy")
+    self.assertEqual("aHy", res["i1"][0]["kind"])
+    self.assertEqual("bHy", res["i2"][0]["kind"])
 
 
 class TestGetHvInfo(unittest.TestCase):

--- a/test/py/legacy/ganeti.hypervisor.hv_chroot_unittest.py
+++ b/test/py/legacy/ganeti.hypervisor.hv_chroot_unittest.py
@@ -55,9 +55,12 @@ class TestConsole(unittest.TestCase):
                                 primary_node="node837-uuid")
     node = objects.Node(name="node837", uuid="node837-uuid", ndparams={})
     group = objects.NodeGroup(name="group164", ndparams={})
-    cons = hv_chroot.ChrootManager.GetInstanceConsole(instance, node, group,
-                                                      {}, {},
-                                                      root_dir=self.tmpdir)
+    consoles = hv_chroot.ChrootManager.GetInstanceConsoles(instance, node,
+                                                    group, {}, {},
+                                                    root_dir=self.tmpdir)
+    self.assertEqual(len(consoles), 1)
+    cons = consoles[0]
+
     self.assertEqual(cons.Validate(), None)
     self.assertEqual(cons.kind, constants.CONS_SSH)
     self.assertEqual(cons.host, node.name)

--- a/test/py/legacy/ganeti.hypervisor.hv_fake_unittest.py
+++ b/test/py/legacy/ganeti.hypervisor.hv_fake_unittest.py
@@ -46,8 +46,10 @@ class TestConsole(unittest.TestCase):
     instance = objects.Instance(name="fake.example.com")
     node = objects.Node(name="fakenode.example.com", ndparams={})
     group = objects.NodeGroup(name="default", ndparams={})
-    cons = hv_fake.FakeHypervisor.GetInstanceConsole(instance, node, group,
+    consoles = hv_fake.FakeHypervisor.GetInstanceConsoles(instance, node, group,
                                                      {}, {})
+    self.assertEqual(len(consoles), 1)
+    cons = consoles[0]
     self.assertEqual(cons.Validate(), None)
     self.assertEqual(cons.kind, constants.CONS_MESSAGE)
 

--- a/test/py/legacy/ganeti.hypervisor.hv_lxc_unittest.py
+++ b/test/py/legacy/ganeti.hypervisor.hv_lxc_unittest.py
@@ -95,8 +95,11 @@ class TestConsole(unittest.TestCase):
     node = objects.Node(name="node199", uuid="node199-uuid",
                         ndparams={})
     group = objects.NodeGroup(name="group991", ndparams={})
-    cons = hv_lxc.LXCHypervisor.GetInstanceConsole(instance, node, group,
+    consoles = hv_lxc.LXCHypervisor.GetInstanceConsoles(instance, node, group,
                                                    {}, {})
+    self.assertEqual(len(consoles), 1)
+    cons = consoles[0]
+
     self.assertEqual(cons.Validate(), None)
     self.assertEqual(cons.kind, constants.CONS_SSH)
     self.assertEqual(cons.host, node.name)

--- a/test/py/legacy/ganeti.hypervisor.hv_xen_unittest.py
+++ b/test/py/legacy/ganeti.hypervisor.hv_xen_unittest.py
@@ -65,7 +65,10 @@ class TestConsole(unittest.TestCase):
       node = objects.Node(name="node24828", uuid="node24828-uuid",
                           ndparams={})
       group = objects.NodeGroup(name="group52341", ndparams={})
-      cons = cls.GetInstanceConsole(instance, node, group, hvparams, {})
+      consoles = cls.GetInstanceConsoles(instance, node, group, hvparams, {})
+      self.assertEqual(len(consoles), 1)
+      cons = consoles[0]
+
       self.assertEqual(cons.Validate(), None)
       self.assertEqual(cons.kind, constants.CONS_SSH)
       self.assertEqual(cons.host, node.name)


### PR DESCRIPTION
The `GetInstanceConsole` function in the hypervisor has been changed to `GetInstanceConsoles` and can now return all available instance consoles and their connection information. The backend, Luxi, RAPI, and gnt-instance console have also been modified.

RAPI (/2/instances/[instance_name]/console) now returns all available consoles.

gnt-instance console behaves as before. SSH is used by default. With the new parameter `--type`, the console can be changed so that the console information is displayed, for example, `gnt-instance console -type vnc <instance-name>`. Previously, only SSH was displayed because it was the first possible console.

closes #1885

---
The Haskell part was created with the help of AI.


The console type msg could now also be removed, as it is no longer necessary. It was used when no console was available in KVM.