### PR TITLE
Generally exclude dotfolders from check-dirs Makefile target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -405,14 +405,7 @@ DIRCHECK_EXCLUDE = \
 	doc/html/_* \
 	doc/man-html/_* \
 	tools/shebang \
-	autom4te.cache \
-	.devcontainer \
-	.idea \
-	.idea/* \
-	.vscode \
-	.vscode/* \
-	.github \
-	.github/workflows
+	autom4te.cache 
 
 # some helper vars
 COVERAGE_DIR = doc/coverage
@@ -2618,7 +2611,7 @@ ganeti:
 .PHONY: check-dirs
 check-dirs: $(GENERATED_FILES)
 	@set -e; \
-	find . -type d \( -name . -o -name .git -prune -o -print \) | { \
+	find . -type d -not -path '*/.*' -a -not -path '.' -a -not -path '*/__pycache__' -print | { \
 	  error=; \
 	  while read dir; do \
 	    case "$$dir" in \


### PR DESCRIPTION
`make check-local` executes the `check-dirs` target to find any folders not defined/listed in the Makefile. The `find` command used has a static exclusion for the `.git` folder already and the `Makefile.am` also has a defined list of folders to include (which is somewhat redundant/inconsistently handled).

However, during local development tools may create more (temporary) local dotfolders and instead of listing all of the possible folders here, we simply exclude them in the `find` command the Makefile invokes.

We can also remove all listed dotfolders from the list of exceptions in `Makefile.am`.

This is only a "quality-of-life" improvement for the local development process. It does not have any impact on the actual build process, tests etc.