### PR TITLE
Make minimum VG size a configurable cluster parameter

### DIFF
--- a/lib/cli_opts.py
+++ b/lib/cli_opts.py
@@ -144,6 +144,7 @@ __all__ = [
   "MAX_TRACK_OPT",
   "MC_OPT",
   "MIGRATION_MODE_OPT",
+  "MIN_VG_SIZE_OPT",
   "MODIFY_ETCHOSTS_OPT",
   "NET_OPT",
   "NETWORK6_OPT",
@@ -1356,6 +1357,13 @@ RESERVED_LVS_OPT = cli_option("--reserved-lvs", default=None,
                               help=("A comma-separated list of reserved"
                                     " logical volumes names, that will be"
                                     " ignored by cluster verify"))
+
+MIN_VG_SIZE_OPT = cli_option("--min-vg-size", default=None,
+                             action="store", type="int",
+                             dest="min_vg_size",
+                             help=("Minimum volume group size in MiB"
+                                   " for cluster verify checks"
+                                   " (use 0 to disable)"))
 
 ROMAN_OPT = cli_option("--roman",
                        dest="roman_integers", default=False,

--- a/lib/client/gnt_cluster.py
+++ b/lib/client/gnt_cluster.py
@@ -607,6 +607,7 @@ def ShowClusterConfig(opts, args):
        result["use_external_mip_script"]),
       ("lvm volume group", result["volume_group_name"]),
       ("lvm reserved volumes", reserved_lvs),
+      ("lvm min volume group size", result["min_vg_size"]),
       ("drbd usermode helper", result["drbd_usermode_helper"]),
       ("file storage path", result["file_storage_dir"]),
       ("shared file storage path", result["shared_file_storage_dir"]),
@@ -1387,6 +1388,7 @@ def SetClusterParams(opts, args):
           opts.default_iallocator is not None or
           opts.default_iallocator_params is not None or
           opts.reserved_lvs is not None or
+          opts.min_vg_size is not None or
           opts.mac_prefix is not None or
           opts.master_netdev is not None or
           opts.master_netmask is not None or
@@ -1542,6 +1544,7 @@ def SetClusterParams(opts, args):
     master_netdev=opts.master_netdev,
     master_netmask=opts.master_netmask,
     reserved_lvs=opts.reserved_lvs,
+    min_vg_size=opts.min_vg_size,
     use_external_mip_script=ext_ip_script,
     hv_state=hv_state,
     disk_state=disk_state,
@@ -2573,7 +2576,8 @@ commands = {
      MAC_PREFIX_OPT, MASTER_NETDEV_OPT, MASTER_NETMASK_OPT, NIC_PARAMS_OPT,
      VG_NAME_OPT, MAINTAIN_NODE_HEALTH_OPT, UIDPOOL_OPT, ADD_UIDS_OPT,
      REMOVE_UIDS_OPT, DRBD_HELPER_OPT, DEFAULT_IALLOCATOR_OPT,
-     DEFAULT_IALLOCATOR_PARAMS_OPT, RESERVED_LVS_OPT, DRY_RUN_OPT, PRIORITY_OPT,
+     DEFAULT_IALLOCATOR_PARAMS_OPT, RESERVED_LVS_OPT, MIN_VG_SIZE_OPT,
+     DRY_RUN_OPT, PRIORITY_OPT,
      PREALLOC_WIPE_DISKS_OPT, NODE_PARAMS_OPT, USE_EXTERNAL_MIP_SCRIPT,
      DISK_PARAMS_OPT, HV_STATE_OPT, DISK_STATE_OPT] + SUBMIT_OPTS +
      [ENABLED_DISK_TEMPLATES_OPT, IPOLICY_STD_SPECS_OPT, MODIFY_ETCHOSTS_OPT,

--- a/lib/cmdlib/cluster/__init__.py
+++ b/lib/cmdlib/cluster/__init__.py
@@ -505,6 +505,7 @@ class LUClusterQuery(NoHooksLU):
       "default_iallocator": cluster.default_iallocator,
       "default_iallocator_params": cluster.default_iallocator_params,
       "reserved_lvs": cluster.reserved_lvs,
+      "min_vg_size": cluster.min_vg_size,
       "primary_ip_version": primary_ip_version,
       "prealloc_wipe_disks": cluster.prealloc_wipe_disks,
       "hidden_os": cluster.hidden_os,
@@ -1017,9 +1018,10 @@ class LUClusterSetParams(LogicalUnit):
                         " (ignoring node): %s",
                         self.cfg.GetNodeName(node_uuid), msg)
         continue
+      min_vg_size = self.cfg.GetClusterInfo().min_vg_size
       vgstatus = utils.CheckVolumeGroupSize(vglist[node_uuid].payload,
                                             self.op.vg_name,
-                                            constants.MIN_VG_SIZE)
+                                            min_vg_size)
       if vgstatus:
         raise errors.OpPrereqError("Error on node '%s': %s" %
                                    (self.cfg.GetNodeName(node_uuid), vgstatus),
@@ -1751,6 +1753,9 @@ class LUClusterSetParams(LogicalUnit):
 
     if self.op.reserved_lvs is not None:
       self.cluster.reserved_lvs = self.op.reserved_lvs
+
+    if self.op.min_vg_size is not None:
+      self.cluster.min_vg_size = self.op.min_vg_size
 
     if self.op.use_external_mip_script is not None:
       self.cluster.use_external_mip_script = self.op.use_external_mip_script

--- a/lib/cmdlib/cluster/verify.py
+++ b/lib/cmdlib/cluster/verify.py
@@ -656,8 +656,9 @@ class LUClusterVerifyGroup(LogicalUnit, _VerifyErrors):
     self._ErrorIf(test, constants.CV_ENODELVM, ninfo.name,
                   "unable to check volume groups")
     if not test:
+      min_vg_size = self.cfg.GetClusterInfo().min_vg_size
       vgstatus = utils.CheckVolumeGroupSize(vglist, vg_name,
-                                            constants.MIN_VG_SIZE)
+                                            min_vg_size)
       self._ErrorIf(vgstatus, constants.CV_ENODELVM, ninfo.name, vgstatus)
 
     # Check PVs

