### PR TITLE
KVM: tolerate transient QMP socket errors when reading instance info

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2047,6 +2047,7 @@ python_tests_unit = \
 	test/py/unit/test_daemon.py \
 	test/py/unit/hypervisor/hv_kvm/test_monitor.py \
 	test/py/unit/hypervisor/hv_kvm/test_bus_manager.py \
+	test/py/unit/hypervisor/hv_kvm/test_instance_info.py \
 	test/py/unit/hypervisor/hv_kvm/test_q35.py \
 	test/py/unit/http/test_auth.py \
 	test/py/unit/http/test_server.py \

--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -1030,14 +1030,12 @@ class KVMHypervisor(hv_base.BaseHypervisor):
       qmp.close()
     except errors.HypervisorError:
       pass
-    # during instance shutdown it may happen, that qemu has already exited
-    # in the middle of talking to it via QMP
-    except BrokenPipeError:
-      logging.debug("Error: Broken pipe. The QMP socket %s has shut down." %
-                    socket_path)
-    except ConnectionError:
-      logging.debug("Error: Unable to connect to the QMP socket %s." %
-                    socket_path)
+    # QMP may be transiently unavailable while the instance is starting up or
+    # shutting down (socket missing, refused, or broken pipe). Harmless here:
+    # fall back to the pid-derived values above.
+    except OSError as err:
+      logging.debug(f"Ignoring transient QMP error on socket {socket_path}:"
+                    f" {err}")
 
     return (instance_name, pid, memory, vcpus, istat, times)
 
@@ -1056,6 +1054,10 @@ class KVMHypervisor(hv_base.BaseHypervisor):
         info = self.GetInstanceInfo(name)
       except errors.HypervisorError:
         # Ignore exceptions due to instances being shut down
+        continue
+      except OSError as err:
+        # One instance in flux must not abort info gathering for the rest.
+        logging.debug(f"Skipping instance {name} while collecting info: {err}")
         continue
       if info:
         data.append(info)

--- a/test/py/unit/hypervisor/hv_kvm/test_instance_info.py
+++ b/test/py/unit/hypervisor/hv_kvm/test_instance_info.py
@@ -1,0 +1,96 @@
+#
+#
+
+# Copyright (C) 2024 the Ganeti project
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import errno
+from unittest import mock
+
+import pytest
+
+from ganeti.hypervisor import hv_kvm
+from ganeti.hypervisor import hv_base
+
+
+@pytest.fixture
+def hypervisor():
+  # The constructor only ensures the runtime directories exist; stub that out
+  # so the tests can run without touching the filesystem.
+  with mock.patch("ganeti.utils.EnsureDirs"):
+    yield hv_kvm.KVMHypervisor()
+
+
+class TestGetInstanceInfoSocketRace:
+  """Regression tests for transient QMP socket races.
+
+  During parallel instance creation/removal (exercised by the QA test
+  TestParallelMaxInstanceCreationPerformance) an instance may be queried while
+  it is still starting up -- before qemu has created its QMP control socket --
+  or while it is being torn down, after the socket has already been removed.
+  In that window socket.connect() raises FileNotFoundError, which previously
+  escaped GetInstanceInfo/GetAllInstancesInfo and failed the whole node RPC,
+  aborting unrelated instance-creation jobs via the IAllocator.
+
+  """
+
+  def test_missing_qmp_socket_is_non_fatal(self, hypervisor):
+    with mock.patch.object(hypervisor, "_InstancePidAlive",
+                           return_value=("file", 1234, True)), \
+         mock.patch.object(hypervisor, "_InstancePidInfo",
+                           return_value=(1234, 768, 2)), \
+         mock.patch.object(hypervisor, "_InstanceQmpMonitor",
+                           return_value="/nonexistent/socket"), \
+         mock.patch("ganeti.hypervisor.hv_kvm.QmpConnection") as qmp:
+      qmp.return_value.connect.side_effect = \
+          FileNotFoundError(errno.ENOENT, "No such file or directory")
+
+      info = hypervisor.GetInstanceInfo("inst1.example.com")
+
+    # We must still get the pid-derived information back instead of an error.
+    assert info is not None
+    name, pid, memory, vcpus, state, _ = info
+    assert name == "inst1.example.com"
+    assert pid == 1234
+    assert memory == 768
+    assert vcpus == 2
+    assert state == hv_base.HvInstanceState.RUNNING
+
+  def test_get_all_instances_info_skips_instance_in_flux(self, hypervisor):
+    def _GetInstanceInfo(name, hvparams=None):
+      if name.startswith("bad"):
+        raise FileNotFoundError(errno.ENOENT, "No such file or directory")
+      return (name, 1234, 768, 2, hv_base.HvInstanceState.RUNNING, 0)
+
+    with mock.patch("os.listdir",
+                    return_value=["good.example.com.conf",
+                                  "bad.example.com.conf"]), \
+         mock.patch.object(hypervisor, "GetInstanceInfo",
+                           side_effect=_GetInstanceInfo):
+      data = hypervisor.GetAllInstancesInfo()
+
+    # The instance in flux is skipped; the healthy one is still reported.
+    assert [d[0] for d in data] == ["good.example.com"]


### PR DESCRIPTION
During parallel instance creation/removal (QA test `TestParallelMaxInstanceCreationPerformance`) an instance may be queried while starting up or shutting down, when its QMP socket does not yet/no longer exist. `socket.connect()` then raises `FileNotFoundError`, which `GetInstanceInfo` did not catch (it is not a `ConnectionError`). This failed the whole `all_instances_info` RPC and made the master's IAllocator raise `OpExecError`, killing unrelated concurrent create jobs.

Catch `OSError` in `GetInstanceInfo` (covering `FileNotFoundError`, `BrokenPipeError` and `ConnectionError`) and fall back to the pid-derived values. Also skip an instance raising `OSError` in `GetAllInstancesInfo` so one instance in flux cannot abort info gathering for the rest.

This error surfaces every now and then in QA runs and has seemingly been introduced with the switch from HMP to QMP. It will probably not be relevant to regular Ganeti use.

Note: I have used AI to analyze various failing QA runs and the codebase to pinpoint the error.