### PR TITLE
Add role-based access control for the Remote API

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2043,6 +2043,7 @@ python_tests_unit = \
 	test/py/unit/test_daemon.py \
 	test/py/unit/hypervisor/hv_kvm/test_monitor.py \
 	test/py/unit/hypervisor/hv_kvm/test_bus_manager.py \
+	test/py/unit/http/test_auth.py \
 	test/py/unit/http/test_server.py \
 	test/py/unit/http/test_ssl.py \
 	test/py/unit/server/test_rapi.py

--- a/NEWS
+++ b/NEWS
@@ -3362,10 +3362,10 @@ New features
   just includes the DRBD data collector, that can be executed by calling
   ``mon-collector`` using the ``drbd`` parameter. See
   :manpage:`mon-collector(7)`.
-- A new user option, :pyeval:`rapi.RAPI_ACCESS_READ`, has been added
+- A new user option, ``rapi.RAPI_ACCESS_READ``, has been added
   for RAPI users. It allows granting permissions to query for
   information to a specific user without giving
-  :pyeval:`rapi.RAPI_ACCESS_WRITE` permissions.
+  ``rapi.RAPI_ACCESS_WRITE`` permissions.
 - A new tool named ``node-cleanup`` has been added. It cleans remains of
   a cluster from a machine by stopping all daemons, removing
   certificates and ssconf files. Unless the ``--no-backup`` option is

--- a/doc/rapi.rst
+++ b/doc/rapi.rst
@@ -43,53 +43,65 @@ Options control a user's access permissions. The section
 :ref:`rapi-access-permissions` lists the permissions required for each
 resource. If the ``--require-authentication`` command line option is
 given to the ``ganeti-rapi`` daemon, all requests require
-authentication. Available options:
+authentication.
 
-.. pyassert::
+Permissions can be specified in three formats:
 
-  rapi.RAPI_ACCESS_ALL == set([
-    rapi.RAPI_ACCESS_WRITE,
-    rapi.RAPI_ACCESS_READ,
-    ])
+Role-based access
+  Use ``@rolename`` to assign a predefined role. Available roles:
 
-.. pyassert::
+  ``@admin``
+    Full access to all RAPI resources (all permissions).
+  ``@readonly``
+    Read-only access to query information (e.g. ``jobs.list``,
+    ``instances.query``, ``nodes.list``, ``cluster.info``, etc.).
+  ``@operator``
+    Everything in ``@readonly`` plus instance operations that do not
+    change instance configuration: start/shutdown/reboot, migrate and
+    fail-over, replace disks, prepare/create/remove exports, and
+    console access. Cannot create, modify, remove or rename instances,
+    and cannot change cluster, node, network or group configuration.
 
-  rlib2.R_2_nodes_name_storage.GET_ACCESS == [rapi.RAPI_ACCESS_WRITE]
+Explicit permissions
+  Specify individual permissions separated by commas, e.g.
+  ``jobs.list,instances.create,nodes.query``. See
+  :ref:`rapi-access-permissions` for the full list of available
+  permissions.
 
-.. pyassert::
+Role with modifications
+  Start with a role and add/remove specific permissions using ``+`` and
+  ``-`` prefixes, e.g. ``@admin,-instances.remove`` (admin without
+  instance deletion) or ``@readonly,+jobs.cancel`` (readonly plus job
+  cancellation).
 
-  rlib2.R_2_jobs_id_wait.GET_ACCESS == [rapi.RAPI_ACCESS_WRITE]
+Order of tokens within a single options field does not affect the
+resulting permission set: ``@admin,-instances.remove`` and
+``-instances.remove,@admin`` produce the same permissions.
 
-:pyeval:`rapi.RAPI_ACCESS_WRITE`
-  Enables the user to execute operations modifying the cluster. Implies
-  :pyeval:`rapi.RAPI_ACCESS_READ` access. Resources blocking other
-  operations for read-only access, such as
-  :ref:`/2/nodes/[node_name]/storage <rapi-res-nodes-node_name-storage+get>`
-  or blocking server-side processes, such as
-  :ref:`/2/jobs/[job_id]/wait <rapi-res-jobs-job_id-wait+get>`, use
-  :pyeval:`rapi.RAPI_ACCESS_WRITE` to control access to their
-  :pyeval:`http.HTTP_GET` method.
-:pyeval:`rapi.RAPI_ACCESS_READ`
-  Allow access to operations querying for information.
+For backward compatibility, the legacy options ``read``, ``write`` and
+``all`` are still accepted and map to ``@readonly``, ``@admin`` and
+``@admin`` respectively. A deprecation warning is logged once per
+users file load; please migrate to roles or explicit permissions.
 
 Example::
 
-  # Give Jack and Fred read-only access
-  jack abc123
-  fred {cleartext}foo555
+  # Admin with full access (role-based)
+  admin_user {HA1}7046452df2cbb530877058712cf17bd4 @admin
 
-  # Give write access to an imaginary instance creation script
-  autocreator xyz789 write
+  # Read-only access for monitoring (role-based)
+  monitoring {cleartext}foo555 @readonly
 
-  # Hashed password for Jessica
-  jessica {HA1}7046452df2cbb530877058712cf17bd4 write
+  # Operator can start/stop/reboot instances but not modify config
+  on_call {HA1}7046452df2cbb530877058712cf17bd4 @operator
 
-  # Monitoring can query for values
-  monitoring {HA1}ec018ffe72b8e75bb4d508ed5b6d079c read
+  # Explicit permissions for a specific use case
+  vm_creator {HA1}7046452df2cbb530877058712cf17bd4 instances.create,instances.list
 
-  # A user who can read and write (the former is implied by granting
-  # write access)
-  superuser {HA1}ec018ffe72b8e75bb4d508ed5b6d079c read,write
+  # Admin without permission to remove instances
+  restricted_admin {HA1}ec018ffe72b8e75bb4d508ed5b6d079c @admin,-instances.remove
+
+  # Read-only with additional permission to cancel jobs
+  monitoring_plus {HA1}7046452df2cbb530877058712cf17bd4 @readonly,+jobs.cancel
 
 When using the RAPI, username and password can be sent to the server
 by using the standard HTTP basic access authentication. This means that

--- a/lib/build/sphinx_ext.py
+++ b/lib/build/sphinx_ext.py
@@ -498,10 +498,15 @@ def _DescribeHandlerAccess(handler, method):
   """
   access = rapi.baserlib.GetHandlerAccess(handler, method)
 
-  if access:
-    return utils.CommaJoin(sorted(access))
-  else:
+  if access is None:
     return "*(none)*"
+  if access == rapi.RAPI_ACCESS_NOT_DEFINED:
+    raise AssertionError(f"Handler {handler.__name__} {method} has no"
+                         " *_ACCESS attribute defined")
+  if isinstance(access, str):
+    return access
+  raise AssertionError(f"Handler {handler.__name__} {method}_ACCESS has"
+                       f" unexpected type {type(access).__name__}")
 
 
 class _RapiHandlersForDocsHelper(object):

--- a/lib/http/auth.py
+++ b/lib/http/auth.py
@@ -42,6 +42,7 @@ from hashlib import md5
 from ganeti import compat
 from ganeti import http
 from ganeti import utils
+from ganeti import rapi
 
 # Digest types from RFC2617
 HTTP_BASIC_AUTH = "Basic"
@@ -287,14 +288,123 @@ class HttpServerRequestAuthentication(object):
     return False
 
 
+_DEPRECATED_PERM_MAPPING = {
+  "read": "readonly",
+  "write": "admin",
+  "all": "admin",
+}
+
+
+def _resolve_permissions(options, roles, _warned=None):
+  """Resolve a list of user options into a set of effective permissions.
+
+  Tokens are processed in a fixed order regardless of their position in
+  the input list:
+
+    1. role references (``@role``) — seed with the role's permission set
+    2. legacy aliases (``read``/``write``/``all``) — map to a role
+    3. explicit permissions (``foo.bar``) — added
+    4. additions (``+foo.bar``) — added
+    5. removals (``-foo.bar``) — removed
+
+  The fixed order means ``@admin,-jobs.cancel`` and ``-jobs.cancel,@admin``
+  produce the same result, eliminating a footgun where a misordered users
+  file silently grants more access than expected.
+
+  @type options: list of str
+  @param options: per-user option tokens from the password file
+  @type roles: dict
+  @param roles: mapping from role name to its frozen permission set
+  @type _warned: set or None
+  @param _warned: optional set used to dedupe deprecation warnings across
+                  multiple calls within one file load
+  @rtype: frozenset
+  @return: effective permissions
+
+  """
+  if _warned is None:
+    _warned = set()
+
+  role_tokens = []
+  legacy_tokens = []
+  explicit_tokens = []
+  add_tokens = []
+  remove_tokens = []
+
+  for option in options:
+    if option.startswith("@"):
+      role_tokens.append(option[1:])
+    elif option.startswith("+"):
+      add_tokens.append(option[1:])
+    elif option.startswith("-"):
+      remove_tokens.append(option[1:])
+    elif option in _DEPRECATED_PERM_MAPPING:
+      legacy_tokens.append(option)
+    else:
+      explicit_tokens.append(option)
+
+  permissions = set()
+
+  for role_name in role_tokens:
+    if role_name in roles:
+      permissions.update(roles[role_name])
+    else:
+      logging.warning("Unknown role '@%s' in user options; ignored."
+                      " Known roles: %s",
+                      role_name, ", ".join(sorted(roles)))
+
+  for option in legacy_tokens:
+    role_name = _DEPRECATED_PERM_MAPPING[option]
+    if option not in _warned:
+      logging.warning("Deprecated permission '%s' found and"
+                      " automatically mapped to '@%s'."
+                      " Please update to use roles (@readonly or @admin)"
+                      " instead.", option, role_name)
+      _warned.add(option)
+    if role_name in roles:
+      permissions.update(roles[role_name])
+
+  permissions.update(explicit_tokens)
+  permissions.update(add_tokens)
+  permissions.difference_update(remove_tokens)
+
+  return frozenset(permissions)
+
+
 class PasswordFileUser(object):
   """Data structure for users from password file.
 
   """
-  def __init__(self, name, password, options):
+  def __init__(self, name, password, options, _warned=None):
+    """Initializes the user.
+
+    @type name: str
+    @param name: user name
+    @type password: str
+    @param password: password (cleartext or hashed)
+    @type options: list of str
+    @param options: per-user option tokens (roles, permissions, modifiers)
+    @type _warned: set or None
+    @param _warned: optional set used by L{ParsePasswordFile} to dedupe
+                    deprecation warnings across all users in one load
+
+    """
     self.name = name
     self.password = password
     self.options = options
+
+    self.permissions = _resolve_permissions(options, rapi.RAPI_ROLES,
+                                            _warned=_warned)
+
+  def has_permission(self, permission):
+    """Returns True if the user has the specified permission.
+
+    @type permission: str
+    @param permission: permission string (e.g. "jobs.list")
+    @rtype: bool
+
+    """
+    return permission in self.permissions
 
 
 def ParsePasswordFile(contents):
@@ -315,13 +425,14 @@ def ParsePasswordFile(contents):
 
   """
   users = {}
