### PR TITLE
Raise virtio-net multiqueue limit from 8 to 32

### DIFF
--- a/lib/hypervisor/hv_base.py
+++ b/lib/hypervisor/hv_base.py
@@ -119,7 +119,8 @@ _NET_PORT_CHECK = (lambda x: 0 < x < 65535, "invalid port number",
                    None, None)
 
 # Check if number of queues is in safe range
-_VIRTIO_NET_QUEUES_CHECK = (lambda x: 0 < x < 9, "invalid number of queues",
+_VIRTIO_NET_QUEUES_CHECK = (lambda x: 0 < x <= constants.MAX_VIRTIO_NET_QUEUES,
+                            "invalid number of queues",
                             None, None)
 
 # Check that an integer is non negative

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -969,7 +969,7 @@ virtio\_net\_queues
     parallelize packets sending or receiving. Tap devices will be
     created with MULTI_QUEUE (IFF_MULTI_QUEUE) support. This only
     works with KVM paravirtual nics (virtio-net) and the maximum
-    number of queues is limited to ``8``. Technically this is an
+    number of queues is limited to ``32``. Technically this is an
     extension of ``vnet_hdr`` which must be enabled for multiqueue
     support.
 

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -1833,6 +1833,9 @@ hvVhostNet = "vhost_net"
 hvVirtioNetQueues :: String
 hvVirtioNetQueues = "virtio_net_queues"
 
+maxVirtioNetQueues :: Int
+maxVirtioNetQueues = 32
+
 hvVifScript :: String
 hvVifScript = "vif_script"
 


### PR DESCRIPTION
## Summary
- Increase `maxVirtioNetQueues` constant from 8 to 32 to support modern hosts with more vCPUs
- No config migration needed — this is a hard limit constant, not a stored parameter