### PR TITLE
Add export capacity and disk usage query fields

### DIFF
--- a/lib/backend.py
+++ b/lib/backend.py
@@ -4623,17 +4623,45 @@ def ExportInfo(dest):
   return config.Dumps()
 
 
-def ListExports():
+def ListExports(calc_du: bool = False):
   """Return a list of exports currently available on this machine.
 
-  @rtype: list
-  @return: list of the exports
+  @rtype: list[dict]
+  @return: list of dictionaries containing
+  export name, export_path and export_du in mebibytes
 
   """
+  output = []
+
   if os.path.isdir(pathutils.EXPORT_DIR):
-    return sorted(utils.ListVisibleFiles(pathutils.EXPORT_DIR))
+    exports = sorted(utils.ListVisibleFiles(pathutils.EXPORT_DIR))
+    for export in exports:
+      path = os.path.join(pathutils.EXPORT_DIR, export)
+      export_info = {
+        "name": export,
+        "export_path": path
+      }
+      # calc size only if requested
+      if calc_du:
+        export_info["export_du"] = utils.CalculateDirectorySize(path)
+      output.append(export_info)
+
+    return output
   else:
     _Fail("No exports directory")
+
+
+def GetNodeExportCapacityInfo():
+  """Get export capacity information from the node.
+
+  @rtype: dict
+  @return: dict with export_dtotal and export_dfree
+  """
+
+  return {
+    "export_dtotal": utils.CalculateDirectorySize(pathutils.EXPORT_DIR),
+    "export_dfree": utils.GetFilesystemStats(pathutils.EXPORT_DIR)[1]
+  }
 
 
 def RemoveExport(export):

--- a/lib/rpc_defs.py
+++ b/lib/rpc_defs.py
@@ -348,7 +348,9 @@ _IMPEXP_CALLS = [
     ("instance", ED_INST_DICT, None),
     ("snap_disks", ED_FINALIZE_EXPORT_DISKS, None),
     ], None, None, "Request the completion of an export operation"),
