### PR TITLE
rbd: no KRBD block device if access is userspace

### DIFF
--- a/doc/design-ceph-ganeti-support.rst
+++ b/doc/design-ceph-ganeti-support.rst
@@ -65,10 +65,9 @@ This approach ensures that no disk template specific changes are
 required in hv_kvm.py allowing easy integration of other distributed
 storage systems (like Gluster).
 
-Note that the RBD volume is mapped as a local block device as before.
-The local mapping won't be used during instance operation in the
-``userspace`` access mode, but can be used by administrators and OS
-scripts.
+Note that the RBD volume is not mapped as a local block device as before
+in the ``userspace`` access mode. Administrators and OS scripts should
+adopt using userspace URIs only.
 
 Updated commands
 ----------------

--- a/lib/storage/bdev.py
+++ b/lib/storage/bdev.py
@@ -884,6 +884,7 @@ class RADOSBlockDevice(base.BlockDev):
 
     self.driver, self.rbd_name = unique_id
     self.rbd_pool = params[constants.LDP_POOL]
+    self.rbd_access = params[constants.LDP_ACCESS]
 
     self.major = self.minor = None
     self.Attach()
@@ -952,6 +953,11 @@ class RADOSBlockDevice(base.BlockDev):
 
     """
     self.attached = False
+
+    # no block device mapping, if access is userspace
+    if self.rbd_access == "userspace":
+      self.attached = True
+      return True
 
     # Map the rbd volume to a block device under /dev
     self.dev_path = self._MapVolumeToBlockdev(self.unique_id)

--- a/test/py/legacy/ganeti.storage.bdev_unittest.py
+++ b/test/py/legacy/ganeti.storage.bdev_unittest.py
@@ -97,7 +97,8 @@ class TestRADOSBlockDevice(testutils.GanetiTestCase):
     self.pool_name = "rbd"
     self.test_unique_id = ("rbd", self.volume_name)
     self.test_params = {
-      constants.LDP_POOL: "fake_pool"
+      constants.LDP_POOL: "fake_pool",
+      constants.LDP_ACCESS: "fake_access"
       }
 
   def testParseRbdShowmappedJson(self):
@@ -210,6 +211,7 @@ class TestRADOSBlockDevice(testutils.GanetiTestCase):
     map_mock.return_value = "/fake/path"
     dev = bdev.RADOSBlockDevice.__new__(bdev.RADOSBlockDevice)
     dev.unique_id = self.test_unique_id
+    dev.rbd_access = "fake_access"
 
     self.assertEqual(dev.Attach(), True)
 
@@ -221,6 +223,7 @@ class TestRADOSBlockDevice(testutils.GanetiTestCase):
     map_mock.return_value = "/fake/path"
     dev = bdev.RADOSBlockDevice.__new__(bdev.RADOSBlockDevice)
     dev.unique_id = self.test_unique_id
+    dev.rbd_access = "fake_access"
 
     self.assertEqual(dev.Attach(), False)
 
@@ -232,6 +235,7 @@ class TestRADOSBlockDevice(testutils.GanetiTestCase):
     map_mock.return_value = "/fake/path"
     dev = bdev.RADOSBlockDevice.__new__(bdev.RADOSBlockDevice)
     dev.unique_id = self.test_unique_id
+    dev.rbd_access = "fake_access"
 
     self.assertEqual(dev.Attach(), False)
 


### PR DESCRIPTION
Currently Ganeti maps a RBD image to a kernel block device, even if disk parameter `access` is set to `userspace`. This creates a dependency on the kernel where it is not required and poses a risk by creating a second access path to the same RBD image.

Toolings relying on KRBD block device, like OS interface (create, export, import), should adopt to use userspace URIs only, if Ganeti is set to access=userspace.

Partially addresses issue #600.