--- a/lib/objects.py
+++ b/lib/objects.py
@@ -1628,6 +1628,7 @@ class Cluster(TaggableObject):
     "mac_prefix",
     "volume_group_name",
     "reserved_lvs",
+    "min_vg_size",
     "drbd_usermode_helper",
     "default_bridge",
     "default_hypervisor",
@@ -1753,6 +1754,9 @@ class Cluster(TaggableObject):
     # reserved_lvs added before 2.2
     if self.reserved_lvs is None:
       self.reserved_lvs = []
+
+    if self.min_vg_size is None:
+      self.min_vg_size = constants.MIN_VG_SIZE
 
     # hidden and blacklisted operating systems added before 2.2.1
     if self.hidden_os is None:

--- a/lib/tools/cfgupgrade.py
+++ b/lib/tools/cfgupgrade.py
@@ -352,6 +352,9 @@ class CfgUpgrade(object):
     if "ssh_key_bits" not in cluster:
       cluster["ssh_key_bits"] = 1024
 
+    if "min_vg_size" not in cluster:
+      cluster["min_vg_size"] = constants.MIN_VG_SIZE
+
     if "hvparams" in cluster:
       variants = [constants.HT_XEN_PVM, constants.HT_XEN_HVM]
       for variant in variants:
@@ -792,12 +795,20 @@ class CfgUpgrade(object):
       raise Error("Can't find the cluster entry in the configuration")
     _removeRbdUserId(nodegroups)
 
+  @OrFail("Removing the min_vg_size parameter")
+  def DowngradeMinVgSize(self):
+    cluster = self.config_data.get("cluster", None)
+    if cluster is None:
+      raise Error("Can't find the cluster entry in the configuration")
+    cluster.pop("min_vg_size", None)
+
   def DowngradeAll(self):
     self.config_data["version"] = version.BuildVersion(DOWNGRADE_MAJOR,
                                                        DOWNGRADE_MINOR, 0)
 
     self.DowngradeXenSettings()
     self.DowngradeRbdUserId()
+    self.DowngradeMinVgSize()
     return not self.errors
 
   def _ComposePaths(self):

--- a/man/gnt-cluster.rst
+++ b/man/gnt-cluster.rst
@@ -720,6 +720,7 @@ MODIFY
 | [{-I|\--default-iallocator} *default instance allocator*]
 | [\--default-iallocator-params *ial-param*=*value*,*ial-param*=*value*]
 | [\--reserved-lvs=*NAMES*]
+| [\--min-vg-size *size*]
 | [\--node-parameters *ndparams*]
 | [{-m|\--mac-prefix} *mac-prefix*]
 | [\--master-netdev *interface-name*]
