### PR TITLE
logrotate: match today’s requirements

### DIFF
--- a/doc/examples/ganeti.logrotate.in
+++ b/doc/examples/ganeti.logrotate.in
@@ -1,11 +1,13 @@
 /var/log/ganeti/*.log {
-        weekly
+        daily
         missingok
-        rotate 52
+        rotate 90
         notifempty
         compress
         delaycompress
+        create 640
         sharedscripts
+        su root root
         postrotate
 		@PKGLIBDIR@/daemon-util rotate-all-logs
         endscript


### PR DESCRIPTION
Switch from weekly to daily rotation, but keep only 90 days instead of 52 weeks. Add create mode and su directive. Without the last, modern logrotete refuses to rotate logfiles not owned by root.