### PR TITLE
pvh_xen: Added hypervisor parameter to run Xen domains in PVH mode.

### DIFF
--- a/lib/hypervisor/hv_xen.py
+++ b/lib/hypervisor/hv_xen.py
@@ -1486,10 +1486,8 @@ class XenPvmHypervisor(XenHypervisor):
     config.write("name = '%s'\n" % instance.name)
 
     pvh_mode = hvp[constants.HV_PVH_MODE]
-    if (pvh_mode == "1"):
-        config.write("pvh = 1\n")
-    elif (pvh_mode == "2"):
-        config.write("type = 'pvh'\n")
+    if (pvh_mode is True):
+        config.write("type = 'pvh'\n)
 
     self._WriteNicConfig(config, instance, hvp)
 

--- a/lib/hypervisor/hv_xen.py
+++ b/lib/hypervisor/hv_xen.py
@@ -1434,6 +1434,7 @@ class XenPvmHypervisor(XenHypervisor):
     constants.HV_VIF_SCRIPT: hv_base.OPT_FILE_CHECK,
     constants.HV_XEN_CPUID: hv_base.NO_CHECK,
     constants.HV_SOUNDHW: hv_base.NO_CHECK,
+    constants.HV_PVH_MODE: hv_base.NO_CHECK,
     }
 
   def _GetConfig(self, instance, startup_memory, block_devices):
@@ -1483,6 +1484,12 @@ class XenPvmHypervisor(XenHypervisor):
       config.write("cpu_weight=%d\n" % cpu_weight)
 
     config.write("name = '%s'\n" % instance.name)
+
+    pvh_mode = hvp[constants.HV_PVH_MODE]
+    if (pvh_mode == "1"):
+        config.write("pvh = 1\n")
+    elif (pvh_mode == "2"):
+        config.write("type = 'pvh'\n")
 
     self._WriteNicConfig(config, instance, hvp)
 

--- a/lib/hypervisor/hv_xen.py
+++ b/lib/hypervisor/hv_xen.py
@@ -1487,7 +1487,7 @@ class XenPvmHypervisor(XenHypervisor):
 
     pvh_mode = hvp[constants.HV_PVH_MODE]
     if (pvh_mode is True):
-        config.write("type = 'pvh'\n)
+        config.write("type = 'pvh'\n")
 
     self._WriteNicConfig(config, instance, hvp)
 

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -1623,6 +1623,9 @@ hvBootloaderPath = "bootloader_path"
 hvBootOrder :: String
 hvBootOrder = "boot_order"
 
+hvPvhMode :: String
+hvPvhMode = "pvh_mode"
+
 hvCdromImagePath :: String
 hvCdromImagePath = "cdrom_image_path"
 
@@ -1871,6 +1874,7 @@ hvsParameterTitles =
   Map.fromList
   [(hvAcpi, "ACPI"),
    (hvBootOrder, "Boot_order"),
+   (hvPvhMode, "Pvh_mode"),
    (hvCdromImagePath, "CDROM_image_path"),
    (hvCpuType, "cpu_type"),
    (hvDiskType, "Disk_type"),
@@ -1971,6 +1975,7 @@ hvsParameterTypes = Map.fromList
   , (hvVncX509Verify,                   VTypeBool)
   , (hvVnetHdr,                         VTypeBool)
   , (hvXenCpuid,                        VTypeString)
+  , (hvPvhMode, 						VTypeString)
   ]
 
 -- * Migration statuses
@@ -4096,6 +4101,7 @@ hvcDefaults =
              , (hvVifScript,      PyValueEx "")
              , (hvXenCpuid,       PyValueEx "")
              , (hvSoundhw,        PyValueEx "")
+			 , (hvPvhMode,  	  PyValueEx "")
              ])
   , (XenHvm, Map.fromList
              [ (hvBootOrder,      PyValueEx "cd")

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -1975,7 +1975,7 @@ hvsParameterTypes = Map.fromList
   , (hvVncX509Verify,                   VTypeBool)
   , (hvVnetHdr,                         VTypeBool)
   , (hvXenCpuid,                        VTypeString)
-  , (hvPvhMode, 						VTypeString)
+  , (hvPvhMode, 						VTypeBool)
   ]
 
 -- * Migration statuses
@@ -4101,7 +4101,7 @@ hvcDefaults =
              , (hvVifScript,      PyValueEx "")
              , (hvXenCpuid,       PyValueEx "")
              , (hvSoundhw,        PyValueEx "")
-			 , (hvPvhMode,  	  PyValueEx "")
+			 , (hvPvhMode,  	  PyValueEx False)
              ])
   , (XenHvm, Map.fromList
              [ (hvBootOrder,      PyValueEx "cd")


### PR DESCRIPTION
New hypervisor parameter, `pvh_mode`, that allows configuring Xen domains to run in PVH mode instead of PV mode.

When `pvh_mode=1`, the domain will run in legacy PVH mode by writing 'pvh = 1' in the Xen domain configuration file.

When `pvh_mode=2`, the domain will run in modern PVH mode by writing "type = 'pvh'" in the Xen domain configuration file.

Based on the patche files found at https://gist.github.com/flumeware/7bfa3e270712ba5bac4ccdaa815c092c.