### PR TITLE
Fix OVS VLAN handling and normalize stored VLAN format

### DIFF
--- a/lib/cmdlib/instance_create.py
+++ b/lib/cmdlib/instance_create.py
@@ -154,6 +154,10 @@ class LUInstanceCreate(LogicalUnit):
     for nic in self.op.nics:
       vlan = nic.get(constants.INIC_VLAN, None)
       if vlan:
+        if vlan[0].isdigit():
+          # Bare number or number:trunk - add leading dot
+          vlan = "." + vlan
+          nic[constants.INIC_VLAN] = vlan
         if vlan[0] == ".":
           # vlan starting with dot means single untagged vlan,
           # might be followed by trunk (:)
@@ -162,10 +166,6 @@ class LUInstanceCreate(LogicalUnit):
         elif vlan[0] == ":":
           # Trunk - tagged only
           _ValidateTrunkVLAN(vlan)
-        elif vlan.isdigit():
-          # This is the simplest case. No dots, only single digit
-          # -> Create untagged access port, dot needs to be added
-          nic[constants.INIC_VLAN] = "." + vlan
         else:
           raise errors.OpPrereqError("Specified VLAN parameter is invalid"
                                        " : %s" % vlan, errors.ECODE_INVAL)

--- a/lib/cmdlib/instance_utils.py
+++ b/lib/cmdlib/instance_utils.py
@@ -1291,6 +1291,8 @@ def ComputeNics(op, cluster, default_ip, cfg, ec_id):
     if link:
       nicparams[constants.NIC_LINK] = link
     if vlan:
+      if vlan[0].isdigit():
+        vlan = "." + vlan
       nicparams[constants.NIC_VLAN] = vlan
 
     check_params = cluster.SimpleFillNIC(nicparams)

--- a/lib/tools/cfgupgrade.py
+++ b/lib/tools/cfgupgrade.py
@@ -488,6 +488,12 @@ class CfgUpgrade(object):
           logging.info("disk_discard was explicitly set to 'default' on "
                        "instance '%s': migrated to 'ignore'" % iobj["name"])
 
+      for nic in iobj.get("nics", []):
+        nicparams = nic.get("nicparams", {})
+        vlan = nicparams.get(constants.NIC_VLAN, "")
+        if vlan and vlan[0].isdigit():
+          nicparams[constants.NIC_VLAN] = "." + vlan
+
     if self.GetExclusiveStorageValue() and missing_spindles:
       # We cannot be sure that the instances that are missing spindles have
       # exclusive storage enabled (the check would be more complicated), so we

--- a/tools/net-common.in
+++ b/tools/net-common.in
@@ -169,9 +169,12 @@ function setup_ovs {
     [ -n "$ACPORT" ] && ovs-vsctl set port $INTERFACE tag=${ACPORT#.}
     # Set up trunk port
     # From gnt-instance man page vlan should be :VLAN_ID[:VLAN_ID2..]
-    TRUNKS=${VLAN#.*:}  # remove any access info
-    TRUNKS=${TRUNKS#:}  # remove leading ':', if still present
-    [ -n "$TRUNKS" ] && ovs-vsctl set port $INTERFACE trunks=${TRUNKS//:/,}
+    # Only parse trunks when ':' is present in the VLAN specification
+    if [[ "$VLAN" == *:* ]]; then
+      TRUNKS=${VLAN#*:}
+      TRUNKS=${TRUNKS//.}  # strip '.' prefixes from VLAN IDs
+      [ -n "$TRUNKS" ] && ovs-vsctl set port $INTERFACE trunks=${TRUNKS//:/,}
+    fi
 
   fi
 }


### PR DESCRIPTION
## Summary
- Fix trunk parsing in `net-common.in` that caused spurious trunk configuration on pure access ports
- Normalize bare-number VLANs to dot-prefixed format (e.g. `174` → `.174`) on create, modify, and cfgupgrade paths
- Fix create path to accept hybrid VLAN format like `174:200` (access + trunk) which was previously rejected