### PR TITLE
Update devcontainers config to use trixie and sane ulimits

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,10 @@
 {
     "name": "Ganeti Dev Container",
-    "image": "docker.io/ganeti/ci:bookworm-py3",
-
+    "image": "docker.io/ganeti/ci:trixie-py3",
+    "init": true,
+    "runArgs": [
+      "--ulimit", "nofile=1024:4096"
+    ],
     "customizations":{
         "vscode": {
             "extensions": [


### PR DESCRIPTION
This commits updats the devcontainers config from using the Debian Bookworm image to using Debian Trixie.

It also sets a sane ulimit on open files, as the Docker daemon is started with a _very_ high number of max-open-files on some distributions. This breaks some unit tests which are stuck for hours enumerating/checking all possible file descriptors.

Example from a Debian container started on a Debian Trixie Container:
```shell
# ulimit -n
2147483584
```