### PR TITLE
Strip trailing newlines from SSH verify errors

### DIFF
--- a/lib/cmdlib/cluster/verify.py
+++ b/lib/cmdlib/cluster/verify.py
@@ -773,7 +773,8 @@ class LUClusterVerifyGroup(LogicalUnit, _VerifyErrors):
       if nresult[constants.NV_NODELIST]:
         for a_node, a_msg in nresult[constants.NV_NODELIST].items():
           self._ErrorIf(True, constants.CV_ENODESSH, ninfo.name,
-                        "ssh communication with node '%s': %s", a_node, a_msg)
+                        "ssh communication with node '%s': %s",
+                        a_node, a_msg.rstrip("\r\n"))
 
     if constants.NV_NODENETTEST not in nresult:
       self._ErrorMsg(constants.CV_ENODENET, ninfo.name,

--- a/test/py/legacy/cmdlib/cluster_unittest.py
+++ b/test/py/legacy/cmdlib/cluster_unittest.py
@@ -1650,6 +1650,18 @@ class TestLUClusterVerifyGroupVerifyNodeNetwork(
     self.mcpu.assertLogContainsRegex("ssh communication with node 'mock_node'")
 
   @withLockedLU
+  def testSshProblemStripsTrailingNewline(self, lu):
+    self.VALID_NRESULT.update({
+      constants.NV_NODELIST: {
+        "mock_node": "mock_error\n"
+      }
+    })
+    lu._VerifyNodeNetwork(self.master, self.VALID_NRESULT)
+    self.mcpu.assertLogContainsInLine(
+      "ssh communication with node 'mock_node': mock_error")
+    self.mcpu.assertLogDoesNotContainRegex("mock_error\n")
+
+  @withLockedLU
   def testTcpProblem(self, lu):
     self.VALID_NRESULT.update({
       constants.NV_NODENETTEST: {


### PR DESCRIPTION
## Summary
- strip trailing CR/LF from SSH node verification error text before formatting the `gnt-cluster verify` message
- add a regression test for an SSH problem message ending in a newline

## Validation
- `python3 -m py_compile lib/cmdlib/cluster/verify.py test/py/legacy/cmdlib/cluster_unittest.py`
- `git diff --check`

## Local test environment note
- `PYTHONPATH="$PWD:$PWD/test/py/legacy" python3 test/py/legacy/cmdlib/cluster_unittest.py TestLUClusterVerifyGroupVerifyNodeNetwork` could not run in the fresh checkout because generated module `ganeti._constants` is absent
- `./autogen.sh` could not generate the missing build files locally because `aclocal` is not installed

## AI assistance
AI assistance was used to draft and verify this small fix. I reviewed the diff and validation output before submitting.

Fixes #1845