### PR TITLE
fix hotplug verify for virtio-scsi

### DIFF
--- a/lib/hypervisor/hv_kvm/monitor.py
+++ b/lib/hypervisor/hv_kvm/monitor.py
@@ -752,7 +752,10 @@ class QmpConnection(QemuMonitorSocket):
     The query-block QMP command returns a list of dictionaries
     including information for each virtual disk. For example:
 
+    old drive_add
     [{"device": "disk-049f140d", "inserted": {"file": ..., "image": ...}}]
+    new blockdev_add + device_add
+    [{"device": "", "inserted": {...}, "qdev": "disk-5d029f20-0c04-4652", ...}]
 
     @rtype: list of dicts
     @return: Info about the virtual disks of the instance.
@@ -767,7 +770,7 @@ class QmpConnection(QemuMonitorSocket):
 
     """
     for d in self._GetBlockDevices():
-      if d["device"] == devid:
+      if d["qdev"] == devid:
         return True
 
     return False

--- a/qa/qa_cluster.py
+++ b/qa/qa_cluster.py
@@ -159,7 +159,7 @@ def PrepareHvParameterSets():
       "disk_aio": constants.HT_KVM_VALID_AIO_TYPES,
       "disk_cache": constants.HT_VALID_CACHE_TYPES,
       "usb_mouse": constants.HT_KVM_VALID_MOUSE_TYPES,
-      "disk_type": ["ide", "paravirtual"],
+      "disk_type": ["ide", "paravirtual", "scsi-hd"],
       "soundhw": ["ac97", "hda"],
       "machine_version": ["", "pc", "q35"],
     }


### PR DESCRIPTION
Around commit b87714e68d5413b08584d0df8d571124952ef15e where disk logic switched from drive to blockdev+device (also for hotplug) the key `device` in QMP response to `query-block` command is empty. The disk ID can now be found in `qdev`.

fixes #1963

@rbott: I like to add `disk_type=scsi-hd` to QA for testing hotplug, but it also needs `scsi_controller_type=virtio-scsi-pci`, which can be set at cluster level/init. How to accomplish this?