### PR TITLE
Add configurable delayed-delete suffix for RBD volumes

### DIFF
--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -2277,6 +2277,9 @@ ldpBarriers = "disabled-barriers"
 ldpDefaultMetavg :: String
 ldpDefaultMetavg = "default-metavg"
 
+ldpDelayedDeleteSuffix :: String
+ldpDelayedDeleteSuffix = "delayed-delete-suffix"
+
 ldpDelayTarget :: String
 ldpDelayTarget = "c-delay-target"
 
@@ -2338,7 +2341,8 @@ diskLdTypes =
    (ldpMaxRate, VTypeInt),
    (ldpMinRate, VTypeInt),
    (ldpPool, VTypeString),
-   (ldpUserId, VTypeString)]
+   (ldpUserId, VTypeString),
+   (ldpDelayedDeleteSuffix, VTypeString)]
 
 diskLdParameters :: FrozenSet String
 diskLdParameters = ConstantUtils.mkSet (Map.keys diskLdTypes)
@@ -2405,6 +2409,9 @@ rbdPool = "pool"
 rbdUserId :: String
 rbdUserId = "user-id"
 
+rbdDelayedDeleteSuffix :: String
+rbdDelayedDeleteSuffix = "delayed-delete-suffix"
+
 diskDtTypes :: Map String VType
 diskDtTypes =
   Map.fromList [(drbdResyncRate, VTypeInt),
@@ -2426,6 +2433,7 @@ diskDtTypes =
                 (rbdAccess, VTypeString),
                 (rbdPool, VTypeString),
                 (rbdUserId, VTypeString),
+                (rbdDelayedDeleteSuffix, VTypeString),
                 (glusterHost, VTypeString),
                 (glusterVolume, VTypeString),
                 (glusterPort, VTypeInt)
@@ -4273,6 +4281,7 @@ diskLdDefaults =
             [ (ldpPool, PyValueEx defaultRbdPool)
             , (ldpAccess, PyValueEx diskKernelspace)
             , (ldpUserId, PyValueEx defaultRbdUserId)
+            , (ldpDelayedDeleteSuffix, PyValueEx ("" :: String))
             ])
   , (DTSharedFile, Map.empty)
   , (DTGluster, Map.fromList
@@ -4314,6 +4323,7 @@ diskDtDefaults =
                    [ (rbdPool, PyValueEx defaultRbdPool)
                    , (rbdAccess, PyValueEx diskKernelspace)
                    , (rbdUserId, PyValueEx defaultRbdUserId)
+                   , (rbdDelayedDeleteSuffix, PyValueEx ("" :: String))
                    ])
   , (DTSharedFile, Map.empty)
   , (DTGluster, Map.fromList

--- a/test/py/legacy/cmdlib/cluster_unittest.py
+++ b/test/py/legacy/cmdlib/cluster_unittest.py
@@ -458,12 +458,17 @@ class TestLUClusterSetParams(CmdlibTestCase):
       self.ExecOpCodeExpectOpPrereqError(op, "verify diskparams")
 
   def testValidDiskparams(self):
-    diskparams = {constants.DT_RBD: {constants.RBD_POOL: "mock_pool",
-                                     constants.RBD_ACCESS: "kernelspace",
-                                     constants.RBD_USER_ID: "mock_user"}}
+    diskparams = {constants.DT_RBD: {
+      constants.RBD_POOL: "mock_pool",
+      constants.RBD_ACCESS: "kernelspace",
+      constants.RBD_USER_ID: "mock_user",
+    }}
     op = opcodes.OpClusterSetParams(diskparams=diskparams)
     self.ExecOpCode(op)
-    self.assertEqual(diskparams[constants.DT_RBD],
+    expected = diskparams[constants.DT_RBD].copy()
+    expected.setdefault(
+        constants.RBD_DELAYED_DELETE_SUFFIX, "")
+    self.assertEqual(expected,
                      self.cluster.diskparams[constants.DT_RBD])
 
   def testMinimalDiskparams(self):


### PR DESCRIPTION
## Summary
- Add `delayed-delete-suffix` RBD disk parameter (default empty string)
- When set, RBD volume removal creates a snapshot and renames the volume with the suffix instead of deleting immediately
- Include cfgupgrade support (upgrade fills default via diskparams, downgrade strips it)