### PR TITLE
tests: add uutils coreutils compatibility

### DIFF
--- a/test/py/legacy/ganeti.hooks_unittest.py
+++ b/test/py/legacy/ganeti.hooks_unittest.py
@@ -198,7 +198,10 @@ class TestHooksRunner(unittest.TestCase):
     for phase in (constants.HOOKS_PHASE_PRE, constants.HOOKS_PHASE_POST):
       fbase = "success"
       fname = "%s/%s" % (self.ph_dirs[phase], fbase)
-      os.symlink("/usr/bin/env", fname)
+      content = "#!/usr/bin/env sh\nenv --unset PWD\n"
+      with open(fname, "w", encoding="utf-8", newline="\n") as f:
+        f.write(content)
+      os.chmod(fname, 0o755)
       self.torm.append((fname, False))
       env_snt = {"PHASE": phase}
       env_exp = "PHASE=%s" % phase


### PR DESCRIPTION
GNU coreutils is recently replaced by the uutils project (a cross-platform reimplementation in Rust). When symlinking `/usr/bin/env` to an arbitrary named executable, the Rust version tries to execute $0 instead of just printing the environment. Work around by creating a shell script that executes the `env` command.

fixes #1923