### PR TITLE
Close DRBD handshake race in AssembleInstanceDisks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -269,6 +269,7 @@ DIRS = \
 
 PYTHON_TEST_DIRS = \
 	test/py/unit \
+	test/py/unit/cmdlib \
 	test/py/unit/confd \
 	test/py/unit/http \
 	test/py/unit/hypervisor \
@@ -2024,6 +2025,7 @@ python_tests_legacy = \
 	test/py/legacy/tempfile_fork_unittest.py
 
 python_tests_unit = \
+	test/py/unit/cmdlib/test_instance_storage_drbd_wait.py \
 	test/py/unit/confd/test_client.py \
 	test/py/unit/test_daemon.py \
 	test/py/unit/hypervisor/hv_kvm/test_monitor.py \

--- a/doc/admin.rst
+++ b/doc/admin.rst
@@ -1629,6 +1629,52 @@ to these parameters will not affect running instances.
   $ gnt-cluster modify --disk-parameters drbd:dynamic-resync=true,c-plan-ahead=20,c-min-rate=104857600,c-max-rate=1073741824
   $ gnt-cluster modify --disk-parameters drbd:net-custom='--max-buffers=16000 --max-epoch-size=16000'
 
+Overriding DRBD split-brain resolution
+++++++++++++++++++++++++++++++++++++++
+
+Ganeti's DRBD backend ships with automatic split-brain resolution enabled:
+``--after-sb-0pri discard-zero-changes`` and ``--after-sb-1pri consensus``.
+The ``consensus`` policy can silently discard one side of a split-brain in
+the one-primary case, which in some failure scenarios amounts to silent
+data loss (see GitHub issue #846).
+
+Operators who prefer manual intervention can override either policy via
+the existing ``net-custom`` disk parameter. Because Ganeti appends
+``net-custom`` at the end of the generated ``drbdsetup`` command line,
+the last occurrence of each flag wins, so an override simply replaces
+the default::
+
+  $ gnt-cluster modify --disk-parameters drbd:net-custom='--after-sb-1pri disconnect'
+
+The override takes effect the next time the DRBD network layer is
+(re-)established for a given disk - e.g. on instance restart, secondary
+re-add, or migration.
+
+DRBD handshake check on disk assembly
++++++++++++++++++++++++++++++++++++++
+
+When activating disks for a DRBD-backed instance (for example during
+``gnt-instance startup``, ``gnt-instance reboot``, ``gnt-instance
+activate-disks``, or ``gnt-instance grow-disk``), Ganeti waits for the
+DRBD handshake to complete on every reachable secondary before
+promoting the primary. If the handshake does not complete on an online
+secondary, the operation fails instead of silently promoting a primary
+in ``WFConnection`` state - this avoids a potential data-loss scenario
+after an instance ran in DRBD diskless mode on its primary node (e.g.
+after a failure in the storage subsystem).
+
+To override the check - accepting the risk of split-brain / data loss:
+
+* ``gnt-instance startup --force``
+* ``gnt-instance reboot --ignore-secondaries``
+* Mark a persistently unreachable secondary as offline with
+  ``gnt-node modify --offline=yes <node>`` - offline secondaries are
+  always skipped (with a warning), independent of the flags above.
+
+``gnt-instance failover``, ``gnt-instance migrate`` and
+``gnt-instance move`` already treat secondary handshake failures as
+non-fatal, matching their existing semantics.
+
 Userspace vs. Kernelspace
 +++++++++++++++++++++++++
 

--- a/lib/cmdlib/instance_storage.py
+++ b/lib/cmdlib/instance_storage.py
@@ -1596,12 +1596,13 @@ def AssembleInstanceDisks(lu, instance, disks=None, ignore_secondaries=False,
 
   # With the two passes mechanism we try to reduce the window of
   # opportunity for the race condition of switching DRBD to primary
-  # before handshaking occured, but we do not eliminate it
-
-  # The proper fix would be to wait (with some limits) until the
-  # connection has been made and drbd transitions from WFConnection
-  # into any other network-connected state (Connected, SyncTarget,
-  # SyncSource, etc.)
+  # before handshaking occured. For DRBD instances with reachable
+  # secondaries we additionally poll the secondaries after pass 1 to
+  # confirm the DRBD handshake transitioned out of WFConnection before
+  # we promote the primary. On handshake failure we abort pass 2
+  # unless the caller has opted into the risk via ignore_secondaries
+  # (mapped from the CLI '--force' / '--ignore-secondaries' flags) or
+  # the secondary is administratively offline.
 
   # 1st pass, assemble on all nodes in secondary mode
   for idx, inst_disk in enumerate(disks):
@@ -1623,7 +1624,65 @@ def AssembleInstanceDisks(lu, instance, disks=None, ignore_secondaries=False,
         if not (ignore_secondaries or is_offline_secondary):
           disks_ok = False
 
-  # FIXME: race condition on drbd migration to primary
+  # Wait for the DRBD handshake on the secondaries before promoting the
+  # primary, closing the WFConnection race that the two-pass scheme
+  # alone only narrows. Short-circuits for non-DRBD templates and for
+  # instances without secondaries (single-node / diskless).
+  if any(d.dev_type == constants.DT_DRBD8 for d in disks):
+    secondary_nodes = lu.cfg.GetInstanceSecondaryNodes(instance.uuid)
+    if secondary_nodes:
+      wait_result = lu.rpc.call_drbd_wait_sync(secondary_nodes,
+                                               (disks, instance))
+      fatal_failures = []
+      offline_skipped = []
+      for node_uuid, nres in wait_result.items():
+        node_name = lu.cfg.GetNodeName(node_uuid)
+        if not nres.fail_msg:
+          _, node_percent = nres.payload
+          if node_percent is not None and node_percent < 100:
+            lu.LogInfo("DRBD resync on secondary %s at %.1f%%",
+                       node_name, node_percent)
+        elif nres.offline:
+          offline_skipped.append(node_name)
+          lu.LogWarning("DRBD handshake wait skipped on secondary %s:"
+                        " node is administratively offline",
+                        node_name)
+        elif ignore_secondaries:
+          lu.LogWarning("DRBD handshake wait failed on secondary %s: %s;"
+                        " proceeding because ignore_secondaries is set",
+                        node_name, nres.fail_msg)
+        else:
+          fatal_failures.append((node_name, nres.fail_msg))
+
+      if fatal_failures:
+        # backend.DrbdWaitSync _Fail's with "is not in sync" on handshake
+        # timeout; any other fail_msg is an RPC or node-level error.
+        def _classify(msg):
+          if "is not in sync" in msg:
+            return "timeout waiting for handshake"
+          return f"RPC error: {msg}"
+
+        lines = [
+          f"DRBD handshake did not complete on {len(fatal_failures)}"
+          f" secondary node(s); refusing to promote the primary to"
+          f" guard against split-brain / data loss:",
+        ]
+        lines.extend(f"  - {name}: {_classify(msg)}"
+                     for name, msg in fatal_failures)
+        if offline_skipped:
+          lines.append(
+            f"Skipped as offline: {', '.join(offline_skipped)}.")
+        lines.append(
+          "To investigate: check network connectivity and /proc/drbd"
+          " on the listed secondaries. To force the operation anyway"
+          " (accepting the data-loss risk), re-run with the appropriate"
+          " opt-out: 'gnt-instance startup --force', 'gnt-instance"
+          " reboot --ignore-secondaries', or mark persistently"
+          " unreachable nodes offline with 'gnt-node modify"
+          " --offline=yes <node>'.")
+
+        lu.cfg.MarkInstanceDisksInactive(instance.uuid)
+        raise errors.OpExecError("\n".join(lines))
 
   # 2nd pass, do only the primary node
   for idx, inst_disk in enumerate(disks):

--- a/test/py/unit/cmdlib/test_instance_storage_drbd_wait.py
+++ b/test/py/unit/cmdlib/test_instance_storage_drbd_wait.py
@@ -1,0 +1,257 @@
+#
+#
+
+# Copyright (C) 2026 the Ganeti project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Pytest tests for the DRBD handshake wait added to AssembleInstanceDisks."""
+
+from unittest import mock
+
+import pytest
+
+from ganeti import constants
+from ganeti import errors
+from ganeti.cmdlib import instance_storage
+
+
+PRIMARY = "primary-uuid"
+SECONDARY = "secondary-uuid"
+
+
+def _mk_disk(dev_type):
+  disk = mock.Mock()
+  disk.dev_type = dev_type
+  disk.iv_name = "disk/0"
+
+  def _compute_tree(primary):
+    if dev_type == constants.DT_DRBD8:
+      return [(PRIMARY, disk), (SECONDARY, disk)]
+    return [(PRIMARY, disk)]
+
+  disk.ComputeNodeTree.side_effect = _compute_tree
+  return disk
+
+
+def _mk_rpc_result(fail_msg=None, payload=None, offline=False):
+  res = mock.Mock()
+  res.fail_msg = fail_msg
+  res.payload = payload if payload is not None else ("/dev/drbd0", 0, None)
+  res.offline = offline
+  return res
+
+
+def _mk_lu(disk, secondary_nodes):
+  lu = mock.Mock()
+  instance = mock.Mock()
+  instance.uuid = "inst-uuid"
+  instance.primary_node = PRIMARY
+
+  lu.cfg.MarkInstanceDisksActive.return_value = instance
+  lu.cfg.GetInstanceDisks.return_value = [disk]
+  lu.cfg.GetInstanceSecondaryNodes.return_value = secondary_nodes
+  lu.cfg.GetNodeName.side_effect = lambda uuid: f"node-{uuid}"
+
+  lu.rpc.call_blockdev_assemble.return_value = _mk_rpc_result()
+  # Successful handshake wait: alldone=True, percent=100
+  wait_payload = (True, 100)
+  lu.rpc.call_drbd_wait_sync.return_value = {
+    sec: _mk_rpc_result(payload=wait_payload) for sec in secondary_nodes
+  }
+  return lu, instance
+
+
+def test_drbd_with_secondaries_waits_between_passes():
+  disk = _mk_disk(constants.DT_DRBD8)
+  lu, instance = _mk_lu(disk, [SECONDARY])
+
+  ok, _, _ = instance_storage.AssembleInstanceDisks(lu, instance)
+
+  assert ok is True
+  lu.rpc.call_drbd_wait_sync.assert_called_once_with(
+    [SECONDARY], ([disk], instance))
+
+  # Ordering: wait must be called after pass 1 (secondary-mode assemble)
+  # and before pass 2 (primary promotion). Check call order on the mocks.
+  call_order = [
+    c for c in lu.rpc.method_calls
+    if c[0] in ("call_blockdev_assemble", "call_drbd_wait_sync")
+  ]
+  names = [c[0] for c in call_order]
+  assert names.count("call_drbd_wait_sync") == 1
+  idx = names.index("call_drbd_wait_sync")
+  # Pass 1 assemble on secondary + primary = 2 calls before wait
+  assert names[:idx] == ["call_blockdev_assemble", "call_blockdev_assemble"]
+  # Pass 2 does one more call_blockdev_assemble for the primary
+  assert names[idx + 1:] == ["call_blockdev_assemble"]
+
+
+def test_drbd_without_secondaries_does_not_wait():
+  disk = _mk_disk(constants.DT_DRBD8)
+  lu, instance = _mk_lu(disk, [])
+
+  instance_storage.AssembleInstanceDisks(lu, instance)
+
+  lu.rpc.call_drbd_wait_sync.assert_not_called()
+
+
+@pytest.mark.parametrize("dev_type", [
+  constants.DT_PLAIN,
+  constants.DT_FILE,
+  constants.DT_RBD,
+  constants.DT_DISKLESS,
+])
+def test_non_drbd_templates_do_not_wait(dev_type):
+  disk = _mk_disk(dev_type)
+  # Non-DRBD templates normally have no secondaries, but even if one were
+  # reported the wait must be skipped because the RPC is DRBD-only.
+  lu, instance = _mk_lu(disk, [SECONDARY])
+
+  instance_storage.AssembleInstanceDisks(lu, instance)
+
+  lu.rpc.call_drbd_wait_sync.assert_not_called()
+
+
+TIMEOUT_FAIL = "DRBD device /dev/drbd0 is not in sync: stats=<...>"
+
+
+def _promote_calls(lu):
+  return [c for c in lu.rpc.call_blockdev_assemble.call_args_list
+          if c.args[3] is True]
+
+
+def test_wait_failure_is_fatal_by_default():
+  disk = _mk_disk(constants.DT_DRBD8)
+  lu, instance = _mk_lu(disk, [SECONDARY])
+  lu.rpc.call_drbd_wait_sync.return_value = {
+    SECONDARY: _mk_rpc_result(fail_msg=TIMEOUT_FAIL),
+  }
+
+  with pytest.raises(errors.OpExecError) as excinfo:
+    instance_storage.AssembleInstanceDisks(lu, instance)
+
+  msg = str(excinfo.value)
+  # Names the secondary by resolved hostname, not UUID.
+  assert f"node-{SECONDARY}" in msg
+  assert SECONDARY not in msg.replace(f"node-{SECONDARY}", "")
+  # Classifies the timeout distinctly from a plain RPC error.
+  assert "timeout waiting for handshake" in msg
+  # References the guard rationale.
+  assert "accepting the data-loss risk" in msg
+  # Disks were marked inactive before the raise.
+  lu.cfg.MarkInstanceDisksInactive.assert_called_once_with(instance.uuid)
+  # Pass 2 must not have run.
+  assert _promote_calls(lu) == []
+
+
+def test_wait_rpc_error_is_fatal_and_classified():
+  disk = _mk_disk(constants.DT_DRBD8)
+  lu, instance = _mk_lu(disk, [SECONDARY])
+  lu.rpc.call_drbd_wait_sync.return_value = {
+    SECONDARY: _mk_rpc_result(fail_msg="connection refused"),
+  }
+
+  with pytest.raises(errors.OpExecError) as excinfo:
+    instance_storage.AssembleInstanceDisks(lu, instance)
+
+  msg = str(excinfo.value)
+  assert "RPC error: connection refused" in msg
+  assert "timeout waiting for handshake" not in msg
+
+
+def test_wait_failure_with_ignore_secondaries_is_warning():
+  disk = _mk_disk(constants.DT_DRBD8)
+  lu, instance = _mk_lu(disk, [SECONDARY])
+  lu.rpc.call_drbd_wait_sync.return_value = {
+    SECONDARY: _mk_rpc_result(fail_msg=TIMEOUT_FAIL),
+  }
+
+  ok, _, _ = instance_storage.AssembleInstanceDisks(
+    lu, instance, ignore_secondaries=True)
+
+  assert ok is True
+  lu.LogWarning.assert_any_call(
+    "DRBD handshake wait failed on secondary %s: %s;"
+    " proceeding because ignore_secondaries is set",
+    f"node-{SECONDARY}", TIMEOUT_FAIL)
+  lu.cfg.MarkInstanceDisksInactive.assert_not_called()
+  assert len(_promote_calls(lu)) == 1
+
+
+def test_wait_failure_on_offline_secondary_is_warning():
+  disk = _mk_disk(constants.DT_DRBD8)
+  lu, instance = _mk_lu(disk, [SECONDARY])
+  lu.rpc.call_drbd_wait_sync.return_value = {
+    SECONDARY: _mk_rpc_result(fail_msg="node down", offline=True),
+  }
+
+  ok, _, _ = instance_storage.AssembleInstanceDisks(lu, instance)
+
+  assert ok is True
+  lu.LogWarning.assert_any_call(
+    "DRBD handshake wait skipped on secondary %s:"
+    " node is administratively offline",
+    f"node-{SECONDARY}")
+  lu.cfg.MarkInstanceDisksInactive.assert_not_called()
+  assert len(_promote_calls(lu)) == 1
+
+
+def test_mixed_offline_and_timeout_is_fatal_but_mentions_offline():
+  other_secondary = "secondary2-uuid"
+  disk = _mk_disk(constants.DT_DRBD8)
+  lu, instance = _mk_lu(disk, [SECONDARY, other_secondary])
+  lu.rpc.call_drbd_wait_sync.return_value = {
+    SECONDARY: _mk_rpc_result(fail_msg=TIMEOUT_FAIL),
+    other_secondary: _mk_rpc_result(fail_msg="node down", offline=True),
+  }
+
+  with pytest.raises(errors.OpExecError) as excinfo:
+    instance_storage.AssembleInstanceDisks(lu, instance)
+
+  msg = str(excinfo.value)
+  assert f"node-{SECONDARY}" in msg
+  assert "timeout waiting for handshake" in msg
+  # Offline node is reported but does not itself cause the fatal.
+  assert f"node-{other_secondary}" in msg
+  assert "Skipped as offline" in msg
+  lu.cfg.MarkInstanceDisksInactive.assert_called_once_with(instance.uuid)
+
+
+def test_error_message_has_remediation_hint():
+  disk = _mk_disk(constants.DT_DRBD8)
+  lu, instance = _mk_lu(disk, [SECONDARY])
+  lu.rpc.call_drbd_wait_sync.return_value = {
+    SECONDARY: _mk_rpc_result(fail_msg=TIMEOUT_FAIL),
+  }
+
+  with pytest.raises(errors.OpExecError) as excinfo:
+    instance_storage.AssembleInstanceDisks(lu, instance)
+
+  msg = str(excinfo.value)
+  # All three documented escape hatches must be named.
+  assert "gnt-instance startup --force" in msg
+  assert "--ignore-secondaries" in msg
+  assert "gnt-node modify --offline" in msg


### PR DESCRIPTION
This PR addresses #846 in a way that does not introduce new cluster parameters. 

The two-pass assemble only narrowed the window where a DRBD device could be promoted while still in WFConnection. Between passes, reuse the existing `drbd_wait_sync` RPC on the secondaries to wait for the handshake; failures are logged but do not abort. The logic does of course not apply to non-DRBD blockdevices.

To avoid new cluster parameters (for now), we resort to document `net-custom` as the supported way to override the hardcoded after-sb-*pri policies. With DRBD utils, the latest occurence of CLI parameters always "wins", hence it is possible to override the cluster default policies.