+  warned = set()
 
   for line in utils.FilterEmptyLinesAndComments(contents):
     parts = line.split(None, 2)
     if len(parts) < 2:
       # Invalid line
-      # TODO: Return line number from FilterEmptyLinesAndComments
-      logging.warning("Ignoring non-comment line with less than two fields")
+      logging.warning("Ignoring non-comment line with less than two fields."
+                      " Line: '%s'", line)
       continue
 
     name = parts[0]
@@ -335,6 +446,6 @@ def ParsePasswordFile(contents):
     else:
       logging.warning("Ignoring values for user '%s': %s", name, parts[3:])
 
-    users[name] = PasswordFileUser(name, password, options)
+    users[name] = PasswordFileUser(name, password, options, _warned=warned)
 
   return users

--- a/lib/rapi/__init__.py
+++ b/lib/rapi/__init__.py
@@ -32,10 +32,148 @@
 from ganeti import compat
 
 
-RAPI_ACCESS_WRITE = "write"
-RAPI_ACCESS_READ = "read"
+RAPI_ACCESS_NOT_DEFINED = "not_defined"
 
-RAPI_ACCESS_ALL = compat.UniqueFrozenset([
-  RAPI_ACCESS_WRITE,
-  RAPI_ACCESS_READ,
-  ])
+# Job permissions
+RAPI_ACCESS_JOBS_LIST = "jobs.list"
+RAPI_ACCESS_JOBS_QUERY = "jobs.query"
+RAPI_ACCESS_JOBS_CANCEL = "jobs.cancel"
+RAPI_ACCESS_JOBS_WAIT = "jobs.wait"
+
+# instance permissions
+RAPI_ACCESS_INSTANCES_MULTI_ALLOC = "instances.multi_alloc"
+RAPI_ACCESS_INSTANCES_LIST = "instances.list"
+RAPI_ACCESS_INSTANCES_CREATE = "instances.create"
+RAPI_ACCESS_INSTANCES_GROW_DISK = "instances.grow_disk"
+RAPI_ACCESS_INSTANCES_MODIFY = "instances.modify"
+RAPI_ACCESS_INSTANCES_REMOVE = "instances.remove"
+RAPI_ACCESS_INSTANCES_QUERY = "instances.query"
+RAPI_ACCESS_INSTANCES_INFO = "instances.info"
+RAPI_ACCESS_INSTANCES_REBOOT = "instances.reboot"
+RAPI_ACCESS_INSTANCES_STARTUP = "instances.startup"
+RAPI_ACCESS_INSTANCES_SHUTDOWN = "instances.shutdown"
+RAPI_ACCESS_INSTANCES_MIGRATE = "instances.migrate"
+RAPI_ACCESS_INSTANCES_FAILOVER = "instances.failover"
+RAPI_ACCESS_INSTANCES_RENAME = "instances.rename"
+RAPI_ACCESS_INSTANCES_REINSTALL = "instances.reinstall"
+RAPI_ACCESS_INSTANCES_REPLACE_DISKS = "instances.replace_disks"
+RAPI_ACCESS_INSTANCES_RECREATE_DISKS = "instances.recreate_disks"
+RAPI_ACCESS_INSTANCES_ACTIVATE_DISKS = "instances.activate_disks"
+RAPI_ACCESS_INSTANCES_DEACTIVATE_DISKS = "instances.deactivate_disks"
+RAPI_ACCESS_INSTANCES_EXPORT_PREPARE = "instances.export.prepare"
+RAPI_ACCESS_INSTANCES_EXPORT_CREATE = "instances.export.create"
+RAPI_ACCESS_INSTANCES_EXPORT_REMOVE = "instances.export.remove"
+RAPI_ACCESS_INSTANCES_QUERY_CONSOLE = "instances.query.console"
+
+# os permissions
+RAPI_ACCESS_OS_LIST = "os.list"
+
+# filter permissions
+RAPI_ACCESS_FILTER_LIST = "filter.list"
+RAPI_ACCESS_FILTER_CREATE = "filter.create"
+RAPI_ACCESS_FILTER_QUERY = "filter.query"
+RAPI_ACCESS_FILTER_MODIFY = "filter.modify"
+RAPI_ACCESS_FILTER_REMOVE = "filter.remove"
+
+# node permissions
+RAPI_ACCESS_NODES_LIST = "nodes.list"
+RAPI_ACCESS_NODES_QUERY = "nodes.query"
+RAPI_ACCESS_NODES_POWERCYCLE = "nodes.powercycle"
+RAPI_ACCESS_NODES_ROLE_QUERY = "nodes.role.query"
+RAPI_ACCESS_NODES_ROLE_MODIFY = "nodes.role.modify"
+RAPI_ACCESS_NODES_EVACUATE = "nodes.evacuate"
+RAPI_ACCESS_NODES_MIGRATE = "nodes.migrate"
+RAPI_ACCESS_NODES_MODIFY = "nodes.modify"
+RAPI_ACCESS_NODES_STORAGE_QUERY = "nodes.storage.query"
+RAPI_ACCESS_NODES_STORAGE_MODIFY = "nodes.storage.modify"
+RAPI_ACCESS_NODES_STORAGE_REPAIR = "nodes.storage.repair"
+
+# network permissions
+RAPI_ACCESS_NETWORKS_LIST = "networks.list"
+RAPI_ACCESS_NETWORKS_QUERY = "networks.query"
+RAPI_ACCESS_NETWORKS_CREATE = "networks.create"
+RAPI_ACCESS_NETWORKS_REMOVE = "networks.remove"
+RAPI_ACCESS_NETWORKS_CONNECT = "networks.connect"
+RAPI_ACCESS_NETWORKS_DISCONNECT = "networks.disconnect"
+RAPI_ACCESS_NETWORKS_MODIFY = "networks.modify"
+RAPI_ACCESS_NETWORKS_RENAME = "networks.rename"
+
+# groups permissions
+RAPI_ACCESS_GROUPS_LIST = "groups.list"
+RAPI_ACCESS_GROUPS_CREATE = "groups.create"
+RAPI_ACCESS_GROUPS_QUERY = "groups.query"
+RAPI_ACCESS_GROUPS_DELETE = "groups.delete"
+RAPI_ACCESS_GROUPS_MODIFY = "groups.modify"
+RAPI_ACCESS_GROUPS_RENAME = "groups.rename"
+RAPI_ACCESS_GROUPS_ASSIGN_NODES = "groups.assign_nodes"
+
+# query permissions
+RAPI_ACCESS_QUERY_ALL = "query.all"
+
+# cluster permissions
+RAPI_ACCESS_CLUSTER_INFO = "cluster.info"
+RAPI_ACCESS_CLUSTER_MODIFY = "cluster.modify"
+RAPI_ACCESS_CLUSTER_REDISTRIBUTE_CONFIG = "cluster.redistribute_config"
+
+# tags permissions
+RAPI_ACCESS_TAGS_GET = "tags.get"
+RAPI_ACCESS_TAGS_SET = "tags.set"
+RAPI_ACCESS_TAGS_DELETE = "tags.delete"
+
+# All defined permissions. Derived automatically from the RAPI_ACCESS_*
+# string constants above so adding a permission only requires declaring
+# the constant; no separate bookkeeping is needed (except updating
+# RAPI_ACCESS_READONLY when the new permission is read-only).
+RAPI_ACCESS_ALL = compat.UniqueFrozenset(
+  v for k, v in dict(vars()).items()
+  if k.startswith("RAPI_ACCESS_")
+  and isinstance(v, str)
+  and k != "RAPI_ACCESS_NOT_DEFINED"
+  )
+
+# Read-only permissions for the @readonly role
+RAPI_ACCESS_READONLY = frozenset([
+  RAPI_ACCESS_JOBS_LIST,
+  RAPI_ACCESS_JOBS_QUERY,
+  RAPI_ACCESS_INSTANCES_LIST,
+  RAPI_ACCESS_INSTANCES_QUERY,
+  RAPI_ACCESS_INSTANCES_INFO,
+  RAPI_ACCESS_NODES_LIST,
+  RAPI_ACCESS_NODES_QUERY,
+  RAPI_ACCESS_NODES_ROLE_QUERY,
+  RAPI_ACCESS_NETWORKS_LIST,
+  RAPI_ACCESS_NETWORKS_QUERY,
+  RAPI_ACCESS_GROUPS_LIST,
+  RAPI_ACCESS_GROUPS_QUERY,
+  RAPI_ACCESS_FILTER_LIST,
+  RAPI_ACCESS_FILTER_QUERY,
+  RAPI_ACCESS_CLUSTER_INFO,
+  RAPI_ACCESS_TAGS_GET,
+  RAPI_ACCESS_QUERY_ALL,
+  RAPI_ACCESS_OS_LIST,
+])
+
+# Permissions for the @operator role: read-only access plus instance
+# operations that don't change cluster/instance configuration. Includes
+# lifecycle (start/stop/reboot), live operations (migrate/failover/
+# replace-disks), backup/export, and console access. Cannot create,
+# modify, remove or rename instances; cannot change cluster, node,
+# network or group configuration.
+RAPI_ACCESS_OPERATOR = RAPI_ACCESS_READONLY | frozenset([
+  RAPI_ACCESS_INSTANCES_STARTUP,
+  RAPI_ACCESS_INSTANCES_SHUTDOWN,
+  RAPI_ACCESS_INSTANCES_REBOOT,
+  RAPI_ACCESS_INSTANCES_MIGRATE,
+  RAPI_ACCESS_INSTANCES_FAILOVER,
+  RAPI_ACCESS_INSTANCES_REPLACE_DISKS,
+  RAPI_ACCESS_INSTANCES_EXPORT_PREPARE,
+  RAPI_ACCESS_INSTANCES_EXPORT_CREATE,
+  RAPI_ACCESS_INSTANCES_EXPORT_REMOVE,
+  RAPI_ACCESS_INSTANCES_QUERY_CONSOLE,
+])
+
+RAPI_ROLES = {
+  "admin": RAPI_ACCESS_ALL,
+  "readonly": RAPI_ACCESS_READONLY,
+  "operator": RAPI_ACCESS_OPERATOR,
+  }

