### PR TITLE
virtio_net_queues: introduce auto queue number

### DIFF
--- a/lib/hypervisor/hv_base.py
+++ b/lib/hypervisor/hv_base.py
@@ -119,9 +119,9 @@ _NET_PORT_CHECK = (lambda x: 0 < x < 65535, "invalid port number",
                    None, None)
 
 # Check if number of queues is in safe range
-_VIRTIO_NET_QUEUES_CHECK = (lambda x: 0 < x <= constants.MAX_VIRTIO_NET_QUEUES,
-                            "invalid number of queues",
-                            None, None)
+_VIRTIO_NET_QUEUES_CHECK = (lambda x: x == "auto" or (isinstance(x, int) and
+                            0 < x <= constants.MAX_VIRTIO_NET_QUEUES),
+                            "invalid number of queues", None, None)
 
 # Check that an integer is non negative
 _NONNEGATIVE_INT_CHECK = (lambda x: x >= 0, "cannot be negative", None, None)

--- a/lib/hypervisor/hv_kvm/__init__.py
+++ b/lib/hypervisor/hv_kvm/__init__.py
@@ -1861,7 +1861,7 @@ class KVMHypervisor(hv_base.BaseHypervisor):
 
     return hv_base.GenerateTapName()
 
-  def _GetNetworkDeviceFeatures(self, up_hvp, devlist, kvmhelp):
+  def _GetNetworkDeviceFeatures(self, up_hvp, devlist, kvmhelp, vcpus):
     """Get network device options to properly enable supported features.
 
     Return a dict of supported and enabled tap features with nic_model along
@@ -1905,7 +1905,9 @@ class KVMHypervisor(hv_base.BaseHypervisor):
         else:
           raise errors.HypervisorError("vhost_net is configured"
                                        " but it is not available")
-        virtio_net_queues = up_hvp.get(constants.HV_VIRTIO_NET_QUEUES, 1)
+        _queues = up_hvp[constants.HV_VIRTIO_NET_QUEUES]
+        _queues_auto = min(vcpus, constants.MAX_VIRTIO_NET_QUEUES_AUTO)
+        virtio_net_queues = _queues_auto if _queues == "auto" else _queues
         if virtio_net_queues > 1:
           # Check for multiqueue virtio-net support.
           if self._VIRTIO_NET_QUEUES_RE.search(kvmhelp):
@@ -2010,8 +2012,9 @@ class KVMHypervisor(hv_base.BaseHypervisor):
     if not kvm_nics:
       kvm_cmd.extend(["-net", "none"])
     else:
+      vcpus = instance.beparams[constants.BE_VCPUS]
       features, tap_extra, nic_extra = \
-          self._GetNetworkDeviceFeatures(up_hvp, devlist, kvmhelp)
+          self._GetNetworkDeviceFeatures(up_hvp, devlist, kvmhelp, vcpus)
       nic_model = features["driver"]
       kvm_supports_netdev = self._NETDEV_RE.search(kvmhelp)
       for nic_seq, nic in enumerate(kvm_nics):
@@ -2426,7 +2429,9 @@ class KVMHypervisor(hv_base.BaseHypervisor):
       is_chrooted = instance.hvparams[constants.HV_KVM_USE_CHROOT]
       kvmhelp = self._GetKVMOutput(kvmpath, self._KVMOPT_HELP)
       devlist = self._GetKVMOutput(kvmpath, self._KVMOPT_DEVICELIST)
-      features, _, _ = self._GetNetworkDeviceFeatures(up_hvp, devlist, kvmhelp)
+      vcpus = len(self.qmp.GetCpuInformation())
+      features, _, _ = self._GetNetworkDeviceFeatures(up_hvp, devlist, kvmhelp,
+                                                      vcpus)
       (tap, tapfds, vhostfds) = OpenTap(features=features)
       try:
         self._ConfigureNIC(instance, seq, device, tap)

--- a/lib/query.py
+++ b/lib/query.py
@@ -165,6 +165,7 @@ _VTToQFT = {
   constants.VTYPE_SIZE: QFT_UNIT,
   constants.VTYPE_INT: QFT_NUMBER,
   constants.VTYPE_FLOAT: QFT_NUMBER_FLOAT,
+  constants.VTYPE_INT_OR_AUTO: QFT_OTHER,
   }
 
 _SERIAL_NO_DOC = "%s object serial number, incremented on each modification"

--- a/lib/utils/__init__.py
+++ b/lib/utils/__init__.py
@@ -153,6 +153,14 @@ def ForceDictType(target, key_types, allowed_values=None):
       except (ValueError, TypeError):
         msg = "'%s' (value %s) is not a valid float" % (key, target[key])
         raise errors.TypeEnforcementError(msg)
+    elif ktype == constants.VTYPE_INT_OR_AUTO:
+        if target[key] != "auto":
+          try:
+            target[key] = int(target[key])
+          except (ValueError, TypeError):
+            msg = "'%s' (value %s) is neither string auto nor a valid" \
+                  " integer" % (key, target[key])
+            raise errors.TypeEnforcementError(msg)
 
 
 def ValidateServiceName(name):

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -1019,8 +1019,14 @@ virtio\_net\_queues
     If set to ``1`` queue, it effectively disables multiqueue support
     on the tap and virio-net devices.
 
-    For instances it is necessary to manually set number of queues (on
-    Linux using: ``ethtool -L ethX combined $queues``).
+    For instances check if it is necessary to manually set number of
+    queues (on Linux using: ``ethtool -L ethX combined $queues``). Modern
+    OSs automatically use multiple queues.
+
+    Make sure to set the number of queues not greater than the
+    instance's ``vcpus``. For convenience the special value ``auto`` will
+    follow the number of ``vcpus`` up to the limited of ``8`` queues per
+    instance NIC.
 
     It is set to ``1`` by default.
 

--- a/man/gnt-instance.rst
+++ b/man/gnt-instance.rst
@@ -1025,7 +1025,7 @@ virtio\_net\_queues
 
     Make sure to set the number of queues not greater than the
     instance's ``vcpus``. For convenience the special value ``auto`` will
-    follow the number of ``vcpus`` up to the limited of ``8`` queues per
+    follow the number of ``vcpus`` up to the limit of ``8`` queues per
     instance NIC.
 
     It is set to ``1`` by default.

--- a/src/Ganeti/Constants.hs
+++ b/src/Ganeti/Constants.hs
@@ -1578,6 +1578,9 @@ vtypeSize = VTypeSize
 vtypeString :: VType
 vtypeString = VTypeString
 
+vtypeIntOrAuto :: VType
+vtypeIntOrAuto = VTypeIntOrAuto
+
 enforceableTypes :: FrozenSet VType
 enforceableTypes = ConstantUtils.mkSet [minBound..]
 
@@ -1836,6 +1839,9 @@ hvVirtioNetQueues = "virtio_net_queues"
 maxVirtioNetQueues :: Int
 maxVirtioNetQueues = 32
 
+maxVirtioNetQueuesAuto :: Int
+maxVirtioNetQueuesAuto = 8
+
 hvVifScript :: String
 hvVifScript = "vif_script"
 
@@ -1960,7 +1966,7 @@ hvsParameterTypes = Map.fromList
   , (hvUseLocaltime,                    VTypeBool)
   , (hvVga,                             VTypeString)
   , (hvVhostNet,                        VTypeBool)
-  , (hvVirtioNetQueues,                 VTypeInt)
+  , (hvVirtioNetQueues,                 VTypeIntOrAuto)
   , (hvVifScript,                       VTypeString)
   , (hvVifType,                         VTypeString)
   , (hvViridian,                        VTypeBool)

--- a/src/Ganeti/Query/Common.hs
+++ b/src/Ganeti/Query/Common.hs
@@ -87,6 +87,7 @@ vTypeToQFT VTypeBool        = QFTBool
 vTypeToQFT VTypeSize        = QFTUnit
 vTypeToQFT VTypeInt         = QFTNumber
 vTypeToQFT VTypeFloat       = QFTNumberFloat
+vTypeToQFT VTypeIntOrAuto   = QFTOther
 
 -- * Result helpers
 

--- a/src/Ganeti/Types.hs
+++ b/src/Ganeti/Types.hs
@@ -826,6 +826,7 @@ $(THH.declareLADT ''String "VType"
   , ("VTypeSize",        "size")
   , ("VTypeInt",         "int")
   , ("VTypeFloat",       "float")
+  , ("VTypeIntOrAuto",   "int-or-auto")
   ])
 $(THH.makeJSONInstance ''VType)
 


### PR DESCRIPTION
In environments with high packets-per-second (i.e. router/firewall, VoIP, loadbalancer, DNS servers etc.) the NIC bandwidth can not be saturated, because the kernel needs to process many small packets as is (softirq). Offloading functions like LRO (Large Receive Offload) or GRO (Generic Receive Offload) can not be used to bundle many packets up to a 64k super packet, before delivered to the OS, like in a single stream. A single NIC queue can only be handled by a single vCPU. The typical limit for one vCPU is in the order of 100k PPS. To raise that limit, multiple queues must be used.

Introduce the special value `auto` that will set the number of virtio_net_queues to the number of vCPUS up to a limit of 8. This is for convenience, where users have already mutliqueue enabled but don't like to track to match the number of vCPUs (i.e. set at cluster level). Also this option enables PPS scaling in a user observable way without understanding the core problem: The user sees high CPU usage (softirq in this case) and put more vCPUs into the instance. With `auto` the PPS scales now automatically.

Extreme setups beyond 8 queues still must set it manually.