-  ("export_list", MULTI, None, constants.RPC_TMO_FAST, [], None, None,
+  ("export_list", MULTI, None, constants.RPC_TMO_FAST, [
+    ("calc_du", None, "Whether to calculate disk usage for exports"),
+    ], None, None,
    "Gets the stored exports list"),
   ("export_remove", SINGLE, None, constants.RPC_TMO_FAST, [
     ("export", None, None),
@@ -523,6 +525,8 @@ _NODE_CALLS = [
     ], None, None, "Request verification of given parameters"),
   ("node_volumes", MULTI, None, constants.RPC_TMO_FAST, [], None, None,
    "Gets all volumes on node(s)"),
+  ("node_export_capacity_info", MULTI, None, constants.RPC_TMO_FAST, [], None,
+   None, "Gets a node export capacity information"),
   ("node_demote_from_mc", SINGLE, None, constants.RPC_TMO_FAST, [], None, None,
    "Demote a node from the master candidate role"),
   ("node_powercycle", SINGLE, ACCEPT_OFFLINE_NODE, constants.RPC_TMO_NORMAL, [

--- a/lib/server/noded.py
+++ b/lib/server/noded.py
@@ -529,7 +529,14 @@ class NodeRequestHandler(http.server.HttpServerHandler):
     (pathutils.EXPORT_DIR).
 
     """
-    return backend.ListExports()
+    calc_du = params[0] if params else False
+    return backend.ListExports(calc_du=calc_du)
+
+  @staticmethod
+  def perspective_node_export_capacity_info(params):
+    """Gets a node export capacity information."""
+
+    return backend.GetNodeExportCapacityInfo()
 
   @staticmethod
   def perspective_export_remove(params):

--- a/src/Ganeti/Query/Export.hs
+++ b/src/Ganeti/Query/Export.hs
@@ -46,10 +46,14 @@ import Ganeti.Query.Language
 import Ganeti.Query.Common
 import Ganeti.Query.Types
 
--- | The parsed result of the ExportList. This is a bit tricky, in
--- that we already do parsing of the results in the RPC calls, so the
--- runtime type is a plain 'ResultEntry', as we have just one type.
-type Runtime = ResultEntry
+-- | The parsed result of the ExportList. We keep the runtime as a tuple
+-- of the exported name (as a 'ResultEntry'), the 'export_path' and an optional
+-- 'export_du' (in mebibytes). This preserves the previous behaviour
+type Runtime = (ResultEntry, String, Maybe Int)
+
+-- | Fields that require disk usage calculation.
+exportDuFields :: [String]
+exportDuFields = ["export_du"]
 
 -- | Small helper for rpc to rs.
 rpcErrToRs :: RpcError -> ResultEntry
@@ -57,19 +61,44 @@ rpcErrToRs err = ResultEntry (rpcErrorToStatus err) Nothing
 
 -- | Helper for extracting fields from RPC result.
 rpcExtractor :: Node -> Either RpcError RpcResultExportList
-             -> [(Node, ResultEntry)]
+             -> [(Node, Runtime)]
 rpcExtractor node (Right res) =
-  [(node, rsNormal path) | path <- rpcResExportListExports res]
-rpcExtractor node (Left err)  = [(node, rpcErrToRs err)]
+  [ (node, ( rsNormal (exportInfoName e)
+           , exportInfoExportPath e
+           , exportInfoExportDu e))
+    | e <- rpcResExportListExports res ]
+rpcExtractor node (Left err)  = [(node, (rpcErrToRs err, "", Nothing))]
 
--- | List of all node fields.
+-- | List of all export fields.
 exportFields :: FieldList Node Runtime
 exportFields =
-  [ (FieldDefinition "node" "Node" QFTText "Node name",
+  [ (FieldDefinition "node" "Node" QFTText
+     "Node name",
      FieldRuntime (\_ n -> rsNormal $ nodeName n), QffHostname)
-  , (FieldDefinition "export" "Export" QFTText "Export name",
-     FieldRuntime (curry fst), QffNormal)
+  , (FieldDefinition "export" "Export" QFTText
+     "Export name",
+     FieldRuntime (\(rt, _, _) _ -> rt), QffNormal)
+  , (FieldDefinition "export_path" "ExpPath" QFTText
+     "Export path on disk",
+     FieldRuntime exportPathFieldExtract, QffNormal)
+  , (FieldDefinition "export_du" "ExpDUsage" QFTUnit
+     "Used size on disk for the export",
+     FieldRuntime exportDuFieldExtract, QffNormal)
   ]
+
+-- | Extract the export path from runtime data.
+exportPathFieldExtract :: Runtime -> Node -> ResultEntry
+exportPathFieldExtract (rt, path, _) _ =
+  case rentryStatus rt of
+    RSNormal -> rsNormal path
+    _        -> rsUnavail
+
+-- | Extract the export disk usage from runtime data.
+exportDuFieldExtract :: Runtime -> Node -> ResultEntry
+exportDuFieldExtract (rt, _, du) _ =
+  case (rentryStatus rt, du) of
+    (RSNormal, Just d) -> rsNormal d
+    _                  -> rsUnavail
 
 -- | The node fields map.
 fieldsMap :: FieldMap Node Runtime
@@ -80,9 +109,12 @@ fieldsMap = fieldListToFieldMap exportFields
 -- Note that this function is \"funny\": the returned rows will not be
 -- 1:1 with the input, as nodes without exports will be pruned,
 -- whereas nodes with multiple exports will be listed multiple times.
-collectLiveData:: Bool -> ConfigData -> [Node] -> IO [(Node, Runtime)]
-collectLiveData False _ nodes =
-  return [(n, rpcErrToRs $ RpcResultError "Live data disabled") | n <- nodes]
-collectLiveData True _ nodes =
+collectLiveData:: Bool -> ConfigData -> [String] -> [Node]
+              -> IO [(Node, Runtime)]
+collectLiveData False _ _ nodes =
+  return [(n, (rpcErrToRs $ RpcResultError "Live data disabled", "", Nothing))
+          | n <- nodes]
+collectLiveData True _ fields nodes = do
+  let calc_du = any (`elem` fields) exportDuFields
   concatMap (uncurry rpcExtractor) `liftM`
-    executeRpcCall nodes RpcCallExportList
+    executeRpcCall nodes (RpcCallExportList calc_du)

--- a/src/Ganeti/Query/Query.hs
+++ b/src/Ganeti/Query/Query.hs
@@ -332,7 +332,7 @@ queryInner cfg live (Query (ItemTypeOpCode QRNetwork) fields qfilter) wanted =
                configNetworks getNetwork cfg live fields qfilter wanted
 
 queryInner cfg live (Query (ItemTypeOpCode QRExport) fields qfilter) wanted =
-  genericQuery Export.fieldsMap (CollectorSimple Export.collectLiveData)
+  genericQuery Export.fieldsMap (CollectorFieldAware Export.collectLiveData)
                nodeName configNodes getNode cfg live fields qfilter wanted
 
 queryInner cfg live (Query (ItemTypeLuxi QRFilter) fields qfilter) wanted =

--- a/src/Ganeti/Rpc.hs
+++ b/src/Ganeti/Rpc.hs
@@ -95,7 +95,11 @@ module Ganeti.Rpc
   , RpcResultTestDelay(..)
 
   , RpcCallExportList(..)
+  , ExportInfo(..)
   , RpcResultExportList(..)
+
+  , RpcCallNodeExportCapacityInfo(..)
+  , RpcResultNodeExportCapacityInfo(..)
 
   , RpcCallJobqueueUpdate(..)
   , RpcCallJobqueueRename(..)
@@ -647,21 +651,54 @@ instance Rpc RpcCallTestDelay RpcResultTestDelay where
 
 -- | Call definition for export list.
 
-$(buildObject "RpcCallExportList" "rpcCallExportList" [])
+$(buildObject "RpcCallExportList" "rpcCallExportList"
+  [ simpleField "calc_du" [t| Bool |]
+  ])
+
+-- | Export entry returned by the node for each export.
+$(buildObject "ExportInfo" "exportInfo"
+  [ simpleField "name" [t| String |]
+  , simpleField "export_path" [t| String |]
+  , optionalField $ simpleField "export_du" [t| Int |]
+  ])
 
 -- | Result definition for export list.
-$(buildObject "RpcResultExportList" "rpcResExportList"
-  [ simpleField "exports" [t| [String] |]
-  ])
+newtype RpcResultExportList = RpcResultExportList
+  { rpcResExportListExports :: [ExportInfo] }
+  deriving (Show, Eq)
+
+instance J.JSON RpcResultExportList where
+  showJSON (RpcResultExportList xs) = J.showJSON xs
+  readJSON = fmap RpcResultExportList . J.readJSON
 
 instance RpcCall RpcCallExportList where
   rpcCallName _          = "export_list"
   rpcCallTimeout _       = rpcTimeoutToRaw Fast
   rpcCallAcceptOffline _ = False
-  rpcCallData            = J.encode
 
 instance Rpc RpcCallExportList RpcResultExportList where
-  rpcResultFill _ res = fromJSValueToRes res RpcResultExportList
+  rpcResultFill _ res = fromJSValueToRes res id
+
+-- ** NodeExportCapacityInfo
+
+-- | Call definition for node export capacity info.
+$(buildObject "RpcCallNodeExportCapacityInfo" "rpcCallNodeExportCapacityInfo"
+  [])
+
+-- | Result definition for node export capacity info.
+$(buildObject "RpcResultNodeExportCapacityInfo" "rpcResNodeExportCapacityInfo"
+  [ simpleField "export_dtotal" [t| Int |]
+  , simpleField "export_dfree" [t| Int |]
+  ])
+
+instance RpcCall RpcCallNodeExportCapacityInfo where
+  rpcCallName _          = "node_export_capacity_info"
+  rpcCallTimeout _       = rpcTimeoutToRaw Fast
+  rpcCallAcceptOffline _ = False
+  rpcCallData _          = J.encode ()
+
+instance Rpc RpcCallNodeExportCapacityInfo RpcResultNodeExportCapacityInfo where
+  rpcResultFill _ res = fromJSValueToRes res id
 
 -- ** Job Queue Replication
 


### PR DESCRIPTION
Introduce new query fields for monitoring export storage:

Node fields:
- export_dtotal: Total disk space available for exports
- export_dfree: Free disk space available for exports

Export fields:
- export_du: Disk usage of individual exports
- export_path: Filesystem path of the export

The export_du field is only calculated when explicitly requested (e.g., "gnt-backup list -o +export_du") to avoid expensive disk usage calculations during regular list operations. This is controlled via the calc_du parameter in the export_list RPC call.

Similarly, the node export capacity fields (export_dtotal, export_dfree) are only queried when requested, using a separate RPC call (node_export_capacity_info). This separation allows for potential future integration with export operations.

The implementation follows the existing pattern used for instance live data collection, where RPC calls are conditionally executed based on the requested query fields.

closes #1874
___
The Haskell part was created with the help of AI.