--- a/lib/rapi/baserlib.py
+++ b/lib/rapi/baserlib.py
@@ -298,10 +298,18 @@ class ResourceBase(object):
 
   """
   # Default permission requirements
-  GET_ACCESS = []
-  PUT_ACCESS = [rapi.RAPI_ACCESS_WRITE]
-  POST_ACCESS = [rapi.RAPI_ACCESS_WRITE]
-  DELETE_ACCESS = [rapi.RAPI_ACCESS_WRITE]
+  # A default permission is set. This must be set in the subclass.
+  # If no permission is required, this must be explicitly set to None.
+  GET_ACCESS = rapi.RAPI_ACCESS_NOT_DEFINED
+  PUT_ACCESS = rapi.RAPI_ACCESS_NOT_DEFINED
+  POST_ACCESS = rapi.RAPI_ACCESS_NOT_DEFINED
+  DELETE_ACCESS = rapi.RAPI_ACCESS_NOT_DEFINED
+
+  # Default authentication requirements
+  GET_AUTH_REQUIRED = True
+  PUT_AUTH_REQUIRED = True
+  POST_AUTH_REQUIRED = True
+  DELETE_AUTH_REQUIRED = True
 
   def __init__(self, items, queryargs, req, _client_cls=None):
     """Generic resource constructor.
@@ -448,15 +456,33 @@ def GetResourceOpcodes(cls):
                        for method_attrs in OPCODE_ATTRS) if opcode)
 
 
+def GetHandlerAuthRequired(handler, method):
+  """Returns whether authentication is required for a method on a handler.
+
+  @type handler: L{ResourceBase}
+  @param handler: handler instance or class
+  @type method: string
+  @param method: HTTP method (e.g. C{"GET"})
+  @rtype: bool
+  @return: whether the handler requires the caller to authenticate
+
+  """
+  return getattr(handler, f"{method}_AUTH_REQUIRED", True)
+
+
 def GetHandlerAccess(handler, method):
   """Returns the access rights for a method on a handler.
 
   @type handler: L{ResourceBase}
+  @param handler: handler instance or class
   @type method: string
+  @param method: HTTP method (e.g. C{"GET"})
   @rtype: string or None
+  @return: required permission name, C{None} for public, or
+           L{rapi.RAPI_ACCESS_NOT_DEFINED} when missing
 
   """
-  return getattr(handler, "%s_ACCESS" % method, None)
+  return getattr(handler, f"{method}_ACCESS", None)
 
 
 def GetHandler(get_fn, aliases):

--- a/lib/rapi/rlib2.py
+++ b/lib/rapi/rlib2.py
@@ -249,6 +249,9 @@ class R_root(baserlib.ResourceBase):
   """/ resource.
 
   """
+  GET_ACCESS = None
+  GET_AUTH_REQUIRED = False
+
   @staticmethod
   def GET():
     """Supported for legacy reasons.
@@ -270,6 +273,9 @@ class R_version(baserlib.ResourceBase):
   to adapt clients accordingly.
 
   """