@@ -792,6 +793,12 @@ verification, but not the actual use of the names given.
 
 To remove all reserved logical volumes, pass in an empty argument
 to the option, as in ``--reserved-lvs=`` or ``--reserved-lvs ''``.
+
+The ``--min-vg-size`` option specifies the minimum size (in MiB) that
+a volume group must have to pass cluster verification. The default is
+20480 MiB (20 GiB). Set to 0 to disable the size check, which is
+useful for clusters where some nodes use non-LVM storage backends and
+have no or small volume groups.
 
 The ``-I (--default-iallocator)`` is described in the **init**
 command. To clear the default iallocator, just pass an empty string

--- a/src/Ganeti/Objects.hs
+++ b/src/Ganeti/Objects.hs
@@ -637,6 +637,7 @@ $(buildObject "Cluster" "cluster" $
   , optionalField $
     simpleField "volume_group_name"              [t| String                  |]
   , simpleField "reserved_lvs"                   [t| [String]                |]
+  , simpleField "min_vg_size"                    [t| Int                     |]
   , optionalField $
     simpleField "drbd_usermode_helper"           [t| String                  |]
   , simpleField "master_node"                    [t| String                  |]

--- a/src/Ganeti/OpCodes.hs
+++ b/src/Ganeti/OpCodes.hs
@@ -250,6 +250,7 @@ $(genOpCode "OpCode"
      , pMasterNetdev
      , pMasterNetmask
      , pReservedLvs
+     , pMinVgSize
      , pHiddenOs
      , pBlacklistedOs
      , pUseExternalMipScript

--- a/src/Ganeti/OpParams.hs
+++ b/src/Ganeti/OpParams.hs
@@ -157,6 +157,7 @@ module Ganeti.OpParams
   , pMasterNetdev
   , pMasterNetmask
   , pReservedLvs
+  , pMinVgSize
   , pHiddenOs
   , pBlacklistedOs
   , pUseExternalMipScript
@@ -806,6 +807,11 @@ pReservedLvs :: Field
 pReservedLvs =
   withDoc "List of reserved LVs" .
   optionalField $ simpleField "reserved_lvs" [t| [NonEmptyString] |]
+
+pMinVgSize :: Field
+pMinVgSize =
+  withDoc "Minimum volume group size (MiB)" .
+  optionalField $ simpleField "min_vg_size" [t| NonNegative Int |]
 
 pHiddenOs :: Field
 pHiddenOs =

--- a/src/Ganeti/Query/Server.hs
+++ b/src/Ganeti/Query/Server.hs
@@ -248,6 +248,7 @@ handleCall _ _ cdata QueryClusterInfo =
             , ("default_iallocator_params",
               showJSON $ clusterDefaultIallocatorParams cluster)
             , ("reserved_lvs", showJSON $ clusterReservedLvs cluster)
+            , ("min_vg_size", showJSON $ clusterMinVgSize cluster)
             , ("primary_ip_version",
                showJSON . ipFamilyToVersion $ clusterPrimaryIpFamily cluster)
             , ("prealloc_wipe_disks",

--- a/test/hs/Test/Ganeti/OpCodes.hs
+++ b/test/hs/Test/Ganeti/OpCodes.hs
@@ -251,6 +251,7 @@ instance Arbitrary OpCodes.OpCode where
           <*> arbitrary                    -- master_netmask
           <*> genMaybe (listOf genPrintableAsciiStringNE)
                                            -- reserved_lvs
+          <*> arbitrary                    -- min_vg_size
           <*> genMaybe (listOf ((,) <$> arbitrary
                                     <*> genPrintableAsciiStringNE))
                                            -- hidden_os

--- a/test/py/legacy/cfgupgrade_unittest.py
+++ b/test/py/legacy/cfgupgrade_unittest.py
@@ -76,6 +76,7 @@ def GetMinimalConfig():
       },
       "ssh_key_type": "dsa",
       "ssh_key_bits": 1024,
+      "min_vg_size": constants.MIN_VG_SIZE,
     },
     "instances": {},
     "disks": {},


### PR DESCRIPTION
## Summary
- Add `min_vg_size` as a cluster-level parameter (default 20480 MiB) configurable via `gnt-cluster modify --min-vg-size`
- Replace hardcoded `MIN_VG_SIZE` constant in volume group checks with the cluster setting
- Include cfgupgrade support (upgrade adds default, downgrade strips it)
- Expose via QueryClusterInfo/RAPI