### PR TITLE
backport: qemu-10.2 compat: update RUNWITH_RE to support multiline help output

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -500,7 +500,9 @@ class KVMHypervisor(hv_base.BaseHypervisor):
   _AUTO_RO_RE = \
     re.compile(r"^-blockdev\s([^-]|(?<!^)-)*,auto-read-only=on\|off",
                re.M | re.S)
-  _RUNWITH_RE = re.compile(r"^-run-with\s.*chroot=.*user=", re.M)
+  _RUNWITH_RE = \
+    re.compile(r"^-run-with\s([^-]|(?<!^)-)*chroot=([^-]|(?<!^)-)*user=",
+               re.M | re.S)
   _ACPI_RE = re.compile(r"^-no-acpi\s", re.M)
   _SOUND_RE = re.compile(r"^-soundhw\s", re.M)
 


### PR DESCRIPTION
needed for Ganeti-3.1 in upcoming Ubuntu 26.04.

Since QEMU 10.2 (commit 886898baad2), the `-run-with` option supports additional parameters, which causes the `chroot=` and `user=` parameters in the help output to appear on separate lines.

Update the corresponding regex to handle multiline output by enabling re.S and using a similar matching pattern as the regex arounds.

(cherry picked from commit 4bda73e9375a200839431c3a901ae25ac23ff0f7)