### PR TITLE
Add explicit IDE bus/unit allocation for KVM instances

### DIFF
--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -373,6 +373,11 @@ disk\_type
     - mtd (KVM)
     - pflash (KVM)
 
+    When set to ``ide``, devices are automatically assigned to IDE bus
+    slots in order: primary-master (ide.0, unit 0), primary-slave
+    (ide.0, unit 1), secondary-master (ide.1, unit 0), secondary-slave
+    (ide.1, unit 1). A maximum of 4 IDE devices (including CDROMs) is
+    supported.
 
 cdrom\_disk\_type
     Valid for the KVM hypervisor.
@@ -388,6 +393,8 @@ cdrom\_disk\_type
     - mtd
     - pflash
 
+    When set to ``ide``, CDROMs are allocated to IDE bus slots after
+    any IDE hard drives.
 
 vnc\_bind\_address
     Valid for the Xen HVM and KVM hypervisors.


### PR DESCRIPTION
Recent QEMU versions have changed the default IDE bus assignment, placing IDE devices on the secondary bus instead of the primary. This causes very old FreeBSD VMs (plus anything else that doesn't support modern UUID based disk detection) to fail to boot properly. Add deterministic bus/unit assignment to all IDE devices (hard drives and CDROMs) so placement is consistent across all QEMU versions: primary-master, primary-slave, secondary-master, secondary-slave.

 ## Changes
   - `lib/hypervisor/hv_kvm/__init__.py`: Add `_GetIDEBusUnit()` helper, update `_GenerateKVMBlockDevicesOptions()`,
   `_CdromOption()`, and `_GenerateKVMRuntime()` to assign IDE bus/unit parameters
   - `man/gnt-instance.rst`: Document IDE bus slot assignment under `disk_type` and `cdrom_disk_type`

   ## QEMU output before/after (1 IDE disk + 1 IDE CDROM)

   **Before:**
   ```
   -device ide-hd,drive=disk-abc,write-cache=on
   -device ide-cd,drive=cdrom1
   ```

   **After:**
   ```
   -device ide-hd,bus=ide.0,unit=0,drive=disk-abc,write-cache=on
   -device ide-cd,bus=ide.0,unit=1,drive=cdrom1
   ```