### PR TITLE
Improve QA Suite by clearing job queue and run some tests less often

### DIFF
--- a/qa/ganeti-qa.py
+++ b/qa/ganeti-qa.py
@@ -867,6 +867,12 @@ def RunInstanceTests():
         else:
           test_desc = "Iterating through hypervisor parameter values"
           ReportTestSkip(test_desc, "instance-iterate-hvparams")
+
+        # Archive completed jobs to prevent large job queues across
+        # long QA runs.
+        # The larger they become, the slower TestJobList gets (from
+        # seconds to minutes).
+        qa_utils.AssertCommand(["gnt-job", "autoarchive", "all"])
       finally:
         qa_config.ReleaseManyNodes(inodes)
     else:

--- a/qa/ganeti-qa.py
+++ b/qa/ganeti-qa.py
@@ -336,8 +336,14 @@ def RunOsTests():
     RunTestIf(os_enabled, fn)
 
 
-def RunCommonInstanceTests(instance, inst_nodes):
+def RunCommonInstanceTests(instance, inst_nodes, reduced=False):
   """Runs a few tests that are common to all disk types.
+
+  @type reduced: bool
+  @param reduced: if True, skip parameter-independent tests (instance list,
+      info, rename, tags, cluster-verify, node list, job list, RAPI instance).
+      These tests do not assert on hypervisor parameters and only need to run
+      once per disk type rather than once per hvparam iteration.
 
   """
   RunTestIf("instance-shutdown", qa_instance.TestInstanceShutdown, instance)
@@ -353,9 +359,10 @@ def RunCommonInstanceTests(instance, inst_nodes):
   RunTestIf(["instance-shutdown", qa_rapi.Enabled],
             qa_rapi.TestRapiInstanceStartup, instance)
 
-  RunTestIf("instance-list", qa_instance.TestInstanceList)
+  if not reduced:
+    RunTestIf("instance-list", qa_instance.TestInstanceList)
 
-  RunTestIf("instance-info", qa_instance.TestInstanceInfo, instance)
+    RunTestIf("instance-info", qa_instance.TestInstanceInfo, instance)
 
   RunTestIf("instance-modify", qa_instance.TestInstanceModify, instance)
   RunTestIf(["instance-modify", qa_rapi.Enabled],
@@ -373,6 +380,14 @@ def RunCommonInstanceTests(instance, inst_nodes):
     "instance-grow-disk",
     ])
 
+  if reduced:
+    # In reduced mode, skip rename tests (parameter-independent) but keep
+    # reinstall and grow-disk which exercise disk-type-specific code paths.
+    DOWN_TESTS = qa_config.Either([
+      "instance-reinstall",
+      "instance-grow-disk",
+      ])
+
   # shutdown instance for any 'down' tests
   RunTestIf(DOWN_TESTS, qa_instance.TestInstanceShutdown, instance)
 
@@ -381,7 +396,7 @@ def RunCommonInstanceTests(instance, inst_nodes):
   RunTestIf(["instance-reinstall", qa_rapi.Enabled],
             qa_rapi.TestRapiInstanceReinstall, instance)
 
-  if qa_config.TestEnabled("instance-rename"):
+  if not reduced and qa_config.TestEnabled("instance-rename"):
     tgt_instance = qa_config.AcquireInstance()
     try:
       rename_source = instance.name
@@ -407,20 +422,22 @@ def RunCommonInstanceTests(instance, inst_nodes):
 
   RunTestIf("instance-reboot", qa_instance.TestInstanceReboot, instance)
 
-  RunTestIf("tags", qa_tags.TestInstanceTags, instance)
+  if not reduced:
+    RunTestIf("tags", qa_tags.TestInstanceTags, instance)
 
   if instance.disk_template == constants.DT_DRBD8:
     RunTestIf("cluster-verify",
               qa_cluster.TestClusterVerifyDisksBrokenDRBD, instance, inst_nodes)
-  RunTestIf("cluster-verify", qa_cluster.TestClusterVerify)
+  if not reduced:
+    RunTestIf("cluster-verify", qa_cluster.TestClusterVerify)
 
-  RunTestIf(qa_rapi.Enabled, qa_rapi.TestInstance, instance)
+    RunTestIf(qa_rapi.Enabled, qa_rapi.TestInstance, instance)
 
-  # Lists instances, too
-  RunTestIf("node-list", qa_node.TestNodeList)
+    # Lists instances, too
+    RunTestIf("node-list", qa_node.TestNodeList)
 
-  # Some jobs have been run, let's test listing them
-  RunTestIf("job-list", qa_job.TestJobList)
+    # Some jobs have been run, let's test listing them
+    RunTestIf("job-list", qa_job.TestJobList)
 
 
 def RunCommonNodeTests():
@@ -941,7 +958,7 @@ def RunInstanceTestsFull(create_fun, inodes, supported_conversions, templ):
 def RunInstanceTestsReduced(create_fun, inodes):
   instance = RunTest(create_fun, inodes)
   try:
-    RunCommonInstanceTests(instance, inodes)
+    RunCommonInstanceTests(instance, inodes, reduced=True)
     RunTest(qa_instance.TestInstanceRemove, instance)
   finally:
     instance.Release()


### PR DESCRIPTION
The QA suite has accumulated quite some runtime if you use e.g. KVM and enable most tests (> 6 hours). This PR improves this by two steps:

- the QA regularly tests/analyzes the job queue. in very long QA runs the queue accumulates thousands of jobs which do not expire during the QA's runtime. while the queue-related tests initially only take 1-2 seconds, they accumulate a runtime of over a minute near the end of the QA run. We now employ `gnt-job autoarchive` every now and then to keep the queue clean.
- we run the instance test block over and over again with iterations over possible HVparams. Some tests in there are not affected by the HVparams (e.g. TestInstanceList, TestNodeList and others). We can execute them in the first run and safely exclude them from further instance test iterations without negatively impacting the results of the QA suite

Overall this has brought the QAs runtime on Debian Forky down from 6:30 to 4:54 which is quite an improvement :-)