### PR TITLE
py-tests-legacy: filter shell-specific env vars in hooks unittest

### DIFF
--- a/test/py/legacy/ganeti.hooks_unittest.py
+++ b/test/py/legacy/ganeti.hooks_unittest.py
@@ -198,7 +198,7 @@ class TestHooksRunner(unittest.TestCase):
     for phase in (constants.HOOKS_PHASE_PRE, constants.HOOKS_PHASE_POST):
       fbase = "success"
       fname = "%s/%s" % (self.ph_dirs[phase], fbase)
-      content = "#!/usr/bin/env sh\nenv --unset PWD\n"
+      content = "#!/usr/bin/env sh\nenv --unset PWD --unset SHLVL --unset _\n"
       with open(fname, "w", encoding="utf-8", newline="\n") as f:
         f.write(content)
       os.chmod(fname, 0o755)


### PR DESCRIPTION
Fixes #1932

This PR fixes the failing `TestHooksRunner.testEnv` in `ganeti.hooks_unittest.py`.

Some /bin/sh implementations add extra variables such as SHLVL or _. Unset them explicitly so the hooks environment test behaves the same on Debian and RHEL.
