### PR TITLE
rbd: add namespace parameter

### DIFF
--- a/doc/design-ceph-ganeti-support.rst
+++ b/doc/design-ceph-ganeti-support.rst
@@ -83,7 +83,14 @@ output applies to KVM based instances only::
 The user id for ceph authentication is an optional setting. If it is not
 provided, then no special option is passed to ceph. If it is provided,
 then all ceph commands are run with the ``--id`` option and the
-configured username.
+configured username.::
+
+  $ gnt-cluster modify -D rbd:namespace=foobar
+
+The namespace for RBD is an optional setting. If it is not provided, the
+default/empty namespace is used. If it is provided, then all ceph
+commands are run with the ``--namespace`` option and the configured
+namespace.
 
 Ceph configuration on Ganeti nodes
 ==================================

--- a/lib/hypervisor/hv_kvm/kvm_utils.py
+++ b/lib/hypervisor/hv_kvm/kvm_utils.py
@@ -41,7 +41,7 @@ _BLOCKDEV_URI_REGEX_GLUSTER = (
 # rbd:{pool-name}/{image-name}[@snapshot-name][:opt1=val1][:opt2=val2...]
 _BLOCKDEV_URI_REGEX_RBD = (
   r"^rbd:(?P<pool>\w+)/(?P<image>[a-z0-9-\.]+)"
-  r"(?P<id_opt>:id=[a-z0-9-\._]+)?$"
+  r"(?P<opts>:[a-z0-9-\._\=:]+)?$"
 )
 
 def TranslateBoolToOnOff(value):
@@ -80,17 +80,19 @@ def ParseStorageUriToBlockdevParam(uri):
       }
   match = re.match(_BLOCKDEV_URI_REGEX_RBD, uri)
   if match is not None:
-    param = {
+    params = {
         "driver": "rbd",
         "pool": match.group("pool"),
         "image": match.group("image")
       }
 
-    id_opt = match.group("id_opt")
-    if id_opt is not None:
-      param["user"] = id_opt.partition("=")[2]
+    opts = match.group("opts")
+    if opts is not None:
+      for opt in opts.split(':')[1:]:
+        key, _, val = opt.partition('=')
+        params["user" if key == "id" else key] = val
 
-    return param
+    return params
   raise errors.HypervisorError("Unsupported storage URI scheme: %s" % (uri))
 
 

--- a/lib/storage/bdev.py
+++ b/lib/storage/bdev.py
@@ -974,10 +974,12 @@ class RADOSBlockDevice(base.BlockDev):
 
   @classmethod
   def MakeRbdCmd(cls, params, cmd):
-    """Add user id option to rbd command if configured.
+    """Add user id/namespace option to rbd command if configured.
     """
     if params.get(constants.RBD_USER_ID, ""):
       cmd.extend(["--id", str(params[constants.RBD_USER_ID])])
+    if params.get(constants.RBD_NAMESPACE, ""):
+      cmd.extend(["--namespace", str(params[constants.RBD_NAMESPACE])])
 
     return [constants.RBD_CMD] + cmd
 
@@ -1304,6 +1306,8 @@ class RADOSBlockDevice(base.BlockDev):
       uri = "rbd:" + self.rbd_pool + "/" + self.rbd_name
       if self.params.get(constants.RBD_USER_ID, ""):
         uri += ":id=%s" % self.params[constants.RBD_USER_ID]
+      if self.params.get(constants.RBD_NAMESPACE, ""):
+        uri += ":namespace=%s" % self.params[constants.RBD_NAMESPACE]
       return uri
     else:
       base.ThrowError("Hypervisor %s doesn't support RBD userspace access" %

--- a/lib/tools/cfgupgrade.py
+++ b/lib/tools/cfgupgrade.py
@@ -762,12 +762,12 @@ class CfgUpgrade(object):
       if variant in hvparams:
         hvparams[variant]["xen_cmd"] = "xl"
 
-  @OrFail("Removing the rbd/user-id parameter")
-  def DowngradeRbdUserId(self):
-    """Remove rbd/user-id parameters if set
+  @OrFail("Removing the rbd/user-id and namespace parameter")
+  def DowngradeRbdSettings(self):
+    """Remove rbd/user-id and namespace parameters if set
 
     """
-    def _removeRbdUserId(data):
+    def _removeRbdSetting(data, setting):
       diskparams = data.get("diskparams", None)
       if diskparams is None:
         return
@@ -776,8 +776,8 @@ class CfgUpgrade(object):
       if rbdparams is None:
         return
 
-      if "user-id" in rbdparams:
-        rbdparams.pop("user-id")
+      if setting in rbdparams:
+        rbdparams.pop(setting)
 
     # pylint: disable=E1103
     # Because config_data is a dictionary which has the get method.
@@ -785,19 +785,21 @@ class CfgUpgrade(object):
     if cluster is None:
       raise Error("Can't find the cluster entry in the configuration")
 
-    _removeRbdUserId(cluster)
+    for setting in ["user-id", "namespace"]:
+      _removeRbdSetting(cluster, setting)
 
     nodegroups = self.config_data.get("nodegroups", None)
     if nodegroups is None:
       raise Error("Can't find the cluster entry in the configuration")
-    _removeRbdUserId(nodegroups)
+    for setting in ["user-id", "namespace"]:
+      _removeRbdSetting(nodegroups, setting)
 
   def DowngradeAll(self):
     self.config_data["version"] = version.BuildVersion(DOWNGRADE_MAJOR,
                                                        DOWNGRADE_MINOR, 0)
 
     self.DowngradeXenSettings()
-    self.DowngradeRbdUserId()
+    self.DowngradeRbdSettings()
     return not self.errors
 
   def _ComposePaths(self):

--- a/man/gnt-cluster.rst
+++ b/man/gnt-cluster.rst
@@ -485,6 +485,18 @@ pool
     When a new RADOS cluster is deployed, the default pool to put rbd
     volumes (Images in RADOS terminology) is 'rbd'.
 
+namespace
+    The RBD namespace this cluster should use. By default no namespace
+    is used.
+
+    Useful for separating RBD consumers and their permissions in
+    combination with 'user-id' below. For example multiple Ganeti
+    clusters sharing a single Ceph cluster.
+
+    Be aware that setting or changing the namespace renders disks from
+    existing instances inaccessible, e.g., by rebooting the instances.
+    The effect is like changing the RBD pool.
+
 access
     If 'userspace', instances will access their disks directly without
     going through a block device, avoiding expensive context switches
@@ -501,14 +513,6 @@ access
 user-id
     The user id is used by ceph to determine the keyring to use for
     authentication. By default the admin keyring is used.
-
-namespace
-    The rbd namespace this cluster should use. By default no namespace
-    is used.
-
-    Useful for separating RBD consumers and their permissions in
-    combination with user-id above. For example multiple Ganeti clusters
-    sharing a single Ceph cluster).
 
 
 .. _deadlocks: http://tracker.ceph.com/issues/3076

