### PR TITLE
Add JSON output support to hcheck and surface hcheck findings in cluster verify

### DIFF
--- a/lib/cmdlib/cluster/verify.py
+++ b/lib/cmdlib/cluster/verify.py
@@ -30,6 +30,7 @@
 """Logical units for cluster verification."""
 
 import itertools
+import json
 import logging
 import operator
 import re
@@ -986,6 +987,62 @@ class LUClusterVerifyGroup(LogicalUnit, _VerifyErrors):
                       self.cfg.GetNodeName(node_uuid),
                       "volume %s is unknown", volume,
                       code=_VerifyErrors.ETYPE_WARNING)
+
+  def _VerifyWithHcheck(self):
+    """Verify cluster health through hcheck when available.
+
+    Only the initial phase of the hcheck report is considered; the existing
+    verification logic remains intact and the hcheck check is best-effort.
+
+    """
+    self._feedback_fn("* Verifying cluster with hcheck")
+
+    try:
+      result = utils.RunCmd(["hcheck", "--output", "json"])
+    except errors.OpExecError:
+      self._feedback_fn("  - WARNING: hcheck not available")
+      return
+
+    if result.failed and not result.stdout:
+      self._Error(constants.CV_ECLUSTERCFG, None,
+                  "hcheck execution failed: %s",
+                  result.fail_reason or result.output,
+                  code=self.ETYPE_WARNING)
+      return
+
+    try:
+      report = json.loads(result.stdout)
+    except (TypeError, ValueError) as err:
+      self._Error(constants.CV_ECLUSTERCFG, None,
+                  "hcheck returned invalid JSON: %s", err,
+                  code=self.ETYPE_WARNING)
+      return
+
+    initial = report.get("initial", {})
+    cluster = initial.get("cluster", {})
+    groups = initial.get("groups", [])
+
+    issues = []
+    if cluster.get("need_rebalance"):
+      issues.append("need rebalancing")
+
+    for group in groups:
+      group_name = group.get("name")
+      if group.get("n1_fail") > 0:
+        issues.append("Nodes not n+1 happy: %d in group %s"
+                      % (group.get("n1_fail"), group_name))
+
+      if group.get("gn1_fail") > 0:
+        issues.append("Nodes not directly evacuateable: %d in group %s"
+                      % (group.get("gn1_fail"), group_name))
+
+    if not issues and report.get("ok") is False:
+      issues.append("cluster is not healthy")
+
+    if issues:
+      self._Error(constants.CV_ECLUSTERCFG, None,
+                  "hcheck reported cluster problems: %s",
+                  ", ".join(issues), code=self.ETYPE_ERROR)
 
   def _VerifyNPlusOneMemory(self, node_image, all_insts):
     """Verify N+1 Memory Resilience.
@@ -2273,6 +2330,8 @@ class LUClusterVerifyGroup(LogicalUnit, _VerifyErrors):
           break
 
     self._VerifyOrphanVolumes(vg_name, node_vol_should, node_image, reserved)
+
+    self._VerifyWithHcheck()
 
     if constants.VERIFY_NPLUSONE_MEM not in self.op.skip_checks:
       feedback_fn("* Verifying N+1 Memory redundancy")

--- a/man/hcheck.rst
+++ b/man/hcheck.rst
@@ -41,6 +41,7 @@ Algorithm options:
 Reporting options:
 
 **[\--machine-readable**[=*CHOICE*] **]**
+**[ \--output *FORMAT* ]**
 **[ -p[ *fields* ] ]**
 **[ \--print-instances ]**
 **[ -v... | -q ]**
@@ -76,6 +77,11 @@ OPTIONS
   Do not check for global N+1 redundancy, i.e., do not warn if the
   shared-storage instances of one node cannot be moved to the others
   should that node fail.
+
+\--output FORMAT
+  Select the output format. Supported values are ``text`` and ``json``.
+  The JSON output reports the initial and final cluster state and whether
+  the cluster is considered healthy.
 
 For a detailed description about the options listed above have a look at
 **htools**\(1), **hspace**\(1) and **hbal**\(1).

--- a/src/Ganeti/HTools/CLI.hs
+++ b/src/Ganeti/HTools/CLI.hs
@@ -83,6 +83,7 @@ module Ganeti.HTools.CLI
   , genOLuxiSocket
   , oLuxiSocket
   , oMachineReadable
+  , oOutputFormat
   , oMaxCpu
   , oMaxSolLength
   , oMinDisk
@@ -123,7 +124,7 @@ module Ganeti.HTools.CLI
   ) where
 
 import Control.Monad
-import Data.Char (toUpper)
+import Data.Char (toLower, toUpper)
 import Data.Maybe (fromMaybe)
 import System.Console.GetOpt
 import System.IO
@@ -175,6 +176,7 @@ data Options = Options
   , optLuxi        :: Maybe FilePath -- ^ Collect data from Luxi
   , optJobDelay    :: Double         -- ^ Delay before executing first job
   , optMachineReadable :: Bool       -- ^ Output machine-readable format
+  , optOutputFormat :: String        -- ^ Output format: 'text' or 'json'
   , optMaster      :: String         -- ^ Collect data from RAPI
   , optMaxLength   :: Int            -- ^ Stop after this many steps
   , optMcpu        :: Maybe Double   -- ^ Override max cpu ratio for nodes
@@ -249,6 +251,7 @@ defaultOptions  = Options
   , optLuxi        = Nothing
   , optJobDelay    = 10
   , optMachineReadable = False
+  , optOutputFormat = "text"
   , optMaster      = ""
   , optMaxLength   = -1
   , optMcpu        = Nothing
@@ -571,6 +574,19 @@ oMachineReadable =
    \ explicitly control the flag, or without an argument defaults to\
    \ yes)",
    optComplYesNo)
+
+oOutputFormat :: OptType
+oOutputFormat =
+  (Option "" ["output"]
+   (ReqArg (\ f opts ->
+              case map toLower f of
+                "text" -> Ok opts { optOutputFormat = "text" }
+                "json" -> Ok opts { optOutputFormat = "json" }
+                _ -> Bad ("Invalid output format '" ++ f ++
+                          "', expected 'text' or 'json'"))
+    "FORMAT")
+   "select output format ('text' or 'json')",
+   OptComplNone)
 
 oMaxCpu :: OptType
 oMaxCpu =

--- a/src/Ganeti/HTools/Program/Hcheck.hs
+++ b/src/Ganeti/HTools/Program/Hcheck.hs
@@ -39,8 +39,9 @@ module Ganeti.HTools.Program.Hcheck
   ) where
 
 import Control.Monad
+import qualified Data.Char as Char
 import qualified Data.IntMap as IntMap
-import Data.List (transpose)
+import Data.List (intercalate, transpose)
 import System.Exit
 import Text.Printf (printf)
 
@@ -79,6 +80,7 @@ options = do
     , oInstMoves
     , luxi
     , oMachineReadable
+    , oOutputFormat
     , oMaxCpu
     , oMaxSolLength
     , oMinDisk
@@ -215,6 +217,64 @@ printStats opts False level phase values = do
     putStr prefix
     mapM_ (uncurry (printf "    %s: %s\n")) (zip descr values)
 
+renderJsonObject :: [(String, String)] -> String
+renderJsonObject [] = "{}"
+renderJsonObject pairs =
+  "{" ++ intercalate ", " (map renderJsonField pairs) ++ "}"
+  where
+    renderJsonField (k, v) = show (map Char.toLower k) ++ ":" ++ v
+
+renderJsonArray :: [String] -> String
+renderJsonArray [] = "[]"
+renderJsonArray items = "[" ++ intercalate ", " items ++ "]"
+
+renderJsonValue :: String -> String
+renderJsonValue value
+  | value == "true" || value == "false" = value
+  | all (\c -> Char.isDigit c || c == '.' || c == '-') value = value
+  | otherwise = show value
+
+renderJsonKeyValue :: String -> String -> String
+renderJsonKeyValue key value =
+  show (map Char.toLower key) ++ ":" ++ renderJsonValue value
+
+clusterStatsToJson :: Options -> [Int] -> Bool -> String
+clusterStatsToJson opts stats needhbal =
+  let values = map show stats ++ [if needhbal then "true" else "false"]
+      keys = map fst $ clusterData opts
+      pairs = zip keys values
+  in renderJsonObject $ map (\(k, v) -> (k, renderJsonValue v)) pairs
+
+groupStatsToJson :: Options -> GroupStats -> String
+groupStatsToJson opts ((grp, score), stats) =
+  let values = prepareGroupValues stats score
+      keys = map fst $ groupData opts
+      groupName = Group.name grp
+      pairs = [("name", groupName)] ++ zip keys values
+  in renderJsonObject $
+       map (\(k, v) -> (map Char.toLower k, renderJsonValue v)) pairs
+
+printJsonReport :: Options -> [GroupStats] -> [Int] -> Bool ->
+                   [GroupStats] -> [Int] -> Bool -> Bool -> IO ()
+printJsonReport opts initialGroups initialCluster initialNeed
+                finalGroups finalCluster finalNeed exitOK = do
+  let initialPhase = renderJsonObject
+        [ ("cluster", clusterStatsToJson opts initialCluster initialNeed)
+        , ("groups", renderJsonArray $
+            map (groupStatsToJson opts) initialGroups)
+        ]
+      finalPhase = renderJsonObject
+        [ ("cluster", clusterStatsToJson opts finalCluster finalNeed)
+        , ("groups", renderJsonArray $
+            map (groupStatsToJson opts) finalGroups)
+        ]
+      root = renderJsonObject
+        [ ("initial", initialPhase)
+        , ("final", finalPhase)
+        , ("ok", if exitOK then "true" else "false")
+        ]
+  putStrLn root
+
 -- | Extract name or idx from group.
 extractGroupData :: Bool -> Group.Group -> String
 extractGroupData True grp = show $ Group.idx grp
@@ -316,6 +376,7 @@ main opts args = do
 
   let verbose = optVerbose opts
       machineread = optMachineReadable opts
+      outputjson = map Char.toLower (optOutputFormat opts) == "json"
       nosimulation = optNoSimulation opts
 
   (ClusterData gl fixed_nl ilf _ _) <- loadExternalData opts
@@ -329,32 +390,44 @@ main opts args = do
       clusterstats = map sum . transpose . map snd $ groupsstats
       needrebalance = clusterNeedsRebalance clusterstats
 
-  unless (verbose < 1 || machineread) .
+  unless (verbose < 1 || machineread || outputjson) .
     putStrLn $ if nosimulation
                  then "Running in no-simulation mode."
                  else if needrebalance
                         then "Cluster needs rebalancing."
                         else "No need to rebalance cluster, no problems found."
 
-  mapM_ (printGroupStats opts machineread Initial) groupsstats
+  if outputjson
+    then do
+      let exitOK = nosimulation || not needrebalance
+          simulate = not nosimulation && needrebalance
+      rebalancedcluster <- maybeSimulateRebalance simulate opts splitcluster
+      let newgroupstats = map (perGroupChecks opts gl) rebalancedcluster
+          newclusterstats = map sum . transpose . map snd $ newgroupstats
+          newneedrebalance = clusterNeedsRebalance newclusterstats
+      printJsonReport opts groupsstats clusterstats needrebalance
+                      newgroupstats newclusterstats newneedrebalance exitOK
+      unless exitOK . exitWith $ ExitFailure 1
+    else do
+      mapM_ (printGroupStats opts machineread Initial) groupsstats
 
-  printClusterStats opts machineread Initial clusterstats needrebalance
+      printClusterStats opts machineread Initial clusterstats needrebalance
 
-  let exitOK = nosimulation || not needrebalance
-      simulate = not nosimulation && needrebalance
+      let exitOK = nosimulation || not needrebalance
+          simulate = not nosimulation && needrebalance
 
-  rebalancedcluster <- maybeSimulateRebalance simulate opts splitcluster
+      rebalancedcluster <- maybeSimulateRebalance simulate opts splitcluster
 
-  when (simulate || machineread) $ do
-    let newgroupstats = map (perGroupChecks opts gl) rebalancedcluster
-        newclusterstats = map sum . transpose . map snd $ newgroupstats
-        newneedrebalance = clusterNeedsRebalance clusterstats
+      when (simulate || machineread) $ do
+        let newgroupstats = map (perGroupChecks opts gl) rebalancedcluster
+            newclusterstats = map sum . transpose . map snd $ newgroupstats
+            newneedrebalance = clusterNeedsRebalance clusterstats
 
-    mapM_ (printGroupStats opts machineread Rebalanced) newgroupstats
+        mapM_ (printGroupStats opts machineread Rebalanced) newgroupstats
 
-    printClusterStats opts machineread Rebalanced newclusterstats
+        printClusterStats opts machineread Rebalanced newclusterstats
                            newneedrebalance
 
-  printFinalHTC machineread
+      printFinalHTC machineread
 
-  unless exitOK . exitWith $ ExitFailure 1
+      unless exitOK . exitWith $ ExitFailure 1

--- a/test/hs/shelltests/htools-hcheck.test
+++ b/test/hs/shelltests/htools-hcheck.test
@@ -22,3 +22,11 @@
 >>>/Cluster is not healthy: False/
 >>>= 0
 
+./test/hs/hcheck -t $TESTDATA_DIR/shared-n1-failure.data --output json
+>>>/"need_rebalance":true/
+>>>= 1
+
+./test/hs/hcheck -t $TESTDATA_DIR/shared-n1-failure.data --output json
+>>>/"name":"group-01"/
+>>>= 1
+

--- a/test/py/legacy/cmdlib/cluster_unittest.py
+++ b/test/py/legacy/cmdlib/cluster_unittest.py
@@ -39,6 +39,7 @@ import unittest
 import re
 import shutil
 import os
+from unittest import mock
 
 from ganeti.cmdlib import cluster
 from ganeti.cmdlib.cluster import verify
@@ -1870,6 +1871,30 @@ class TestLUClusterVerifyGroupVerifyNPlusOneMemory(
     node1_img.mfree = 1000
     lu._VerifyNPlusOneMemory(node_imgs, self.cfg.GetAllInstancesInfo())
     self.mcpu.assertLogIsEmpty()
+
+
+class TestLUClusterVerifyGroupVerifyWithHcheck(TestLUClusterVerifyGroupMethods):
+  @withLockedLU
+  def testHcheckUnavailable(self, lu):
+    with mock.patch.object(utils, "RunCmd",
+                           side_effect=errors.OpExecError("hcheck missing")):
+      lu._VerifyWithHcheck()
+    self.mcpu.assertLogContainsRegex("hcheck not available")
+
+  @withLockedLU
+  def testHcheckReportsIssues(self, lu):
+    hcheck_result = mock.Mock()
+    hcheck_result.failed = True
+    hcheck_result.stdout = (
+      '{"ok": false, "initial": {"cluster": {"need_rebalance": true}, '
+      '"groups": [{"name": "group-01", "n1_fail": 1, "gn1_fail": 1}]}}')
+    hcheck_result.stderr = ""
+
+    with mock.patch.object(utils, "RunCmd", return_value=hcheck_result):
+      lu._VerifyWithHcheck()
+
+    self.mcpu.assertLogContainsRegex("hcheck reported cluster problems")
+    self.mcpu.assertLogContainsRegex("need rebalancing")
 
 
 class TestLUClusterVerifyGroupVerifyFiles(TestLUClusterVerifyGroupMethods):


### PR DESCRIPTION
This change adds JSON output support to hcheck and keeps the implementation scoped to hcheck itself. It also extends gnt-cluster verify to run hcheck when available and report its findings as errros, while preserving the existing verify logic.

This provides a structured way to consume hcheck results and makes cluster verification reflect the checks performed by hcheck more closely. With this change, the issue is #1952 addressed and closed.

@saschalucas or @rbott please check if this is relevant to you; if not, please close this PR.

closes #1952

> [!NOTE] 
> I've only tested this against unittests and shell tests (make hs-shell-hcheck), not against a real cluster!