### PR TITLE
kvm: always enable debug-threads in QEMU -name argument

### DIFF
--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -1248,8 +1248,14 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     pidfile = self._InstancePidFile(instance.name)
     kvm = hvp[constants.HV_KVM_PATH]
     kvm_cmd = [kvm]
-    # used just by the vnc server, if enabled
-    kvm_cmd.extend(["-name", instance.name])
+
+    (_, kvm_major, _, _) = self._ParseKVMVersion(kvmhelp)
+    if kvm_major < 11:
+      kvm_cmd.extend(["-name", f"{instance.name},debug-threads=on"])
+    else:
+      # debug-threads is implicitly enabled starting with QEMU 11
+      kvm_cmd.extend(["-name", f"{instance.name}"])
+
     kvm_cmd.extend(["-m", instance.beparams[constants.BE_MAXMEM]])
 
     smp_list = ["%s" % instance.beparams[constants.BE_VCPUS]]


### PR DESCRIPTION
QEMU supports a debug-threads sub-parameter appended comma-separated to the -name argument (e.g. `-name instance,debug-threads=on`), which causes QEMU to assign meaningful names to its threads instead of generic ones. This aids observability when inspecting the host with tools like top.

The feature was previously implemented as an optional HV parameter (#1528) but had to be reverted (#1822) because the instance name parser did not strip the comma-separated suffix, causing downgraded clusters to lose track of running instances (#1820).

The parser fix landed as part of #1822 and has been in place since. There is no performance impact, so the parameter is now unconditionally enabled rather than gated behind a new HV parameter (so there is no need for up/downgrade code).
