### PR TITLE
fix KVM runtime upgrades for discard and chroot

### DIFF
--- a/lib/hypervisor/hv_kvm/kvm_runtime.py
+++ b/lib/hypervisor/hv_kvm/kvm_runtime.py
@@ -215,25 +215,26 @@ def _upgrade_serialized_runtime(loaded_runtime: List) -> List:
 
       # Replace the original vnc argument with the new ones
       kvm_cmd[idx:idx+2] = tls_obj_cmd + vnc_cmd
+  # end vnc
 
-    # with 3.1 the 'default' value for disk_discard has been dropped
-    # and replaced by 'ignore'
-    if constants.HV_DISK_DISCARD in hvparams \
-      and hvparams[constants.HV_DISK_DISCARD] not in \
-        constants.HT_VALID_DISCARD_TYPES:
-      hvparams[constants.HV_DISK_DISCARD] = constants.HT_DISCARD_IGNORE
+  # with 3.1 the 'default' value for disk_discard has been dropped
+  # and replaced by 'ignore'
+  if constants.HV_DISK_DISCARD in hvparams \
+    and hvparams[constants.HV_DISK_DISCARD] not in \
+      constants.HT_VALID_DISCARD_TYPES:
+    hvparams[constants.HV_DISK_DISCARD] = constants.HT_DISCARD_IGNORE
 
-    # remove chroot from the runtime
-    # commit e607423 addresses that the -chroot parameter is now combined into
-    # -run-with. This happens in a way that -chroot is no longer written into
-    # the KVM runtime.  When live migrating, the old runtime (containing
-    # -chroot) is read and therefore has to be filtered out. Otherwise kvm_cmd
-    # will contain old -chroot and new -run-with. This makes live
-    # migration to >=Qemu-9.0 possible.
-    try:
-      idx = kvm_cmd.index("-chroot")
-      del kvm_cmd[idx:idx+2]
-    except ValueError:
-      pass
+  # remove chroot from the runtime
+  # commit e607423 addresses that the -chroot parameter is now combined into
+  # -run-with. This happens in a way that -chroot is no longer written into
+  # the KVM runtime.  When live migrating, the old runtime (containing
+  # -chroot) is read and therefore has to be filtered out. Otherwise kvm_cmd
+  # will contain old -chroot and new -run-with. This makes live
+  # migration to >=Qemu-9.0 possible.
+  try:
+    idx = kvm_cmd.index("-chroot")
+    del kvm_cmd[idx:idx+2]
+  except ValueError:
+    pass
 
   return [kvm_cmd, serialized_nics, hvparams, serialized_disks]


### PR DESCRIPTION
With commit 377cfd5 the kvm_runtime has been separated into a class, but with that a python indentation error causes updates regarding disk_discard to be skipped, if VNC is not enabled. Later chroot fixes (commit 9e56387) start erroneously at the same indentation level.

For master this is addressed in PR #1953 where the problem was first discovered.