### PR TITLE
Report WConfd update timeouts in job errors

### DIFF
--- a/lib/config/__init__.py
+++ b/lib/config/__init__.py
@@ -3033,12 +3033,19 @@ class ConfigWriter(object):
       raise errors.ProgrammerError("Invalid object type (%s) passed to"
                                    " ConfigWriter.Update" % type(target))
 
+    polls = 0
+
     def WithRetry():
+      nonlocal polls
+      polls += 1
       result = update_function(target.ToDict())
       self.OutDate()
 
       if result is None:
-        raise utils.RetryAgain()
+        raise utils.RetryAgain(
+          "WConfd config-lock timeout - %s for object UUID %s;"
+          " config lock unavailable on all %s polls (30-second retry budget)" %
+          (update_function.__name__, target.uuid, polls))
       else:
         return result
     vals = utils.Retry(WithRetry, 0.1, 30)

--- a/lib/jqueue/__init__.py
+++ b/lib/jqueue/__init__.py
@@ -670,7 +670,7 @@ def _EncodeOpError(err):
   if isinstance(err, errors.GenericError):
     to_encode = err
   else:
-    to_encode = errors.OpExecError(str(err))
+    to_encode = errors.OpExecError(str(err) or err.__class__.__name__)
 
   return errors.EncodeException(to_encode)
 

--- a/test/py/legacy/ganeti.jqueue_unittest.py
+++ b/test/py/legacy/ganeti.jqueue_unittest.py
@@ -78,6 +78,15 @@ class _FakeJob:
 
 
 class TestEncodeOpError(unittest.TestCase):
+  def testEmptyException(self):
+    self.assertEqual(jqueue._EncodeOpError(utils.RetryTimeout()),
+                     ("OpExecError", ("RetryTimeout",)))
+
+  def testRetryTimeout(self):
+    message = "WConfd config-lock timeout - UpdateInstance"
+    self.assertEqual(jqueue._EncodeOpError(utils.RetryTimeout(message)),
+                     ("OpExecError", (message,)))
+
   def test(self):
     encerr = jqueue._EncodeOpError(errors.LockError("Test 1"))
     self.assertTrue(isinstance(encerr, tuple))


### PR DESCRIPTION
Often, we will see errors in `gnt-job info` with 

```
     Result:
        - OpExecError
        - - 
```

This is quite frustrating since it gives you nothing to go on. After some back and forth, I believe this is caused by `OpExecError(str(err))`. The `err` gets raised from `utils.RetryAgain()`, which gets parsed as an empty string. 

This adds a nonlocal poll counter to track how many times the retry has occurred, as well as some additional debugging information. 

-----

Testing wise this is a basic dummy one:

```
Python 3.11.14 (main, Oct  9 2025, 16:16:55) [GCC 14.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.

>>> import json
>>> from ganeti import config, jqueue, objects
>>>
>>> class BusyWConfd:
...   def UpdateInstance(self, instance):
...     return None
...
>>> try:
...   config.ConfigWriter(wconfd=BusyWConfd()).Update(
...     objects.Instance(uuid="demo-instance"), None)
... except Exception as err:
...   print("Raised:", type(err).__name__)
...   print(json.dumps(jqueue._EncodeOpError(err)))
...
Raised: RetryTimeout
["OpExecError", ["WConfd config-lock timeout - UpdateInstance for object UUID demo-instance; config lock unavailable on all 301 polls (30-second retry budget)"]]
```

I also tested this live on a Ganeti cluster and got 

```
Status: error
      Result:
        - OpExecError
        - - WConfd config-lock timeout - UpdateInstance for object UUID <UUID>; config lock unavailable on all 300 polls (30-second retry budget)
      Execution log:
```

Assisted-by: OpenAI Codex