--- a/man/gnt-cluster.rst
+++ b/man/gnt-cluster.rst
@@ -502,6 +502,14 @@ user-id
     The user id is used by ceph to determine the keyring to use for
     authentication. By default the admin keyring is used.
 
+namespace
+    The rbd namespace this cluster should use. By default no namespace
+    is used.
+
+    Useful for separating RBD consumers and their permissions in
+    combination with user-id above. For example multiple Ganeti clusters
+    sharing a single Ceph cluster).
+
 
 .. _deadlocks: http://tracker.ceph.com/issues/3076
 

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -2313,6 +2313,9 @@ ldpPool = "pool"
 ldpUserId :: String
 ldpUserId = "user-id"
 
+ldpNamespace :: String
+ldpNamespace = "namespace"
+
 ldpProtocol :: String
 ldpProtocol = "protocol"
 
@@ -2341,7 +2344,8 @@ diskLdTypes =
    (ldpMaxRate, VTypeInt),
    (ldpMinRate, VTypeInt),
    (ldpPool, VTypeString),
-   (ldpUserId, VTypeString)]
+   (ldpUserId, VTypeString),
+   (ldpNamespace, VTypeString)]
 
 diskLdParameters :: FrozenSet String
 diskLdParameters = ConstantUtils.mkSet (Map.keys diskLdTypes)
@@ -2408,6 +2412,9 @@ rbdPool = "pool"
 rbdUserId :: String
 rbdUserId = "user-id"
 
+rbdNamespace :: String
+rbdNamespace = "namespace"
+
 diskDtTypes :: Map String VType
 diskDtTypes =
   Map.fromList [(drbdResyncRate, VTypeInt),
@@ -2429,6 +2436,7 @@ diskDtTypes =
                 (rbdAccess, VTypeString),
                 (rbdPool, VTypeString),
                 (rbdUserId, VTypeString),
+                (rbdNamespace, VTypeString),
                 (glusterHost, VTypeString),
                 (glusterVolume, VTypeString),
                 (glusterPort, VTypeInt)
@@ -4263,6 +4271,9 @@ defaultRbdPool = "rbd"
 defaultRbdUserId :: String
 defaultRbdUserId = ""
 
+defaultRbdNamespace :: String
+defaultRbdNamespace = ""
+
 diskLdDefaults :: Map DiskTemplate (Map String PyValueEx)
 diskLdDefaults =
   Map.fromList
@@ -4291,6 +4302,7 @@ diskLdDefaults =
             [ (ldpPool, PyValueEx defaultRbdPool)
             , (ldpAccess, PyValueEx diskKernelspace)
             , (ldpUserId, PyValueEx defaultRbdUserId)
+            , (ldpNamespace, PyValueEx defaultRbdNamespace)
             ])
   , (DTSharedFile, Map.empty)
   , (DTGluster, Map.fromList
@@ -4332,6 +4344,7 @@ diskDtDefaults =
                    [ (rbdPool, PyValueEx defaultRbdPool)
                    , (rbdAccess, PyValueEx diskKernelspace)
                    , (rbdUserId, PyValueEx defaultRbdUserId)
+                   , (rbdNamespace, PyValueEx defaultRbdNamespace)
                    ])
   , (DTSharedFile, Map.empty)
   , (DTGluster, Map.fromList

--- a/test/py/legacy/cmdlib/cluster_unittest.py
+++ b/test/py/legacy/cmdlib/cluster_unittest.py
@@ -460,7 +460,8 @@ class TestLUClusterSetParams(CmdlibTestCase):
   def testValidDiskparams(self):
     diskparams = {constants.DT_RBD: {constants.RBD_POOL: "mock_pool",
                                      constants.RBD_ACCESS: "kernelspace",
-                                     constants.RBD_USER_ID: "mock_user"}}
+                                     constants.RBD_USER_ID: "mock_user",
+                                     constants.RBD_NAMESPACE: "mock_ns"}}
     op = opcodes.OpClusterSetParams(diskparams=diskparams)
     self.ExecOpCode(op)
     self.assertEqual(diskparams[constants.DT_RBD],


### PR DESCRIPTION
To separate a single RBD Ceph pool for multiple consumers (i.e. multiple Ganeti clusters) RBD namespaces must be used. With that every namespace has its own space for RBD images and in combination with RBD `user-id` it's own permissions only inside this namespace.