### PR TITLE
Vcluster iproute2 support

### DIFF
--- a/tools/vcluster-setup.in
+++ b/tools/vcluster-setup.in
@@ -269,7 +269,7 @@ setup_network_interfaces() {
     ip addr add "$ipaddr" dev "$netdev"
   done
 
-  route add -net $netprefix.0 netmask 255.255.255.0 dev $netdev || :
+  ip route add "$netprefix.0/24" dev "$netdev" || :
 }
 
 setup_scripts() {

--- a/tools/vif-ganeti-metad.in
+++ b/tools/vif-ganeti-metad.in
@@ -65,6 +65,6 @@ case "$1" in
     xenstore_write "hotplug-status" "connected"
     ;;
   offline)
-    ifconfig "$vif" down || true
+    ip link set dev "$vif" down || true
     ;;
 esac


### PR DESCRIPTION
While building the Debian package, autopkgtest failed because vcluster-setup invokes the route command.

The route and ifconfig commands are provided by the legacy net-tools package, which is no longer installed by default on recent Linux distributions. Ganeti already depends on iproute2, which provides the modern ip command.

This patch replaces the remaining net-tools commands with their ip equivalents. The changes are limited to two occurrences: one in vcluster-setup.in and one in vif-ganeti-metad.

Signed-off-by: Carlos R. Pasqualini carlos@carlospasqualini.com.ar