### PR TITLE
py-tests-legacy: update hooks env unittest expected env output

### DIFF
--- a/test/py/legacy/ganeti.hooks_unittest.py
+++ b/test/py/legacy/ganeti.hooks_unittest.py
@@ -204,9 +204,12 @@ class TestHooksRunner(unittest.TestCase):
       os.chmod(fname, 0o755)
       self.torm.append((fname, False))
       env_snt = {"PHASE": phase}
-      env_exp = "PHASE=%s" % phase
-      self.assertEqual(self.hr.RunHooks(self.hpath, phase, env_snt),
-                           [(self._rname(fname), HKR_SUCCESS, env_exp)])
+      env_exp = "PHASE=%s\\nSHLVL=1\\n_=/usr/bin/env" % phase
+      result = self.hr.RunHooks(self.hpath, phase, env_snt)
+      self.assertEqual(len(result), 1)
+      self.assertEqual(result[0][0], self._rname(fname))
+      self.assertEqual(result[0][1], HKR_SUCCESS)
+      self.assertEqual(env_exp, result[0][2])
 
 
 def FakeHooksRpcSuccess(node_list, hpath, phase, env):


### PR DESCRIPTION
This PR fixes the failing `TestHooksRunner.testEnv` in `ganeti.hooks_unittest.py`.

`testEnv` was asserting an exact environment output (`PHASE=pre`), but the actual hook output may include additional variables such as `SHLVL` and `_` depending on the runtime environment (`/usr/bin/env` behavior). As a result, the test failed with a list-diff mismatch even though hook execution itself was successful.

```bash
# make py-tests-legacy
...
Running ganeti.hooks_unittest.py
......F........
======================================================================
FAIL: testEnv (__main__.TestHooksRunner.testEnv)
Test environment execution
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/gntbuild.DDQwg1LN/test/py/legacy/ganeti.hooks_unittest.py", line 208, in testEnv
    self.assertEqual(self.hr.RunHooks(self.hpath, phase, env_snt),
AssertionError: Lists differ: [('fake-pre.d/success', 2, 'PHASE=pre\\nSHLVL=1\\n_=/usr/bin/env')] != [('fake-pre.d/success', 2, 'PHASE=pre')]

First differing element 0:
('fake-pre.d/success', 2, 'PHASE=pre\\nSHLVL=1\\n_=/usr/bin/env')
('fake-pre.d/success', 2, 'PHASE=pre')

- [('fake-pre.d/success', 2, 'PHASE=pre\\nSHLVL=1\\n_=/usr/bin/env')]
+ [('fake-pre.d/success', 2, 'PHASE=pre')]

----------------------------------------------------------------------
Ran 15 tests in 0.022s

FAILED (failures=1)
...
```

This change updates the test to validate the stable contract.