+  GET_ACCESS = None
+  GET_AUTH_REQUIRED = False
+
   @staticmethod
   def GET():
     """Returns the remote API version.
@@ -282,6 +288,7 @@ class R_2_info(baserlib.OpcodeResource):
   """/2/info resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_CLUSTER_INFO
   GET_OPCODE = opcodes.OpClusterQuery
   GET_ALIASES = {
     "volume_group_name": "vg_name",
@@ -300,6 +307,9 @@ class R_2_features(baserlib.ResourceBase):
   """/2/features resource.
 
   """
+  GET_ACCESS = None
+  GET_AUTH_REQUIRED = False
+
   @staticmethod
   def GET():
     """Returns list of optional RAPI features implemented.
@@ -312,6 +322,7 @@ class R_2_os(baserlib.OpcodeResource):
   """/2/os resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_OS_LIST
   GET_OPCODE = opcodes.OpOsDiagnose
 
   def GET(self):
@@ -369,6 +380,7 @@ class R_2_redist_config(baserlib.OpcodeResource):
   """/2/redistribute-config resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_CLUSTER_REDISTRIBUTE_CONFIG
   PUT_OPCODE = opcodes.OpClusterRedistConf
 
 
@@ -376,6 +388,7 @@ class R_2_cluster_modify(baserlib.OpcodeResource):
   """/2/modify resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_CLUSTER_MODIFY
   PUT_OPCODE = opcodes.OpClusterSetParams
   PUT_FORBIDDEN = [
     "compression_tools",
@@ -418,6 +431,8 @@ class R_2_filters(baserlib.ResourceBase):
   """/2/filters resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_FILTER_LIST
+  POST_ACCESS = rapi.RAPI_ACCESS_FILTER_CREATE
 
   def GET(self):
     """Returns a list of all filter rules.
@@ -453,6 +468,9 @@ class R_2_filters_uuid(baserlib.ResourceBase):
   """/2/filters/[filter_uuid] resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_FILTER_QUERY
+  PUT_ACCESS = rapi.RAPI_ACCESS_FILTER_MODIFY
+  DELETE_ACCESS = rapi.RAPI_ACCESS_FILTER_REMOVE
   def GET(self):
     """Returns a filter rule.
 
@@ -504,6 +522,8 @@ class R_2_jobs(baserlib.ResourceBase):
   """/2/jobs resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_JOBS_LIST
+
   def GET(self):
     """Returns a dictionary of jobs.
 
@@ -525,6 +545,9 @@ class R_2_jobs_id(baserlib.ResourceBase):
   """/2/jobs/[job_id] resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_JOBS_QUERY
+  DELETE_ACCESS = rapi.RAPI_ACCESS_JOBS_CANCEL
+
   def GET(self):
     """Returns a job status.
 
@@ -559,7 +582,7 @@ class R_2_jobs_id_wait(baserlib.ResourceBase):
   """
   # WaitForJobChange provides access to sensitive information and blocks
   # machine resources (it's a blocking RAPI call), hence restricting access.
-  GET_ACCESS = [rapi.RAPI_ACCESS_WRITE]
+  GET_ACCESS = rapi.RAPI_ACCESS_JOBS_WAIT
 
   def GET(self):
     """Waits for job changes.
@@ -606,6 +629,7 @@ class R_2_nodes(baserlib.OpcodeResource):
   """/2/nodes resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_NODES_LIST
 
   def GET(self):
     """Returns a list of all nodes.
@@ -627,6 +651,7 @@ class R_2_nodes_name(baserlib.OpcodeResource):
   """/2/nodes/[node_name] resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_NODES_QUERY
   GET_ALIASES = {
     "sip": "secondary_ip",
     }
@@ -649,6 +674,7 @@ class R_2_nodes_name_powercycle(baserlib.OpcodeResource):
   """/2/nodes/[node_name]/powercycle resource.
 
   """
+  POST_ACCESS = rapi.RAPI_ACCESS_NODES_POWERCYCLE
   POST_OPCODE = opcodes.OpNodePowercycle
 
   def GetPostOpInput(self):
@@ -665,6 +691,8 @@ class R_2_nodes_name_role(baserlib.OpcodeResource):
   """/2/nodes/[node_name]/role resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_NODES_ROLE_QUERY
+  PUT_ACCESS = rapi.RAPI_ACCESS_NODES_ROLE_MODIFY
   PUT_OPCODE = opcodes.OpNodeSetParams
 
   def GET(self):
@@ -724,6 +752,7 @@ class R_2_nodes_name_evacuate(baserlib.OpcodeResource):
   """/2/nodes/[node_name]/evacuate resource.
 
   """
+  POST_ACCESS = rapi.RAPI_ACCESS_NODES_EVACUATE
   POST_OPCODE = opcodes.OpNodeEvacuate
 
   def GetPostOpInput(self):
@@ -740,6 +769,7 @@ class R_2_nodes_name_migrate(baserlib.OpcodeResource):
   """/2/nodes/[node_name]/migrate resource.
 
   """
+  POST_ACCESS = rapi.RAPI_ACCESS_NODES_MIGRATE
   POST_OPCODE = opcodes.OpNodeMigrate
 
   def GetPostOpInput(self):
@@ -775,6 +805,7 @@ class R_2_nodes_name_modify(baserlib.OpcodeResource):
   """/2/nodes/[node_name]/modify resource.
 
   """
+  POST_ACCESS = rapi.RAPI_ACCESS_NODES_MODIFY
   POST_OPCODE = opcodes.OpNodeSetParams
 
   def GetPostOpInput(self):
@@ -793,7 +824,7 @@ class R_2_nodes_name_storage(baserlib.OpcodeResource):
 
   """
   # LUNodeQueryStorage acquires locks, hence restricting access to GET
-  GET_ACCESS = [rapi.RAPI_ACCESS_WRITE]
+  GET_ACCESS = rapi.RAPI_ACCESS_NODES_STORAGE_QUERY
   GET_OPCODE = opcodes.OpNodeQueryStorage
 
   def GetGetOpInput(self):
@@ -818,6 +849,7 @@ class R_2_nodes_name_storage_modify(baserlib.OpcodeResource):
   """/2/nodes/[node_name]/storage/modify resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_NODES_STORAGE_MODIFY
   PUT_OPCODE = opcodes.OpNodeModifyStorage
 
   def GetPutOpInput(self):
@@ -849,6 +881,7 @@ class R_2_nodes_name_storage_repair(baserlib.OpcodeResource):
   """/2/nodes/[node_name]/storage/repair resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_NODES_STORAGE_REPAIR
   PUT_OPCODE = opcodes.OpRepairNodeStorage
 
   def GetPutOpInput(self):
@@ -872,6 +905,8 @@ class R_2_networks(baserlib.OpcodeResource):
   """/2/networks resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_NETWORKS_LIST
+  POST_ACCESS = rapi.RAPI_ACCESS_NETWORKS_CREATE
   POST_OPCODE = opcodes.OpNetworkAdd
   POST_RENAME = {
     "name": "network_name",
@@ -906,6 +941,8 @@ class R_2_networks_name(baserlib.OpcodeResource):
   """/2/networks/[network_name] resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_NETWORKS_QUERY
+  DELETE_ACCESS = rapi.RAPI_ACCESS_NETWORKS_REMOVE
   DELETE_OPCODE = opcodes.OpNetworkRemove
 
   def GET(self):
@@ -937,6 +974,7 @@ class R_2_networks_name_connect(baserlib.OpcodeResource):
   """/2/networks/[network_name]/connect resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_NETWORKS_CONNECT
   PUT_OPCODE = opcodes.OpNetworkConnect
 
   def GetPutOpInput(self):
@@ -954,6 +992,7 @@ class R_2_networks_name_disconnect(baserlib.OpcodeResource):
   """/2/networks/[network_name]/disconnect resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_NETWORKS_DISCONNECT
   PUT_OPCODE = opcodes.OpNetworkDisconnect
 
   def GetPutOpInput(self):
@@ -971,6 +1010,7 @@ class R_2_networks_name_modify(baserlib.OpcodeResource):
   """/2/networks/[network_name]/modify resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_NETWORKS_MODIFY
   PUT_OPCODE = opcodes.OpNetworkSetParams
 
   def GetPutOpInput(self):
@@ -987,6 +1027,7 @@ class R_2_networks_name_rename(baserlib.OpcodeResource):
   """/2/networks/[network_name]/rename resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_NETWORKS_RENAME
   PUT_OPCODE = opcodes.OpNetworkRename
 
   def GetPutOpInput(self):
@@ -1004,6 +1045,8 @@ class R_2_groups(baserlib.OpcodeResource):
   """/2/groups resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_GROUPS_LIST
+  POST_ACCESS = rapi.RAPI_ACCESS_GROUPS_CREATE
   POST_OPCODE = opcodes.OpGroupAdd
   POST_RENAME = {
     "name": "group_name",
@@ -1039,6 +1082,8 @@ class R_2_groups_name(baserlib.OpcodeResource):
   """/2/groups/[group_name] resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_GROUPS_QUERY
+  DELETE_ACCESS = rapi.RAPI_ACCESS_GROUPS_DELETE
   DELETE_OPCODE = opcodes.OpGroupRemove
 
   def GET(self):
@@ -1069,6 +1114,7 @@ class R_2_groups_name_modify(baserlib.OpcodeResource):
   """/2/groups/[group_name]/modify resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_GROUPS_MODIFY
   PUT_OPCODE = opcodes.OpGroupSetParams
   PUT_RENAME = {
     "custom_ndparams": "ndparams",
@@ -1090,6 +1136,7 @@ class R_2_groups_name_rename(baserlib.OpcodeResource):
   """/2/groups/[group_name]/rename resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_GROUPS_RENAME
   PUT_OPCODE = opcodes.OpGroupRename
 
   def GetPutOpInput(self):
@@ -1107,6 +1154,7 @@ class R_2_groups_name_assign_nodes(baserlib.OpcodeResource):
   """/2/groups/[group_name]/assign-nodes resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_GROUPS_ASSIGN_NODES
   PUT_OPCODE = opcodes.OpGroupAssignNodes
 
   def GetPutOpInput(self):
@@ -1146,6 +1194,8 @@ class R_2_instances(baserlib.OpcodeResource):
   """/2/instances resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_INSTANCES_LIST
+  POST_ACCESS = rapi.RAPI_ACCESS_INSTANCES_CREATE
   POST_OPCODE = opcodes.OpInstanceCreate
   POST_RENAME = {
     "os": "os_type",
@@ -1202,6 +1252,7 @@ class R_2_instances_multi_alloc(baserlib.OpcodeResource):
   """/2/instances-multi-alloc resource.
 
   """
+  POST_ACCESS = rapi.RAPI_ACCESS_INSTANCES_MULTI_ALLOC
   POST_OPCODE = opcodes.OpInstanceMultiAlloc
 
   def GetPostOpInput(self):
@@ -1239,6 +1290,8 @@ class R_2_instances_name(baserlib.OpcodeResource):
   """/2/instances/[instance_name] resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_INSTANCES_QUERY
+  DELETE_ACCESS = rapi.RAPI_ACCESS_INSTANCES_REMOVE
   DELETE_OPCODE = opcodes.OpInstanceRemove
 
   def GET(self):
@@ -1271,6 +1324,7 @@ class R_2_instances_name_info(baserlib.OpcodeResource):
   """/2/instances/[instance_name]/info resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_INSTANCES_INFO
   GET_OPCODE = opcodes.OpInstanceQueryData
 
   def GetGetOpInput(self):
@@ -1290,6 +1344,7 @@ class R_2_instances_name_reboot(baserlib.OpcodeResource):
   Implements an instance reboot.
 
   """
+  POST_ACCESS = rapi.RAPI_ACCESS_INSTANCES_REBOOT
   POST_OPCODE = opcodes.OpInstanceReboot
 
   def GetPostOpInput(self):
@@ -1314,6 +1369,7 @@ class R_2_instances_name_startup(baserlib.OpcodeResource):
   Implements an instance startup.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_INSTANCES_STARTUP
   PUT_OPCODE = opcodes.OpInstanceStartup
 
   def GetPutOpInput(self):
@@ -1337,6 +1393,7 @@ class R_2_instances_name_shutdown(baserlib.OpcodeResource):
   Implements an instance shutdown.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_INSTANCES_SHUTDOWN
   PUT_OPCODE = opcodes.OpInstanceShutdown
 
   def GetPutOpInput(self):
@@ -1380,6 +1437,7 @@ class R_2_instances_name_reinstall(baserlib.OpcodeResource):
   Implements an instance reinstall.
 
   """
+  POST_ACCESS = rapi.RAPI_ACCESS_INSTANCES_REINSTALL
   POST_OPCODE = opcodes.OpInstanceReinstall
 
   def POST(self):
@@ -1413,6 +1471,7 @@ class R_2_instances_name_replace_disks(baserlib.OpcodeResource):
   """/2/instances/[instance_name]/replace-disks resource.
 
   """
+  POST_ACCESS = rapi.RAPI_ACCESS_INSTANCES_REPLACE_DISKS
   POST_OPCODE = opcodes.OpInstanceReplaceDisks
 
   def GetPostOpInput(self):
@@ -1459,6 +1518,7 @@ class R_2_instances_name_activate_disks(baserlib.OpcodeResource):
   """/2/instances/[instance_name]/activate-disks resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_INSTANCES_ACTIVATE_DISKS
   PUT_OPCODE = opcodes.OpInstanceActivateDisks
 
   def GetPutOpInput(self):
@@ -1477,6 +1537,7 @@ class R_2_instances_name_deactivate_disks(baserlib.OpcodeResource):
   """/2/instances/[instance_name]/deactivate-disks resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_INSTANCES_DEACTIVATE_DISKS
   PUT_OPCODE = opcodes.OpInstanceDeactivateDisks
 
   def GetPutOpInput(self):
@@ -1493,6 +1554,7 @@ class R_2_instances_name_recreate_disks(baserlib.OpcodeResource):
   """/2/instances/[instance_name]/recreate-disks resource.
 
   """
+  POST_ACCESS = rapi.RAPI_ACCESS_INSTANCES_RECREATE_DISKS
   POST_OPCODE = opcodes.OpInstanceRecreateDisks
 
   def GetPostOpInput(self):
@@ -1508,6 +1570,7 @@ class R_2_instances_name_prepare_export(baserlib.OpcodeResource):
   """/2/instances/[instance_name]/prepare-export resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_INSTANCES_EXPORT_PREPARE
   PUT_OPCODE = opcodes.OpBackupPrepare
 
   def GetPutOpInput(self):
@@ -1524,10 +1587,12 @@ class R_2_instances_name_export(baserlib.OpcodeResource):
   """/2/instances/[instance_name]/export resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_INSTANCES_EXPORT_CREATE
   PUT_OPCODE = opcodes.OpBackupExport
   PUT_RENAME = {
     "destination": "target_node",
     }
+  DELETE_ACCESS = rapi.RAPI_ACCESS_INSTANCES_EXPORT_REMOVE
   DELETE_OPCODE = opcodes.OpBackupRemove
 
   def GetPutOpInput(self):
@@ -1550,6 +1615,7 @@ class R_2_instances_name_migrate(baserlib.OpcodeResource):
   """/2/instances/[instance_name]/migrate resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_INSTANCES_MIGRATE
   PUT_OPCODE = opcodes.OpInstanceMigrate
 
   def GetPutOpInput(self):
@@ -1565,6 +1631,7 @@ class R_2_instances_name_failover(baserlib.OpcodeResource):
   """/2/instances/[instance_name]/failover resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_INSTANCES_FAILOVER
   PUT_OPCODE = opcodes.OpInstanceFailover
 
   def GetPutOpInput(self):
@@ -1580,6 +1647,7 @@ class R_2_instances_name_rename(baserlib.OpcodeResource):
   """/2/instances/[instance_name]/rename resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_INSTANCES_RENAME
   PUT_OPCODE = opcodes.OpInstanceRename
 
   def GetPutOpInput(self):
@@ -1595,6 +1663,7 @@ class R_2_instances_name_modify(baserlib.OpcodeResource):
   """/2/instances/[instance_name]/modify resource.
 
   """
+  PUT_ACCESS = rapi.RAPI_ACCESS_INSTANCES_MODIFY
   PUT_OPCODE = opcodes.OpInstanceSetParams
   PUT_RENAME = {
     "custom_beparams": "beparams",
@@ -1617,6 +1686,7 @@ class R_2_instances_name_disk_grow(baserlib.OpcodeResource):
   """/2/instances/[instance_name]/disk/[disk_index]/grow resource.
 
   """
+  POST_ACCESS = rapi.RAPI_ACCESS_INSTANCES_GROW_DISK
   POST_OPCODE = opcodes.OpInstanceGrowDisk
 
   def GetPostOpInput(self):
@@ -1633,7 +1703,7 @@ class R_2_instances_name_console(baserlib.ResourceBase):
   """/2/instances/[instance_name]/console resource.
 
   """
-  GET_ACCESS = [rapi.RAPI_ACCESS_WRITE, rapi.RAPI_ACCESS_READ]
+  GET_ACCESS = rapi.RAPI_ACCESS_INSTANCES_QUERY_CONSOLE
   GET_OPCODE = opcodes.OpInstanceConsole
 
   def GET(self):
@@ -1688,7 +1758,7 @@ class R_2_query(baserlib.ResourceBase):
 
   """
   # Results might contain sensitive information
-  GET_ACCESS = [rapi.RAPI_ACCESS_WRITE, rapi.RAPI_ACCESS_READ]
+  GET_ACCESS = rapi.RAPI_ACCESS_QUERY_ALL
   PUT_ACCESS = GET_ACCESS
   GET_OPCODE = opcodes.OpQuery
   PUT_OPCODE = opcodes.OpQuery
@@ -1732,6 +1802,7 @@ class R_2_query_fields(baserlib.ResourceBase):
   """/2/query/[resource]/fields resource.
 
   """
+  GET_ACCESS = rapi.RAPI_ACCESS_QUERY_ALL
   GET_OPCODE = opcodes.OpQueryFields
 
   def GET(self):
@@ -1758,6 +1829,9 @@ class _R_Tags(baserlib.OpcodeResource):
 
   """
   TAG_LEVEL = None
+  GET_ACCESS = rapi.RAPI_ACCESS_TAGS_GET
+  PUT_ACCESS = rapi.RAPI_ACCESS_TAGS_SET
+  DELETE_ACCESS = rapi.RAPI_ACCESS_TAGS_DELETE
   GET_OPCODE = opcodes.OpTagsGet
   PUT_OPCODE = opcodes.OpTagsSet
   DELETE_OPCODE = opcodes.OpTagsDel

--- a/lib/rapi/testutils.py
+++ b/lib/rapi/testutils.py
@@ -425,7 +425,7 @@ class InputTestClient(object):
       """
       assert username == wanted
       return http.auth.PasswordFileUser(username, password,
-                                        [rapi.RAPI_ACCESS_WRITE])
+                                        ["@admin"])
 
     self._lcr = _LuxiCallRecorder()
 

--- a/lib/server/rapi.py
+++ b/lib/server/rapi.py
@@ -53,6 +53,7 @@ from ganeti import utils
 from ganeti import pathutils
 from ganeti.rapi import connector
 from ganeti.rapi import baserlib
+from ganeti import rapi
 
 import ganeti.http.auth   # pylint: disable=W0611
 import ganeti.http.server # pylint: disable=W0611
@@ -66,6 +67,7 @@ class RemoteApiRequestContext(object):
     self.handler = None
     self.handler_fn = None
     self.handler_access = None
+    self.handler_auth_required = True
     self.body_data = None
 
 
@@ -128,10 +130,15 @@ class RemoteApiHandler(http.auth.HttpServerRequestAuthentication,
                                       (method, req.request_path))
 
       ctx.handler_access = baserlib.GetHandlerAccess(ctx.handler, method)
-
       # Require permissions definition (usually in the base class)
-      if ctx.handler_access is None:
+      if ctx.handler_access is rapi.RAPI_ACCESS_NOT_DEFINED:
         raise AssertionError("Permissions definition missing")
+
+      ctx.handler_auth_required = baserlib.GetHandlerAuthRequired(
+        ctx.handler, method)
+      # Require auth required definition
+      if ctx.handler_auth_required is None:
+        raise AssertionError("Authentication requirement definition missing")
 
       # This is only made available in HandleRequest
       ctx.body_data = None
@@ -141,7 +148,7 @@ class RemoteApiHandler(http.auth.HttpServerRequestAuthentication,
     # Check for expected attributes
     assert req.private.handler
     assert req.private.handler_fn
-    assert req.private.handler_access is not None
+    # handler_access can be None for public endpoints
 
     return req.private
 
@@ -149,7 +156,8 @@ class RemoteApiHandler(http.auth.HttpServerRequestAuthentication,
     """Determine whether authentication is required.
 
     """
-    return self._reqauth or bool(self._GetRequestContext(req).handler_access)
+    ctx = self._GetRequestContext(req)
+    return self._reqauth or ctx.handler_auth_required
 
   def Authenticate(self, req, username, password):
     """Checks whether a user can access a resource.
@@ -164,12 +172,13 @@ class RemoteApiHandler(http.auth.HttpServerRequestAuthentication,
       # Unknown user or password wrong
       return False
 
-    if (not ctx.handler_access or
-        set(user.options).intersection(ctx.handler_access)):
-      # Allow access
+    # check permissions
+    if ctx.handler_access is None or user.has_permission(ctx.handler_access):
       return True
 
-    # Access forbidden
+    logging.warning("User '%s' lacks permission '%s' for %s %s",
+                    username, ctx.handler_access,
+                    req.request_method, req.request_path)
     raise http.HttpForbidden()
 
   def HandleRequest(self, req):

--- a/man/ganeti-rapi.rst
+++ b/man/ganeti-rapi.rst
@@ -50,12 +50,15 @@ in the same format as for the node and master daemon.
 ACCESS CONTROLS
 ---------------
 
-Most query operations are allowed without authentication. Only the
-modification operations require authentication, in the form of basic
-authentication. Specify the ``--require-authentication`` command line
-flag to always require authentication.
+Authentication is required for almost all RAPI resources. Only the
+informational endpoints (``/``, ``/2``, ``/version``, ``/2/features``)
+are reachable without credentials. Each remaining resource declares the
+permission it requires; users are granted permissions individually or
+via predefined roles (``@admin``, ``@readonly``, ``@operator``). When the
+``--require-authentication`` command line flag is passed, even the
+informational endpoints require authentication.
 
-The users and their rights are defined in the
+The users and their permissions are defined in the
 ``@LOCALSTATEDIR@/lib/ganeti/rapi/users`` file. The format of this file
 is described in the Ganeti documentation (``rapi.html``).
 

--- a/qa/ganeti-qa.py
+++ b/qa/ganeti-qa.py
@@ -292,6 +292,7 @@ def RunClusterTests():
     ("cluster-instance-communication", qa_cluster.TestInstanceCommunication),
     (qa_rapi.Enabled, qa_rapi.TestVersion),
     (qa_rapi.Enabled, qa_rapi.TestEmptyCluster),
+    (qa_rapi.Enabled, qa_rapi.TestRapiUserPermissions),
     (qa_rapi.Enabled, qa_rapi.TestRapiQuery),
     ]:
     RunTestIf(test, fn)

--- a/qa/qa_rapi.py
+++ b/qa/qa_rapi.py
@@ -183,7 +183,7 @@ def _CreateRapiUser(rapi_user):
 
   fh = tempfile.NamedTemporaryFile(mode="w")
   try:
-    fh.write("%s %s write\n" % (rapi_user, rapi_secret))
+    fh.write("%s %s @admin\n" % (rapi_user, rapi_secret))
     fh.flush()
 
     tmpru = qa_utils.UploadFile(master.primary, fh.name)
@@ -199,6 +199,92 @@ def _CreateRapiUser(rapi_user):
   AssertCommand(["service", "ganeti", "restart"])
 
   return rapi_secret
+
+
+def _UploadRapiUsersFile(content):
+  """Replaces the RAPI users file on the master with C{content}.
+
+  @type content: str
+  @param content: full file content to write
+
+  """
+  master = qa_config.GetMasterNode()
+  rapi_users_path = qa_utils.MakeNodePath(master, pathutils.RAPI_USERS_FILE)
+  rapi_dir = os.path.dirname(rapi_users_path)
+
+  fh = tempfile.NamedTemporaryFile(mode="w")
+  try:
+    fh.write(content)
+    fh.flush()
+    tmpru = qa_utils.UploadFile(master.primary, fh.name)
+    try:
+      AssertCommand(["mkdir", "-p", rapi_dir])
+      AssertCommand(["mv", tmpru, rapi_users_path])
+    finally:
+      AssertCommand(["rm", "-f", tmpru])
+  finally:
+    fh.close()
+
+
+def _ReloadRapiUsers():
+  """Sends SIGHUP to the RAPI daemon to reload the users file in place.
+
+  """
+  pidfile = utils.PathJoin(pathutils.RUN_DIR, f"{constants.RAPI}.pid")
+  AssertCommand(f"kill -HUP $(cat {utils.ShellQuote(pidfile)})")
+
+
+def _AddRapiUsers(extra_users):
+  """Appends extra users to the RAPI users file and SIGHUP-reloads.
+
+  @type extra_users: list of tuple
+  @param extra_users: list of C{(username, password, options)} triples
+    where C{options} is a string such as C{"@readonly"} or
+    C{"@operator,+jobs.cancel"}
+  @rtype: str
+  @return: the original file content; pass to L{_RestoreRapiUsersFile}
+    to revert all changes
+
+  """
+  master = qa_config.GetMasterNode()
+  rapi_users_path = qa_utils.MakeNodePath(master, pathutils.RAPI_USERS_FILE)
+
+  original = qa_utils.GetCommandOutput(
+    master.primary, utils.ShellQuoteArgs(["cat", rapi_users_path]))
+
+  # GetCommandOutput may drop a trailing newline; make sure the appended
+  # lines start on a fresh line.
+  separator = "" if not original or original.endswith("\n") else "\n"
+  appended = "".join(f"{u} {p} {o}\n" for (u, p, o) in extra_users)
+  _UploadRapiUsersFile(original + separator + appended)
+  _ReloadRapiUsers()
+  return original
+
+
+def _RestoreRapiUsersFile(original_content):
+  """Restores the RAPI users file from a snapshot taken by L{_AddRapiUsers}.
+
+  """
+  _UploadRapiUsersFile(original_content)
+  _ReloadRapiUsers()
+
+
+def _BuildRapiClient(username, password):
+  """Constructs a L{GanetiRapiClient} for the given credentials.
+
+  Reuses the CA file already loaded by L{ReloadCertificates}.
+
+  @type username: str
+  @type password: str
+  @rtype: L{rapi.client.GanetiRapiClient}
+
+  """
+  master = qa_config.GetMasterNode()
+  port = qa_config.get("rapi-port", default=constants.DEFAULT_RAPI_PORT)
+  cfg_curl = rapi.client.GenericCurlConfig(cafile=_rapi_ca.name, proxy="")
+  return rapi.client.GanetiRapiClient(master.primary, port=port,
+                                      username=username, password=password,
+                                      curl_config_fn=cfg_curl)
 
 
 def _LookupRapiSecret(rapi_user):
@@ -529,6 +615,98 @@ def TestEmptyCluster():
   _DoGetPutTests("/2/info", "/2/modify", opcodes.OpClusterSetParams.OP_PARAMS,
                  exceptions=(LEGITIMATELY_MISSING + NOT_EXPOSED_YET),
                  set_exceptions=DEFAULT_ISSUES + FORBIDDEN_PARAMS)
+
+
+def _AssertRapiCode(client, method, uri, body, expected_code):
+  """Send a request and assert that it fails with C{expected_code}.
+
+  """
+  # pylint: disable=W0212
+  try:
+    client._SendRequest(method, uri, None, body)
+  except rapi.client.GanetiApiError as err:
+    AssertEqual(err.code, expected_code)
+    return
+  raise qa_error.Error(f"Expected HTTP {expected_code} for {method} {uri},"
+                       " got success")
+
+
+def _AssertAuthPasses(client, method, uri, body):
+  """Send a request and assert that authentication/authorization succeeded.
+
+  Any HTTP status other than 401/403 is acceptable: the goal is to prove
+  that the user was authorized, not that the underlying handler succeeded.
+
+  """
+  # pylint: disable=W0212
+  try:
+    client._SendRequest(method, uri, None, body)
+  except rapi.client.GanetiApiError as err:
+    if err.code in (401, 403):
+      raise qa_error.Error(f"Expected auth pass for {method} {uri},"
+                           f" got HTTP {err.code}")
+
+
+def TestRapiUserPermissions():
+  """Verify the role-based access control enforces correctly.
+
+  Adds temporary @readonly and @operator users via SIGHUP reload, then
+  asserts:
+
+    - @readonly cannot perform modifications (403 on write endpoints)
+    - @operator cannot reconfigure cluster (403 on /2/modify)
+    - @operator IS allowed to call instance lifecycle endpoints
+      (a non-existent target name yields 404 from the handler, proving
+      authorization passed)
+    - both can call /2/info (granted by @readonly)
+    - wrong password / unknown user => 401
+
+  Restores the original users file at the end regardless of outcome.
+
+  """
+  if _rapi_ca is None:
+    # Virtual cluster: ReloadCertificates() never set things up
+    return
+
+  ro_user = "qa-rbac-readonly"
+  ro_pass = utils.GenerateSecret()
+  op_user = "qa-rbac-operator"
+  op_pass = utils.GenerateSecret()
+
+  original = _AddRapiUsers([
+    (ro_user, ro_pass, "@readonly"),
+    (op_user, op_pass, "@operator"),
+    ])
+  try:
+    ro_client = _BuildRapiClient(ro_user, ro_pass)
+    op_client = _BuildRapiClient(op_user, op_pass)
+
+    # Both roles can read cluster info.
+    ro_client.GetInfo()
+    op_client.GetInfo()
+
+    # @readonly: every modification endpoint returns 403.
+    _AssertRapiCode(ro_client, "PUT", "/2/redistribute-config", None, 403)
+    _AssertRapiCode(ro_client, "PUT", "/2/modify", {}, 403)
+    _AssertRapiCode(ro_client, "POST", "/2/groups",
+                    {"group_name": "qa-rbac-fake"}, 403)
+
+    # @operator: cluster reconfiguration is forbidden ...
+    _AssertRapiCode(op_client, "PUT", "/2/redistribute-config", None, 403)
+    _AssertRapiCode(op_client, "PUT", "/2/modify", {}, 403)
+
+    # ... but instance lifecycle is permitted: targeting a nonexistent
+    # instance gets past the auth layer and hits the resource handler.
+    _AssertAuthPasses(op_client, "PUT",
+                      "/2/instances/qa-rbac-nonexistent/shutdown", {})
+
+    # Wrong password and unknown users both get 401.
+    _AssertRapiCode(_BuildRapiClient(ro_user, "wrongpassword"),
+                    "GET", "/2/info", None, 401)
+    _AssertRapiCode(_BuildRapiClient("qa-rbac-no-such-user", "anything"),
+                    "GET", "/2/info", None, 401)
+  finally:
+    _RestoreRapiUsersFile(original)
 
 
 def TestRapiQuery():

--- a/test/py/legacy/ganeti.rapi.rlib2_unittest.py
+++ b/test/py/legacy/ganeti.rapi.rlib2_unittest.py
@@ -1483,25 +1483,27 @@ class TestInstancesMultiAlloc(unittest.TestCase):
 
 
 class TestPermissions(unittest.TestCase):
-  def testEquality(self):
-    self.assertEqual(rlib2.R_2_query.GET_ACCESS, rlib2.R_2_query.PUT_ACCESS)
-    self.assertEqual(rlib2.R_2_query.GET_ACCESS,
-                     rlib2.R_2_instances_name_console.GET_ACCESS)
-
   def testMethodAccess(self):
     for handler in connector.CONNECTOR.values():
       for method in baserlib._SUPPORTED_METHODS:
+        # Only check methods that are actually implemented by the handler
+        if not hasattr(handler, method):
+          continue
+
         access = baserlib.GetHandlerAccess(handler, method)
-        self.assertFalse(access is None)
-        self.assertFalse(set(access) - rapi.RAPI_ACCESS_ALL,
-                         msg=("Handler '%s' uses unknown access options for"
-                              " method %s" % (handler, method)))
-        self.assertTrue(rapi.RAPI_ACCESS_READ not in access or
-                        rapi.RAPI_ACCESS_WRITE in access,
-                        msg=("Handler '%s' gives query, but not write access"
-                             " for method %s (the latter includes query and"
-                             " should therefore be given as well)" %
-                             (handler, method)))
+        # None access is allowed for endpoint without permissions
+        if access is None:
+          continue
+
+        # Check that permission is defined
+        self.assertNotEqual(access, rapi.RAPI_ACCESS_NOT_DEFINED,
+                            msg=(f"Handler '{handler}' does not define access"
+                                 f" for method {method}"))
+
+        # Check that access is known and defined in rapi module
+        self.assertIn(access, rapi.RAPI_ACCESS_ALL,
+                      msg=(f"Handler '{handler}' uses unknown access option"
+                           f" for method {method}"))
 
 
 class ForbiddenOpcode(opcodes.OpCode):

--- a/test/py/legacy/ganeti.server.rapi_unittest.py
+++ b/test/py/legacy/ganeti.server.rapi_unittest.py
@@ -181,7 +181,7 @@ class TestRemoteApiHandler(unittest.TestCase):
       else:
         return None
 
-    for access in [rapi.RAPI_ACCESS_WRITE, rapi.RAPI_ACCESS_READ]:
+    for access in [rapi.RAPI_ACCESS_QUERY_ALL]:
       def _LookupUserWithWrite(name):
         if name == username:
           return http.auth.PasswordFileUser(name, password, [
@@ -252,9 +252,12 @@ class TestRemoteApiHandler(unittest.TestCase):
         # No authorization
         (code, _, _) = self._Test(method, path, "", "", reqauth=reqauth)
 
-        if method == http.HTTP_GET or reqauth:
+        if method == http.HTTP_GET:
+          # GET is implemented but requires auth
           self.assertEqual(code, http.HttpUnauthorized.code)
         else:
+          # Other methods are not implemented - 501 is returned
+          # before authentication is checked
           self.assertEqual(code, http.HttpNotImplemented.code)
 
 

--- a/test/py/unit/http/test_auth.py
+++ b/test/py/unit/http/test_auth.py
@@ -1,0 +1,256 @@
+#
+#
+
+# Copyright (C) 2026 the Ganeti project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Unit tests for ganeti.http.auth module."""
+
+import logging
+
+from ganeti import rapi
+from ganeti.http import auth
+
+
+class TestPasswordFileUserPermissions:
+  """Test cases for PasswordFileUser.has_permission() with different formats.
+
+  Format: username password <@role|permissions|@role,+add,-remove>
+  """
+
+  def test_explicit_permissions(self):
+    """Test explicit permission list: user password perm1,perm2,perm3"""
+    users = auth.ParsePasswordFile(
+      "user1 secret jobs.list,jobs.cancel,instances.list"
+    )
+    user = users["user1"]
+
+    assert user.has_permission("jobs.list")
+    assert user.has_permission("jobs.cancel")
+    assert user.has_permission("instances.list")
+
+    assert not user.has_permission("instances.create")
+    assert not user.has_permission("nodes.list")
+    assert not user.has_permission("cluster.info")
+
+  def test_role_based_permissions(self):
+    """Test role-based permissions: user password @admin"""
+    users = auth.ParsePasswordFile("admin_user secret @admin")
+    user = users["admin_user"]
+
+    assert user.has_permission("jobs.list")
+    assert user.has_permission("instances.create")
+    assert user.has_permission("nodes.migrate")
+    assert user.has_permission("cluster.info")
+
+  def test_role_with_modifications(self):
+    """Test role with additions and removals:
+        user password @admin,+custom,-removed
+    """
+    users = auth.ParsePasswordFile(
+      "modified_user secret @admin,+custom.permission,-jobs.cancel"
+    )
+    user = users["modified_user"]
+
+    assert user.has_permission("jobs.list")
+    assert user.has_permission("instances.create")
+
+    assert user.has_permission("custom.permission")
+
+    assert not user.has_permission("jobs.cancel")
+
+  def test_unknown_role(self):
+    """Test that unknown roles are ignored"""
+    users = auth.ParsePasswordFile(
+      "user1 secret @nonexistent_role,jobs.list"
+    )
+    user = users["user1"]
+
+    assert user.has_permission("jobs.list")
+    assert not user.has_permission("instances.create")
+
+  def test_empty_options(self):
+    """Test user with no permissions"""
+    users = auth.ParsePasswordFile("user1 secret")
+    user = users["user1"]
+
+    assert not user.has_permission("jobs.list")
+    assert not user.has_permission("instances.create")
+    assert len(user.permissions) == 0
+
+  def test_mixed_permissions_and_role(self):
+    """Test mixed format: role + explicit permissions"""
+    users = auth.ParsePasswordFile(
+      "user1 secret @admin,extra.permission"
+    )
+    user = users["user1"]
+
+    assert user.has_permission("jobs.list")
+    assert user.has_permission("instances.create")
+
+    assert user.has_permission("extra.permission")
+
+  def test_deprecated_write_maps_to_admin(self):
+    """Legacy 'write' option resolves to admin role permissions."""
+    users = auth.ParsePasswordFile("user1 secret write")
+    user = users["user1"]
+
+    assert user.has_permission("instances.create")
+    assert user.has_permission("cluster.modify")
+
+  def test_deprecated_read_maps_to_readonly(self):
+    """Legacy 'read' option resolves to readonly role permissions."""
+    users = auth.ParsePasswordFile("user1 secret read")
+    user = users["user1"]
+
+    assert user.has_permission("instances.list")
+    assert user.has_permission("cluster.info")
+    assert not user.has_permission("instances.create")
+
+
+class TestResolvePermissions:
+  """Direct unit tests for _resolve_permissions."""
+
+  def test_returns_frozenset(self):
+    result = auth._resolve_permissions([], rapi.RAPI_ROLES)
+    assert isinstance(result, frozenset)
+
+  def test_empty_options(self):
+    assert auth._resolve_permissions([], rapi.RAPI_ROLES) == frozenset()
+
+  def test_order_independence_admin_then_remove(self):
+    """@admin,-jobs.cancel and -jobs.cancel,@admin must give same result."""
+    a = auth._resolve_permissions(["@admin", "-jobs.cancel"], rapi.RAPI_ROLES)
+    b = auth._resolve_permissions(["-jobs.cancel", "@admin"], rapi.RAPI_ROLES)
+    assert a == b
+    assert "jobs.cancel" not in a
+
+  def test_order_independence_complex(self):
+    """All combinations of role+add+remove+explicit must canonicalize."""
+    tokens = ["-jobs.cancel", "+custom.x", "@readonly", "extra.y"]
+    expected = auth._resolve_permissions(tokens, rapi.RAPI_ROLES)
+    # Reverse order produces the same set
+    assert auth._resolve_permissions(list(reversed(tokens)),
+                                     rapi.RAPI_ROLES) == expected
+    assert "custom.x" in expected
+    assert "extra.y" in expected
+    assert "jobs.cancel" not in expected
+
+  def test_remove_wins_over_add(self):
+    """A token in both add and remove lists is removed."""
+    result = auth._resolve_permissions(["+x.y", "-x.y"], rapi.RAPI_ROLES)
+    assert "x.y" not in result
+
+  def test_unknown_role_logs_warning(self, caplog):
+    with caplog.at_level(logging.WARNING):
+      result = auth._resolve_permissions(["@bogus"], rapi.RAPI_ROLES)
+    assert result == frozenset()
+    assert any("Unknown role '@bogus'" in r.getMessage()
+               for r in caplog.records)
+
+  def test_deprecated_write_logs_warning(self, caplog):
+    with caplog.at_level(logging.WARNING):
+      result = auth._resolve_permissions(["write"], rapi.RAPI_ROLES)
+    assert result == rapi.RAPI_ACCESS_ALL
+    assert any("Deprecated permission 'write'" in r.getMessage()
+               for r in caplog.records)
+
+  def test_deprecation_warning_dedups_within_load(self, caplog):
+    """Two users with 'write' should produce one warning per file load."""
+    contents = "user1 pw write\nuser2 pw write\nuser3 pw read\n"
+    with caplog.at_level(logging.WARNING):
+      auth.ParsePasswordFile(contents)
+    write_warnings = [r for r in caplog.records
+                      if "Deprecated permission 'write'" in r.getMessage()]
+    read_warnings = [r for r in caplog.records
+                     if "Deprecated permission 'read'" in r.getMessage()]
+    assert len(write_warnings) == 1
+    assert len(read_warnings) == 1
+
+
+class TestOperatorRole:
+  """The @operator role grants @readonly + start/stop/restart on instances."""
+
+  def test_operator_is_readonly_superset(self):
+    operator = rapi.RAPI_ROLES["operator"]
+    readonly = rapi.RAPI_ROLES["readonly"]
+    assert readonly < operator
+
+  def test_operator_instance_operations(self):
+    """Operator can perform non-config instance operations."""
+    users = auth.ParsePasswordFile("op secret @operator")
+    user = users["op"]
+    allowed = [
+      "instances.startup",
+      "instances.shutdown",
+      "instances.reboot",
+      "instances.migrate",
+      "instances.failover",
+      "instances.replace_disks",
+      "instances.export.prepare",
+      "instances.export.create",
+      "instances.export.remove",
+      "instances.query.console",
+    ]
+    for perm in allowed:
+      assert user.has_permission(perm), \
+        f"@operator should have '{perm}'"
+
+  def test_operator_inherits_readonly_queries(self):
+    """Operator can still query everything @readonly can."""
+    users = auth.ParsePasswordFile("op secret @operator")
+    user = users["op"]
+    assert user.has_permission("instances.list")
+    assert user.has_permission("cluster.info")
+    assert user.has_permission("nodes.query")
+
+  def test_operator_cannot_modify_config(self):
+    """Operator must NOT be able to create/modify/remove/rename."""
+    users = auth.ParsePasswordFile("op secret @operator")
+    user = users["op"]
+    forbidden = [
+      "instances.create",
+      "instances.modify",
+      "instances.remove",
+      "instances.rename",
+      "instances.recreate_disks",
+      "instances.grow_disk",
+      "cluster.modify",
+      "cluster.redistribute_config",
+      "nodes.modify",
+      "nodes.role.modify",
+      "nodes.migrate",
+      "nodes.powercycle",
+      "networks.create",
+      "networks.modify",
+      "networks.remove",
+      "groups.create",
+      "groups.modify",
+      "groups.delete",
+    ]
+    for perm in forbidden:
+      assert not user.has_permission(perm), \
+        f"@operator should not have '{perm}'"

--- a/test/py/unit/server/test_rapi.py
+++ b/test/py/unit/server/test_rapi.py
@@ -260,6 +260,34 @@ class TestRemoteApiHandler:
     data = serializer.LoadJson(body)
     assert data["code"] == 404
 
+  @pytest.mark.parametrize("path", ["/", "/2", "/version", "/2/features"])
+  def test_public_endpoints_serve_without_auth(self, basic_handler, path):
+    """Endpoints with AUTH_REQUIRED = False are reachable unauthenticated."""
+    code, _, _ = self._make_request(basic_handler, "GET", path, "", None)
+    assert code == http.HTTP_OK
+
+  def test_forbidden_when_user_lacks_permission(self, make_auth_headers):
+    """Authenticated user without required permission gets 403 (no leak)."""
+    def _lookup(username):
+      if username == "ro":
+        return auth.PasswordFileUser("ro", "pw", ["@readonly"])
+      return None
+
+    handler = rapi.RemoteApiHandler(_lookup, reqauth=False)
+    auth_value = make_auth_headers("ro", "pw")
+    headers = (f"Authorization: {auth_value}\r\n"
+               "Content-Type: application/json\r\n\r\n")
+
+    # /2/redistribute-config requires cluster.redistribute_config (admin only)
+    code, _, data = self._make_request(
+      handler, "PUT", "/2/redistribute-config", headers, ""
+    )
+
+    assert code == http.HttpForbidden.code
+    # Required permission name must NOT be echoed in the response body
+    assert "cluster.redistribute_config" not in (data.get("message") or "")
+    assert "cluster.redistribute_config" not in (data.get("explain") or "")
+
 
 class TestRapiUsers:
   """Test RapiUsers class."""


### PR DESCRIPTION
This PR picks up where #1895 by @codefritzel left. The original PR does not apply cleanly any more because of the changes to the HTTP server implementation (transition from asyncore to threaded model). Changes were mostly related to unit tests though.

We replace the binary read/write permission model with a granular permission system featuring ~66 individual permissions and two predefined roles (`@admin`, `@readonly`). The rapi_users file now accepts three formats:

  - role reference: `@admin`
  - explicit permissions: `jobs.list,instances.query`
  - role with modifications: `@readonly,+jobs.cancel,-cluster.info`

Each RAPI handler declares the permission it requires via `*_ACCESS`, and may opt out of authentication entirely with `*_AUTH_REQUIRED=False` (used for /, /version, /2, /2/features). **Legacy `read`/`write`/`all` options keep working via a deprecation-mapped fallback** (with a deprecation warning in the logs).

The following additions have been made by me (analyzed and partially implemented by Claude Opus 4.7, as reflected in the commit message):

  - Code & tests adapted to the removal of asyncore (new HTTP server implementation)
  - _resolve_permissions() processes tokens in a fixed order so `@admin,-x` and `-x,@admin` produce the same result
  - 403 responses no longer echo the required permission name
  - Unknown `@role` tokens log a warning instead of failing silent
  - Deprecation warnings dedupe per file load
  - Sphinx ext asserts on RAPI_ACCESS_NOT_DEFINED
  - Permission tests

The commit message cites @codefritzel as Co-Author, I hope that is fine with you :-)
