### PR TITLE
doc: add RAPI instance reboot opcode parameters

### DIFF
--- a/doc/rapi.rst
+++ b/doc/rapi.rst
@@ -1389,6 +1389,9 @@ instance even if secondary disks are failing.
 
 It supports the ``dry-run`` argument.
 
+.. opcode_params:: OP_INSTANCE_REBOOT
+   :exclude: instance_name, dry_run
+
 Job result:
 
 .. opcode_result:: OP_INSTANCE_REBOOT


### PR DESCRIPTION
While discussing PR #1883, it turns [out,](https://github.com/ganeti/ganeti/pull/1883#issuecomment-3614910687) that only the documentation of the RAPI instance reboot opcode parameters (i.e. `shutdown_timeout`) are missing.