### PR TITLE
Add connected_node_groups to network API responses

### DIFF
--- a/lib/rapi/rlib2.py
+++ b/lib/rapi/rlib2.py
@@ -215,6 +215,28 @@ def _UpdateBeparams(inst):
   return inst
 
 
+def _NormalizeConnectedNodeGroups(group_list):
+  """Normalizes the network's group_list into a JSON-friendly view.
+
+  @param group_list: list of tuples from the query layer
+  @type group_list: list
+  @return: list of dictionaries with name/mode/link/vlan
+
+  """
+  if not group_list:
+    return []
+
+  def _NormalizeValue(value):
+    return None if value == "" else value
+
+  return [{
+    "name": group[0],
+    "mode": _NormalizeValue(group[1]),
+    "link": _NormalizeValue(group[2]),
+    "vlan": _NormalizeValue(group[3]),
+  } for group in group_list]
+
+
 def _CheckIfConnectionDropped(sock):
   """Utility function to monitor the state of an open connection.
 
@@ -894,7 +916,11 @@ class R_2_networks(baserlib.OpcodeResource):
 
     if self.useBulk():
       bulkdata = client.QueryNetworks([], NET_FIELDS, False)
-      return baserlib.MapBulkFields(bulkdata, NET_FIELDS)
+      bulk = baserlib.MapBulkFields(bulkdata, NET_FIELDS)
+      for item in bulk:
+        item["connected_node_groups"] = _NormalizeConnectedNodeGroups(
+          item.get("group_list", []))
+      return bulk
     else:
       data = client.QueryNetworks([], ["name"], False)
       networknames = [row[0] for row in data]
@@ -920,7 +946,10 @@ class R_2_networks_name(baserlib.OpcodeResource):
                                             fields=NET_FIELDS,
                                             use_locking=self.useLocking())
 
-    return baserlib.MapFields(NET_FIELDS, result[0])
+    mapped = baserlib.MapFields(NET_FIELDS, result[0])
+    mapped["connected_node_groups"] = _NormalizeConnectedNodeGroups(
+      mapped.get("group_list", []))
+    return mapped
 
   def GetDeleteOpInput(self):
     """Delete a network.


### PR DESCRIPTION
This change adds a new connected_node_groups field to the network API response for `/2/networks` and `/2/networks/<network_name>`.

The goal is to expose the network-to-nodegroup relation in a structured, JSON-friendly form instead of the current opaque group_list tuple representation. Each entry now contains:
- name
- mode
- link
- vlan

This makes the API much easier to consume by clients and tooling, and avoids forcing downstream users to decode a positional list format.

It also normalizes empty string values to `None`, so missing optional fields are represented cleanly in JSON.

This is an important API improvement because a well-designed endpoint should return data in a stable, self-describing, and machine-friendly structure. That makes integrations more robust and reduces the amount of client-side parsing logic needed.

See #1889


@saschalucas or @rbott please check if this is relevant to you; if not, please close the PR.